### PR TITLE
INS-108: all arguments in one CBOR blob

### DIFF
--- a/logicrunner/goplugin/girpc/girpc.go
+++ b/logicrunner/goplugin/girpc/girpc.go
@@ -6,12 +6,12 @@ import "github.com/insolar/insolar/logicrunner"
 type CallReq struct {
 	Object    logicrunner.Object
 	Method    string
-	Arguments []logicrunner.Argument
+	Arguments logicrunner.Arguments
 }
 
 // CallResp is response from Call RPC in the runner
 type CallResp struct {
 	Data []byte
-	Ret  logicrunner.Argument
+	Ret  logicrunner.Arguments
 	Err  error
 }

--- a/logicrunner/goplugin/goplugin.go
+++ b/logicrunner/goplugin/goplugin.go
@@ -123,7 +123,7 @@ func (gp *GoPlugin) Stop() {
 }
 
 // Exec runs a method on an object in controlled environment
-func (gp *GoPlugin) Exec(object logicrunner.Object, method string, args []logicrunner.Argument) ([]byte, logicrunner.Argument, error) {
+func (gp *GoPlugin) Exec(object logicrunner.Object, method string, args logicrunner.Arguments) ([]byte, logicrunner.Arguments, error) {
 	client, err := rpc.DialHTTP("tcp", gp.RunnerOptions.Listen)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "problem with rpc connection")

--- a/logicrunner/goplugin/goplugin_test.go
+++ b/logicrunner/goplugin/goplugin_test.go
@@ -30,16 +30,16 @@ func (r *HelloWorlder) ProxyEcho(gp *GoPlugin, s string) {
 		Data:        data,
 	}
 
-	args := make([]logicrunner.Argument, 1)
+	args := make([]interface{}, 1)
+	args[0] = s
 
-	var arg []byte
-	err = codec.NewEncoderBytes(&arg, ch).Encode(s)
+	var argsSerialized []byte
+	err = codec.NewEncoderBytes(&argsSerialized, ch).Encode(args)
 	if err != nil {
 		panic(err)
 	}
-	args[0] = arg
 
-	data, _, err = gp.Exec(obj, "Echo", args)
+	data, _, err = gp.Exec(obj, "Echo", argsSerialized)
 	if err != nil {
 		panic(err)
 	}
@@ -103,7 +103,7 @@ func TestHelloWorld(t *testing.T) {
 	defer gp.Stop()
 
 	hw := &HelloWorlder{77}
-	hw.ProxyEcho(gp, "hi")
+	hw.ProxyEcho(gp, "hi there here we are")
 	if hw.Greeted != 78 {
 		t.Fatalf("Got unexpected value: %d, 78 is expected", hw.Greeted)
 	}

--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -30,5 +30,5 @@ const (
 type LogicRunner interface {
 	Start()
 	Stop()
-	Exec(object Object, method string, args []Argument) (ret Argument, err error)
+	Exec(object Object, method string, args Arguments) (ret Arguments, err error)
 }

--- a/logicrunner/types.go
+++ b/logicrunner/types.go
@@ -26,5 +26,5 @@ type Object struct {
 	Data        []byte
 }
 
-// Argument is a dedicated type for arguments, that represented as bynary cbored blob
-type Argument []byte
+// Arguments is a dedicated type for arguments, that represented as bynary cbored blob
+type Arguments []byte


### PR DESCRIPTION
this CBOR is serialized array of empty interfaces ([]interface{}{}) with
every element holding interface{} to one argument of the method

in case method has a variadic argument at the end of its signature then
the last element in the array should be an array with all variadic
values