### PR TITLE
Speedup ledger tests

### DIFF
--- a/ledger/artifactmanager/artifactmanager_test.go
+++ b/ledger/artifactmanager/artifactmanager_test.go
@@ -56,8 +56,10 @@ func prepareAMTestData(t *testing.T) (preparedAMTestData, func()) {
 }
 
 func TestLedgerArtifactManager_DeclareType(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	typeDec := []byte{1, 2, 3}
 	coreRef, err := td.manager.DeclareType(td.domainRef.Bytes(), td.requestRef.Bytes(), typeDec)
 	assert.NoError(t, err)
@@ -78,8 +80,10 @@ func TestLedgerArtifactManager_DeclareType(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_DeployCode_VerifiesRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	codeMap := map[core.MachineType][]byte{1: {1}}
 	_, err := td.manager.DeployCode(
 		td.domainRef.Bytes(), td.requestRef.Bytes(), []core.RecordRef{genRandomRef().Bytes()}, codeMap,
@@ -93,8 +97,10 @@ func TestLedgerArtifactManager_DeployCode_VerifiesRecord(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_DeployCode_CreatesCorrectRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	codeMap := map[core.MachineType][]byte{1: {1}}
 	typeRef, _ := td.ledger.SetRecord(&record.TypeRecord{
 		StorageRecord: record.StorageRecord{
@@ -127,8 +133,10 @@ func TestLedgerArtifactManager_DeployCode_CreatesCorrectRecord(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_ActivateClass_VerifiesRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	_, err := td.manager.ActivateClass(
 		td.domainRef.Bytes(), td.requestRef.Bytes(), genRandomRef().Bytes(), []byte{})
 	assert.NotNil(t, err)
@@ -140,8 +148,10 @@ func TestLedgerArtifactManager_ActivateClass_VerifiesRecord(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_ActivateClass_CreatesCorrectRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	memory := []byte{1, 2, 3}
 	codeRef, _ := td.ledger.SetRecord(&record.CodeRecord{
 		StorageRecord: record.StorageRecord{
@@ -172,8 +182,10 @@ func TestLedgerArtifactManager_ActivateClass_CreatesCorrectRecord(t *testing.T) 
 }
 
 func TestLedgerArtifactManager_DeactivateClass_VerifiesRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	_, err := td.manager.DeactivateClass(td.domainRef.Bytes(), td.requestRef.Bytes(), genRandomRef().Bytes())
 	assert.NotNil(t, err)
 
@@ -183,8 +195,10 @@ func TestLedgerArtifactManager_DeactivateClass_VerifiesRecord(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_DeactivateClass_VerifiesClassIsActive(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	classRef, _ := td.ledger.SetRecord(&record.ClassActivateRecord{})
 	deactivateRef, _ := td.ledger.SetRecord(&record.DeactivationRecord{})
 	td.ledger.SetClassIndex(classRef, &index.ClassLifeline{
@@ -195,8 +209,10 @@ func TestLedgerArtifactManager_DeactivateClass_VerifiesClassIsActive(t *testing.
 }
 
 func TestLedgerArtifactManager_DeactivateClass_CreatesCorrectRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	classRef, _ := td.ledger.SetRecord(&record.ClassActivateRecord{
 		ActivationRecord: record.ActivationRecord{
 			StatefulResult: record.StatefulResult{
@@ -230,8 +246,10 @@ func TestLedgerArtifactManager_DeactivateClass_CreatesCorrectRecord(t *testing.T
 }
 
 func TestLedgerArtifactManager_UpdateClass_VerifiesRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	_, err := td.manager.UpdateClass(
 		td.domainRef.Bytes(), td.requestRef.Bytes(), genRandomRef().Bytes(), genRandomRef().Bytes(), nil)
 	assert.NotNil(t, err)
@@ -242,8 +260,10 @@ func TestLedgerArtifactManager_UpdateClass_VerifiesRecord(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_UpdateClass_VerifiesClassIsActive(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	classRef, _ := td.ledger.SetRecord(&record.ClassActivateRecord{})
 	deactivateRef, _ := td.ledger.SetRecord(&record.DeactivationRecord{})
 	codeRef, _ := td.ledger.SetRecord(&record.CodeRecord{})
@@ -256,8 +276,10 @@ func TestLedgerArtifactManager_UpdateClass_VerifiesClassIsActive(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_UpdateClass_CreatesCorrectRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	classRef, _ := td.ledger.SetRecord(&record.ClassActivateRecord{
 		ActivationRecord: record.ActivationRecord{
 			StatefulResult: record.StatefulResult{
@@ -313,8 +335,10 @@ func TestLedgerArtifactManager_UpdateClass_CreatesCorrectRecord(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_ActivateObj_VerifiesRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	_, err := td.manager.ActivateObj(
 		td.domainRef.Bytes(), td.requestRef.Bytes(), genRandomRef().Bytes(), []byte{})
 	assert.NotNil(t, err)
@@ -325,8 +349,10 @@ func TestLedgerArtifactManager_ActivateObj_VerifiesRecord(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_ActivateObj_CreatesCorrectRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	memory := []byte{1, 2, 3}
 	classRef, _ := td.ledger.SetRecord(&record.ClassActivateRecord{
 		ActivationRecord: record.ActivationRecord{
@@ -361,8 +387,10 @@ func TestLedgerArtifactManager_ActivateObj_CreatesCorrectRecord(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_DeactivateObj_VerifiesRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	_, err := td.manager.DeactivateClass(
 		td.domainRef.Bytes(), td.requestRef.Bytes(), genRandomRef().Bytes())
 	assert.NotNil(t, err)
@@ -372,8 +400,10 @@ func TestLedgerArtifactManager_DeactivateObj_VerifiesRecord(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_DeactivateObj_VerifiesObjectIsActive(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	objRef, _ := td.ledger.SetRecord(&record.ObjectActivateRecord{})
 	deactivateRef, _ := td.ledger.SetRecord(&record.DeactivationRecord{})
 	td.ledger.SetObjectIndex(objRef, &index.ObjectLifeline{
@@ -384,8 +414,10 @@ func TestLedgerArtifactManager_DeactivateObj_VerifiesObjectIsActive(t *testing.T
 }
 
 func TestLedgerArtifactManager_DeactivateObj_CreatesCorrectRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	objRef, _ := td.ledger.SetRecord(&record.ObjectActivateRecord{
 		ActivationRecord: record.ActivationRecord{
 			StatefulResult: record.StatefulResult{
@@ -418,8 +450,10 @@ func TestLedgerArtifactManager_DeactivateObj_CreatesCorrectRecord(t *testing.T) 
 }
 
 func TestLedgerArtifactManager_UpdateObj_VerifiesRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	_, err := td.manager.UpdateObj(
 		td.domainRef.Bytes(), td.requestRef.Bytes(), genRandomRef().Bytes(), nil)
 	assert.NotNil(t, err)
@@ -430,8 +464,10 @@ func TestLedgerArtifactManager_UpdateObj_VerifiesRecord(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_UpdateObj_VerifiesObjectIsActive(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	objRef, _ := td.ledger.SetRecord(&record.ObjectActivateRecord{})
 	deactivateRef, _ := td.ledger.SetRecord(&record.DeactivationRecord{})
 	td.ledger.SetObjectIndex(objRef, &index.ObjectLifeline{
@@ -443,8 +479,10 @@ func TestLedgerArtifactManager_UpdateObj_VerifiesObjectIsActive(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_UpdateObj_CreatesCorrectRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	objRef, _ := td.ledger.SetRecord(&record.ObjectActivateRecord{
 		ActivationRecord: record.ActivationRecord{
 			StatefulResult: record.StatefulResult{
@@ -480,8 +518,10 @@ func TestLedgerArtifactManager_UpdateObj_CreatesCorrectRecord(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_AppendObjDelegate_VerifiesRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	_, err := td.manager.AppendObjDelegate(
 		td.domainRef.Bytes(), td.requestRef.Bytes(), genRandomRef().Bytes(), nil)
 	assert.NotNil(t, err)
@@ -492,8 +532,10 @@ func TestLedgerArtifactManager_AppendObjDelegate_VerifiesRecord(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_AppendObjDelegate_VerifiesClassIsActive(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	objRef, _ := td.ledger.SetRecord(&record.ObjectActivateRecord{})
 	deactivateRef, _ := td.ledger.SetRecord(&record.DeactivationRecord{})
 	td.ledger.SetObjectIndex(objRef, &index.ObjectLifeline{
@@ -505,8 +547,10 @@ func TestLedgerArtifactManager_AppendObjDelegate_VerifiesClassIsActive(t *testin
 }
 
 func TestLedgerArtifactManager_AppendObjDelegate_CreatesCorrectRecord(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	objRef, _ := td.ledger.SetRecord(&record.ObjectActivateRecord{
 		ActivationRecord: record.ActivationRecord{
 			StatefulResult: record.StatefulResult{
@@ -545,8 +589,10 @@ func TestLedgerArtifactManager_AppendObjDelegate_CreatesCorrectRecord(t *testing
 }
 
 func TestLedgerArtifactManager_GetLatestObj_VerifiesRecords(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	_, _, err := td.manager.GetLatestObj(
 		genRandomRef().Bytes(), genRandomRef().Bytes(), genRandomRef().Bytes())
 	assert.NotNil(t, err)
@@ -563,8 +609,10 @@ func TestLedgerArtifactManager_GetLatestObj_VerifiesRecords(t *testing.T) {
 }
 
 func TestLedgerArtifactManager_GetLatestObj_VerifiesClassIsActive(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	classRef, _ := td.ledger.SetRecord(&record.ClassActivateRecord{})
 	classDeactivateRef, _ := td.ledger.SetRecord(&record.DeactivationRecord{})
 	td.ledger.SetClassIndex(classRef, &index.ClassLifeline{LatestStateRef: *classDeactivateRef})
@@ -578,8 +626,10 @@ func TestLedgerArtifactManager_GetLatestObj_VerifiesClassIsActive(t *testing.T) 
 }
 
 func TestLedgerArtifactManager_GetLatestObj_ReturnsNilDescriptorsIfCurrentStateProvided(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	classRef, _ := td.ledger.SetRecord(&record.ClassActivateRecord{
 		ActivationRecord: record.ActivationRecord{
 			StatefulResult: record.StatefulResult{
@@ -633,8 +683,10 @@ func TestLedgerArtifactManager_GetLatestObj_ReturnsNilDescriptorsIfCurrentStateP
 }
 
 func TestLedgerArtifactManager_GetLatestObj_ReturnsCorrectDescriptors(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	ledgerManager, _ := td.manager.(*LedgerArtifactManager)
 
 	classRef, _ := td.ledger.SetRecord(&record.ClassActivateRecord{
@@ -706,15 +758,19 @@ func TestLedgerArtifactManager_GetLatestObj_ReturnsCorrectDescriptors(t *testing
 }
 
 func TestLedgerArtifactManager_GetExactObj_VerifiesRecords(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	_, _, err := td.manager.GetExactObj(genRandomRef().Bytes(), genRandomRef().Bytes())
 	assert.Error(t, err)
 }
 
 func TestLedgerArtifactManager_GetExactObj_ReturnsCorrectData(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareAMTestData(t)
 	defer cleaner()
+
 	td.manager.SetArchPref([]core.MachineType{1})
 
 	codeRec := record.CodeRecord{TargetedCode: map[core.MachineType][]byte{

--- a/ledger/artifactmanager/descriptor_object_test.go
+++ b/ledger/artifactmanager/descriptor_object_test.go
@@ -55,6 +55,7 @@ func prepareDOTestData(t *testing.T) (preparedDOTestData, func()) {
 }
 
 func TestObjectDescriptor_GetMemory(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareDOTestData(t)
 	defer cleaner()
 
@@ -87,6 +88,7 @@ func TestObjectDescriptor_GetMemory(t *testing.T) {
 }
 
 func TestObjectDescriptor_GetDelegates(t *testing.T) {
+	t.Parallel()
 	td, cleaner := prepareDOTestData(t)
 	defer cleaner()
 

--- a/ledger/storage/badgerdb/storage_test.go
+++ b/ledger/storage/badgerdb/storage_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestStore_GetRecordNotFound(t *testing.T) {
+	t.Parallel()
 	store, cleaner := badgertestutils.TmpDB(t, "")
 	defer cleaner()
 
@@ -41,6 +42,7 @@ func TestStore_GetRecordNotFound(t *testing.T) {
 }
 
 func TestStore_SetRecord(t *testing.T) {
+	t.Parallel()
 	store, cleaner := badgertestutils.TmpDB(t, "")
 	defer cleaner()
 	// mock pulse source
@@ -77,6 +79,7 @@ func TestStore_SetRecord(t *testing.T) {
 }
 
 func TestStore_GetClassIndex_ReturnsNotFoundIfNoIndex(t *testing.T) {
+	t.Parallel()
 	store, cleaner := badgertestutils.TmpDB(t, "")
 	defer cleaner()
 
@@ -90,6 +93,7 @@ func TestStore_GetClassIndex_ReturnsNotFoundIfNoIndex(t *testing.T) {
 }
 
 func TestStore_SetClassIndex_StoresCorrectDataInStorage(t *testing.T) {
+	t.Parallel()
 	store, cleaner := badgertestutils.TmpDB(t, "")
 	defer cleaner()
 
@@ -123,6 +127,7 @@ func TestStore_SetClassIndex_StoresCorrectDataInStorage(t *testing.T) {
 }
 
 func TestStore_SetObjectIndex_ReturnsNotFoundIfNoIndex(t *testing.T) {
+	t.Parallel()
 	store, cleaner := badgertestutils.TmpDB(t, "")
 	defer cleaner()
 
@@ -133,6 +138,7 @@ func TestStore_SetObjectIndex_ReturnsNotFoundIfNoIndex(t *testing.T) {
 }
 
 func TestStore_SetObjectIndex_StoresCorrectDataInStorage(t *testing.T) {
+	t.Parallel()
 	store, cleaner := badgertestutils.TmpDB(t, "")
 	defer cleaner()
 
@@ -155,6 +161,7 @@ func TestStore_SetObjectIndex_StoresCorrectDataInStorage(t *testing.T) {
 }
 
 func TestStore_GetDrop_ReturnsNotFoundIfNoDrop(t *testing.T) {
+	t.Parallel()
 	store, cleaner := badgertestutils.TmpDB(t, "")
 	defer cleaner()
 
@@ -164,6 +171,7 @@ func TestStore_GetDrop_ReturnsNotFoundIfNoDrop(t *testing.T) {
 }
 
 func TestStore_SetDrop_StoresCorrectDataInStorage(t *testing.T) {
+	t.Parallel()
 	store, cleaner := badgertestutils.TmpDB(t, "")
 	defer cleaner()
 
@@ -181,6 +189,7 @@ func TestStore_SetDrop_StoresCorrectDataInStorage(t *testing.T) {
 }
 
 func TestStore_SetCurrentPulse(t *testing.T) {
+	t.Parallel()
 	store, cleaner := badgertestutils.TmpDB(t, "")
 	defer cleaner()
 
@@ -189,6 +198,7 @@ func TestStore_SetCurrentPulse(t *testing.T) {
 }
 
 func TestStore_SetEntropy(t *testing.T) {
+	t.Parallel()
 	store, cleaner := badgertestutils.TmpDB(t, "")
 	defer cleaner()
 


### PR DESCRIPTION
**- What I did**

parallelize tests which uses unique temporary store database
(because BadgerDB Close() method no so fast and significally slow down sequental tests)
