### PR TITLE
NOISSUE: remove wrong code

### DIFF
--- a/ledger/storage/transaction_test.go
+++ b/ledger/storage/transaction_test.go
@@ -254,6 +254,5 @@ func TestStore_TransactionRetryOver(t *testing.T) {
 var keycounter int32
 
 func genuniqkey() []byte {
-	keycounter++
 	return []byte(fmt.Sprintf("k%v", atomic.AddInt32(&keycounter, 1)))
 }


### PR DESCRIPTION
**- What I did**

fix race condition in database tests

**- How I did it**

removed wrong code

**- How to verify it**

fails in CI with text:

> WARNING: DATA RACE
Read at 0x0000022ba7c0 by goroutine 73:
 github.com/insolar/insolar/ledger/storage_test.genuniqkey()
   
should gone