### PR TITLE
NOISSUE: disable CGO in CI for builds consistency on different platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 # «For parallel processes running at the same time, try to reduce the number. More than two to four processes should be fine, beyond that, resources are likely to be exhausted.»
 # https://docs.travis-ci.com/user/common-build-problems/#my-build-script-is-killed-without-any-error
     - GOMAXPROCS=2
+    - CGO_ENABLED=0
 
 before_install:
   - "go get -u github.com/golang/dep/cmd/dep"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 install:
   - "dep ensure"
 script:
-  - "go test --race --coverprofile=coverage.txt --covermode=atomic ./..."
+  - "CGO_ENABLED=1 go test --race --coverprofile=coverage.txt --covermode=atomic ./..."
   - "go build -o insolard cmd/insolard/*"
 after_success:
   - "bash <(curl -s https://codecov.io/bash)"


### PR DESCRIPTION
**- What I did**

disable CGO in CI by default
