### PR TITLE
NOISSUE: remove go 1.10 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: go
 sudo: false
 
 go:
-  - "1.10.x"
   - "1.11.x"
 
 env:


### PR DESCRIPTION
**- What I did**
Removed go 1.10 from Travis