### PR TITLE
NOISSUE: CI linter should skip generated code and samples

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,8 @@
 run:
   tests: false
+  skip-dirs:
+    - genesis/example/
+    - genesis/proxy/
 
 linters:
   enable:


### PR DESCRIPTION
**- What I did**

disable CI linter in some dirs with generated code and samples
