### PR TITLE
chdir - change of global state and doesn't work with parallel tests

### DIFF
--- a/logicrunner/goplugin/preprocessor/main_test.go
+++ b/logicrunner/goplugin/preprocessor/main_test.go
@@ -184,15 +184,15 @@ func NewWrong() {
 
 func TestCompileContractProxy(t *testing.T) {
 	t.Parallel()
-	cwd, err := os.Getwd()
-	assert.NoError(t, err)
-	defer os.Chdir(cwd) // nolint: errcheck
 
 	tmpDir, err := ioutil.TempDir("", "test-")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir) // nolint: errcheck
 
 	err = os.MkdirAll(filepath.Join(tmpDir, "src/secondary"), 0777)
+	assert.NoError(t, err)
+
+	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 
 	// XXX: dirty hack to make `dep` installed packages available in generated code
@@ -228,10 +228,7 @@ func main() {
 	`)
 	assert.NoError(t, err)
 
-	err = os.Chdir(tmpDir)
-	assert.NoError(t, err)
-
-	cmd := exec.Command("go", "build", "test.go")
+	cmd := exec.Command("go", "build", filepath.Join(tmpDir, "test.go"))
 	cmd.Env = append(os.Environ(), "GOPATH="+testutil.PrependGoPath(tmpDir))
 	out, err := cmd.CombinedOutput()
 	assert.NoError(t, err, string(out))


### PR DESCRIPTION
sometimes we can get

    can't build contract: 2018/10/04 20:47:35 cannot determine
    current directory: getwd: no such file or directory

this happens when one test grabbed CWD from other test (tmp directory)
and it's been removed