### PR TITLE
INS-606: clear transaction updates map right away after usage

### DIFF
--- a/ledger/storage/transaction.go
+++ b/ledger/storage/transaction.go
@@ -71,6 +71,7 @@ func (m *TransactionManager) Commit() error {
 			break
 		}
 	}
+	m.txupdates = nil
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**- What I did**

clear transaction updates map right away after usage
