### PR TITLE
improve greatly handling of insgorund in tests

### DIFF
--- a/functest/main_test.go
+++ b/functest/main_test.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/insolar/insolar/logicrunner/goplugin/goplugintestutils"
-	"github.com/insolar/insolar/testutils"
 	"github.com/pkg/errors"
 )
 
@@ -264,7 +263,7 @@ func stopInsolard() error {
 var insgorundCleaner func()
 
 func startInsgorund() (err error) {
-	insgorundCleaner, err = testutils.StartInsgorund(insgorundPath, "tcp", "127.0.0.1:18181", "tcp", "127.0.0.1:18182")
+	insgorundCleaner, err = goplugintestutils.StartInsgorund(insgorundPath, "tcp", "127.0.0.1:18181", "tcp", "127.0.0.1:18182")
 	if err != nil {
 		return errors.Wrap(err, "[ startInsolard ] could't wait for insolard to start completely: ")
 	}

--- a/logicrunner/goplugin/goplugintestutils/insgorund.go
+++ b/logicrunner/goplugin/goplugintestutils/insgorund.go
@@ -1,4 +1,4 @@
-package testutils
+package goplugintestutils
 
 import (
 	"os"
@@ -8,12 +8,13 @@ import (
 	"time"
 
 	"github.com/insolar/insolar/log"
+	"github.com/insolar/insolar/testutils"
 	"github.com/pkg/errors"
 )
 
 // StartInsgorund starts `insgorund` process
 func StartInsgorund(cmdPath, lProto, listen, upstreamProto, upstreamAddr string) (func(), error) {
-	id := RandomString()
+	id := testutils.RandomString()
 	log.Debug("Starting 'insgorund' ", id)
 
 	stackTrace := (string)(debug.Stack())

--- a/logicrunner/logicrunner_test.go
+++ b/logicrunner/logicrunner_test.go
@@ -76,7 +76,7 @@ func PrepareLrAmCbPm(t testing.TB) (core.LogicRunner, core.ArtifactManager, *gop
 	lrSock := os.TempDir() + "/" + testutils.RandomString() + ".sock"
 	rundSock := os.TempDir() + "/" + testutils.RandomString() + ".sock"
 
-	rundCleaner, err := testutils.StartInsgorund(runnerbin, "unix", rundSock, "unix", lrSock)
+	rundCleaner, err := goplugintestutils.StartInsgorund(runnerbin, "unix", rundSock, "unix", lrSock)
 	assert.NoError(t, err)
 
 	lr, err := NewLogicRunner(&configuration.LogicRunner{

--- a/testutils/insgorund.go
+++ b/testutils/insgorund.go
@@ -3,14 +3,29 @@ package testutils
 import (
 	"os"
 	"os/exec"
+	"runtime/debug"
 	"syscall"
 	"time"
 
+	"github.com/insolar/insolar/log"
 	"github.com/pkg/errors"
 )
 
 // StartInsgorund starts `insgorund` process
 func StartInsgorund(cmdPath, lProto, listen, upstreamProto, upstreamAddr string) (func(), error) {
+	id := RandomString()
+	log.Debug("Starting 'insgorund' ", id)
+
+	stackTrace := (string)(debug.Stack())
+	cancelWarning := make(chan error, 1)
+	go func() {
+		select {
+		case <-time.After(60 * time.Second):
+			log.Error("'insgorund' is running for a minute, was started by:\n", stackTrace)
+		case <-cancelWarning:
+		}
+	}()
+
 	var args []string
 	if listen != "" {
 		args = append(args, "-l", listen)
@@ -45,11 +60,34 @@ func StartInsgorund(cmdPath, lProto, listen, upstreamProto, upstreamAddr string)
 	time.Sleep(200 * time.Millisecond)
 
 	return func() {
-		err := runner.Process.Signal(syscall.SIGINT)
+		log.Debug("stopping 'insgorund' ", id)
+
+		close(cancelWarning)
+
+		p := runner.Process
+		err := p.Kill()
 		if err != nil {
-			return
+			log.Error("couldn't kill process: ", err)
 		}
-		// XXX: dirty hack
-		time.Sleep(200 * time.Millisecond)
+
+		// Wait for the process to finish or kill it after a timeout:
+		done := make(chan error, 1)
+		go func() {
+			done <- runner.Wait()
+		}()
+
+		select {
+		case <-time.After(3 * time.Second):
+			log.Debug("waited for insgorund to finish and got tired")
+			if err := p.Signal(syscall.SIGTERM); err != nil {
+				log.Fatal("failed to terminate process: ", err)
+			}
+		case err := <-done:
+			if err != nil {
+				log.Debug("process finished, error: ", err)
+			} else {
+				log.Debug("process finished successfully")
+			}
+		}
 	}, nil
 }


### PR DESCRIPTION
* start with log message and random identifier
* report random identifier when stopping
* log a error if insgorund is running for a minute with stack trace,
  helps find runaway daemons
* run Wait() so we don't leave zombies
* first .Kill(), then Wait() 3 seconds, then SIGTERM

should help us find hang insgorund processes that we either forgot to
stop or that are in deadlock