### PR TITLE
simplify how we deal with lock during execution

### DIFF
--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -44,7 +44,6 @@ type ExecutionState struct {
 	Ref    *Ref
 	Method string
 
-	noWait      bool
 	validate    bool
 	insContext  context.Context
 	callContext *core.LogicCallContext
@@ -443,9 +442,9 @@ func (lr *LogicRunner) getObjectMessage(es *ExecutionState, objref Ref) error {
 func (lr *LogicRunner) executeMethodCall(es *ExecutionState, m *message.CallMethod, vb ValidationBehaviour) (core.Reply, error) {
 	ctx := es.insContext
 
-	es.noWait = false
+	delayedUnlock := false
 	defer func() {
-		if !es.noWait {
+		if !delayedUnlock {
 			es.Unlock()
 		}
 	}()
@@ -467,11 +466,6 @@ func (lr *LogicRunner) executeMethodCall(es *ExecutionState, m *message.CallMeth
 	}
 
 	executeFunction := func() (*reply.CallMethod, error) {
-		defer func() {
-			if es.noWait {
-				es.Unlock()
-			}
-		}()
 		newData, result, err := executor.CallMethod(
 			ctx, es.callContext, *es.objectbody.CodeRef, es.objectbody.Object, m.Method, m.Arguments,
 		)
@@ -499,7 +493,6 @@ func (lr *LogicRunner) executeMethodCall(es *ExecutionState, m *message.CallMeth
 			if err != nil {
 				return nil, es.ErrorWrap(err, "couldn't save results")
 			}
-
 		}
 
 		es.objectbody.Object = newData
@@ -516,8 +509,9 @@ func (lr *LogicRunner) executeMethodCall(es *ExecutionState, m *message.CallMeth
 	case message.ReturnResult:
 		return executeFunction()
 	case message.ReturnNoWait:
-		es.noWait = true
+		delayedUnlock = true
 		go func() {
+			defer es.Unlock()
 			_, err := executeFunction()
 			if err != nil {
 				inslogger.FromContext(ctx).Error(err)
@@ -530,9 +524,7 @@ func (lr *LogicRunner) executeMethodCall(es *ExecutionState, m *message.CallMeth
 
 func (lr *LogicRunner) executeConstructorCall(es *ExecutionState, m *message.CallConstructor, vb ValidationBehaviour) (core.Reply, error) {
 	ctx := es.insContext
-	defer func() {
-		es.Unlock()
-	}()
+	defer es.Unlock()
 
 	if es.callContext.Caller.IsEmpty() {
 		return nil, es.ErrorWrap(nil, "Call constructor from nowhere")


### PR DESCRIPTION
* use closures with local variable rather than state struct,
  local variable makes it clear that this thing is not used elsewhere
  and makes problem isolated
* make only one defer conditional the one in the beginning, less logic
  -> less chances of error