### PR TITLE
FIX: rerequest objectbody when network fails

### DIFF
--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -489,6 +489,8 @@ func (lr *LogicRunner) executeMethodCall(es *ExecutionState, m *message.CallMeth
 				err = e
 				if od != nil && e == nil {
 					es.objectbody.objDescriptor = od
+				} else {
+					es.objectbody = nil
 				}
 			}
 			if err != nil {


### PR DESCRIPTION
**sometime AM returns a n error, and objectdescriptor become invalid**