### PR TITLE
INS-834: executeOrValidate method

### DIFF
--- a/logicrunner/casebind.go
+++ b/logicrunner/casebind.go
@@ -47,6 +47,7 @@ func (lr *LogicRunner) Validate(ctx context.Context, ref Ref, p core.Pulse, cb c
 	es.insContext = ctx
 	es.validate = true
 	es.objectbody = nil
+	var cbr core.CaseBindReplay
 	err := func() error {
 		lr.caseBindReplaysMutex.Lock()
 		defer lr.caseBindReplaysMutex.Unlock()
@@ -60,6 +61,7 @@ func (lr *LogicRunner) Validate(ctx context.Context, ref Ref, p core.Pulse, cb c
 			Record:   -1,
 			Steps:    0,
 		}
+		cbr = lr.caseBindReplays[ref]
 		return nil
 	}()
 	if err != nil {
@@ -102,7 +104,8 @@ func (lr *LogicRunner) Validate(ctx context.Context, ref Ref, p core.Pulse, cb c
 		}
 
 		es.insContext = inslogger.ContextWithTrace(es.insContext, traceID)
-		ret, err := lr.Execute(es.insContext, parcel)
+		es.Lock()
+		ret, err := lr.executeOrValidate(es.insContext, es, ValidationChecker{lr: lr, cb: cbr}, parcel)
 		if err != nil {
 			return 0, errors.Wrap(err, "validation step failed")
 		}
@@ -139,12 +142,18 @@ func (lr *LogicRunner) ValidateCaseBind(ctx context.Context, inmsg core.Parcel) 
 	if !ok {
 		return nil, errors.New("Execute( ! message.ValidateCaseBindInterface )")
 	}
+
+	err := lr.CheckOurRole(ctx, msg, core.RoleVirtualValidator)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't play role")
+	}
+
 	passedStepsCount, validationError := lr.Validate(ctx, msg.GetReference(), msg.GetPulse(), msg.CaseBind)
 	errstr := ""
 	if validationError != nil {
 		errstr = validationError.Error()
 	}
-	_, err := lr.MessageBus.Send(
+	_, err = lr.MessageBus.Send(
 		ctx,
 		&message.ValidationResults{
 			RecordRef:        msg.GetReference(),


### PR DESCRIPTION
low level common point of validation and execution.

we need this as first step towards executing or validating at the same
time. We should avoid detection in Execute method, this method should be
named HandleCalls.