### PR TITLE
INS-919: serialization codegen (part 1 of 2, without recursive enumeration of all types used in the contract)

### DIFF
--- a/cmd/insgocc/insgocc.go
+++ b/cmd/insgocc/insgocc.go
@@ -64,6 +64,7 @@ func (r *outputFlag) Type() string {
 	return "file"
 }
 
+// Returns $GOPATH or the default value (usually $HOME/go) if the environment variable is not set.
 func getGOPATH() string {
 	gopath := os.Getenv("GOPATH")
 	if gopath == "" {

--- a/cmd/insgocc/insgocc.go
+++ b/cmd/insgocc/insgocc.go
@@ -241,7 +241,26 @@ func main() {
 				os.Exit(1)
 			}
 
-			out, err := exec.Command("go", "build", "-buildmode=plugin", "-o", path.Join(dir, outdir, name+".so")).CombinedOutput()
+			// TODO: comments regarding two renames
+
+			var out []byte
+			allgo := filepath.Join(tmpDir, "*.go")
+			out, err = exec.Command("sh", "-c", "sed -i.bak 's/package main/package xmain/' " + allgo).CombinedOutput()
+			if err != nil {
+				fmt.Printf("Error during renaming package main to xmain: %s (%v)\n", string(out), err)
+				os.Exit(1)
+			}
+
+			// TODO: execute codecgen HERE!
+
+			out, err = exec.Command("sh", "-c", "sed -i.bak 's/package xmain/package main/' " + allgo).CombinedOutput()
+			if err != nil {
+				fmt.Printf("Error during renaming package xmain to main: %s (%v)\n", string(out), err)
+				os.Exit(1)
+			}
+
+			// Finally, build the plugin
+			out, err = exec.Command("go", "build", "-buildmode=plugin", "-o", path.Join(dir, outdir, name+".so")).CombinedOutput()
 			if err != nil {
 				fmt.Println(errors.Wrap(err, "can't build contract: "+string(out)))
 				os.Exit(1)

--- a/cmd/insgocc/insgocc.go
+++ b/cmd/insgocc/insgocc.go
@@ -279,7 +279,7 @@ func main() {
 				os.Exit(1)
 			}
 
-			expr, _ := regexp.Compile("^(.*)\\.go$")
+			expr, _ := regexp.Compile(`^(.*)\.go$`)
 			for _, infile := range files {
 				// If the name of the input file is xyz.go, the name of the output file is xyz.gen.go.
 				matches := expr.FindStringSubmatch(infile)

--- a/cmd/insgocc/insgocc.go
+++ b/cmd/insgocc/insgocc.go
@@ -205,7 +205,7 @@ func main() {
 			// is that `codecgen` refuses to generate serialization and deserialization
 			// code otherwise. Even on trivial benchmarks serialization based on generated code
 			// is about 30% faster then default serialization based on reflaction. On the flip
-			// side resulting binaries become larger (17 Mb vs 14 Mb). However at th time of writing
+			// side resulting binaries become larger (17 Mb vs 14 Mb). However at the time of writing
 			// we are OK with that.
 			tmpDir, err := ioutil.TempDir(filepath.Join(getGOPATH(), "src"), "insgocc-temp-")
 			if err != nil {


### PR DESCRIPTION
**- What I did**

Proposed patch speeds up the serialization and deserialization of the contracts by using code generation feature of `codec` library. The patch doesn't implement recursive code generation for all types used in the contract since this is a much more complicated feature and it deserves a separate code review. 

**- How to verify it**

1. Build the system (e.g. `make build`) from branch `master`
2. Execute `./bin/insgocc compile --keep-temp ./application/contract/wallet/wallet.go`
3. Remember the size of wallet.so and the content of the temp directory (the path is reported by insgocc utility). Repeat for other contracts.
4. Apply the path
5. Execute `make build` once again and repeat step 2
6. Make sure the resulting .so files are much larger, there are extra files in the temp directory, and the temp directory is in `$GOPATH` now.

**- Description for the changelog**

Speed-up of serialization and deserialization of the contracts.