### PR TITLE
NET-12 NET-69 multinode test suite

### DIFF
--- a/certificate/manager.go
+++ b/certificate/manager.go
@@ -102,7 +102,7 @@ func NewManagerReadCertificateFromReader(publicKey crypto.PublicKey, keyProcesso
 }
 
 // NewManagerCertificateWithKeys generate manager with certificate from given keys
-// DEPRECATED, this method generates invalid certificate
+// DEPRECATED, this method generates invalid certificate, remove it after pulsar tests refactor
 func NewManagerCertificateWithKeys(publicKey crypto.PublicKey, keyProcessor core.KeyProcessor) (*CertificateManager, error) {
 	cert, err := NewCertificatesWithKeys(publicKey, keyProcessor)
 	if err != nil {

--- a/network/servicenetwork/integr_test.go
+++ b/network/servicenetwork/integr_test.go
@@ -45,9 +45,9 @@ var testNetworkPort = 10001
 type testSuite struct {
 	suite.Suite
 	ctx            context.Context
-	bootstrapNodes []networkNode
-	networkNodes   []networkNode
-	testNode       networkNode
+	bootstrapNodes []*networkNode
+	networkNodes   []*networkNode
+	testNode       *networkNode
 	//networkPort    int
 }
 
@@ -56,8 +56,8 @@ func NewTestSuite(bootstrapCount, nodesCount int) *testSuite {
 		Suite: suite.Suite{},
 		ctx:   context.Background(),
 		//networkPort:    10001,
-		bootstrapNodes: make([]networkNode, 0),
-		networkNodes:   make([]networkNode, 0),
+		bootstrapNodes: make([]*networkNode, 0),
+		networkNodes:   make([]*networkNode, 0),
 	}
 
 	for i := 0; i < bootstrapCount; i++ {
@@ -76,11 +76,11 @@ func NewTestSuite(bootstrapCount, nodesCount int) *testSuite {
 func (s *testSuite) SetupSuite() {
 	log.Infoln("SetupSuite")
 	for _, node := range s.bootstrapNodes {
-		s.initNode(&node, Disable)
+		s.initNode(node, Disable)
 	}
 
 	for _, node := range s.networkNodes {
-		s.initNode(&node, Disable)
+		s.initNode(node, Disable)
 	}
 
 	log.Infoln("Init bootstrap nodes")
@@ -173,7 +173,7 @@ type networkNode struct {
 }
 
 // newNetworkNode returns networkNode initialized only with id, host address and key pair
-func newNetworkNode() networkNode {
+func newNetworkNode() *networkNode {
 	key, err := platformpolicy.NewKeyProcessor().GeneratePrivateKey()
 	if err != nil {
 		panic(err.Error())
@@ -181,7 +181,7 @@ func newNetworkNode() networkNode {
 	address := "127.0.0.1:" + strconv.Itoa(testNetworkPort)
 	testNetworkPort += 2 // coz consensus transport port+=1
 
-	return networkNode{
+	return &networkNode{
 		id:                  testutils.RandomRef(),
 		privateKey:          key,
 		cryptographyService: cryptography.NewKeyBoundCryptographyService(key),
@@ -292,7 +292,7 @@ func (s *testSuite) initNode(node *networkNode, timeOut PhaseTimeOut) {
 func (s *testSuite) TestNodeConnect() {
 	phasesResult := make(chan error)
 
-	s.initNode(&s.testNode, Disable)
+	s.initNode(s.testNode, Disable)
 
 	s.InitTestNode()
 	s.StartTestNode()
@@ -308,7 +308,7 @@ func (s *testSuite) TestNodeConnect() {
 
 func (s *testSuite) TestNodeLeave() {
 
-	s.initNode(&s.testNode, Disable)
+	s.initNode(s.testNode, Disable)
 
 	phasesResult := make(chan error)
 	s.InitTestNode()
@@ -352,7 +352,7 @@ func (s *testSuite) TestFullTimeOut() {
 	s.T().Skip("will be available after phase result fix !")
 	phasesResult := make(chan error)
 
-	s.initNode(&s.testNode, Full)
+	s.initNode(s.testNode, Full)
 
 	s.InitTestNode()
 	s.StartTestNode()
@@ -370,7 +370,7 @@ func (s *testSuite) TestFullTimeOut() {
 func (s *testSuite) TestPartialTimeOut() {
 	phasesResult := make(chan error)
 
-	s.initNode(&s.testNode, Partial)
+	s.initNode(s.testNode, Partial)
 
 	s.InitTestNode()
 	s.StartTestNode()

--- a/network/servicenetwork/integr_test.go
+++ b/network/servicenetwork/integr_test.go
@@ -334,6 +334,11 @@ func TestServiceNetworkIntegration(t *testing.T) {
 	suite.Run(t, s)
 }
 
+func TestServiceNetwork3BootsrtapNodes(t *testing.T) {
+	s := NewTestSuite(3, 0)
+	suite.Run(t, s)
+}
+
 // Full timeout test
 
 type FullTimeoutPhaseManager struct {

--- a/network/servicenetwork/integr_test.go
+++ b/network/servicenetwork/integr_test.go
@@ -211,7 +211,7 @@ func (s *testSuite) initCrypto(node *networkNode, ref core.RecordRef) (*certific
 	s.NoError(err)
 	log.Infof("cert: %s", jsonCert)
 
-	cert, err = certificate.ReadCertificateFromReader(publicKey, proc, strings.NewReader(jsonCert))
+	cert, err = certificate.ReadCertificateFromReader(pubKey, proc, strings.NewReader(jsonCert))
 	s.NoError(err)
 	return certificate.NewCertificateManager(cert), node.cryptographyService
 }


### PR DESCRIPTION
**- What I did**
multinode test suite

**- How I did it**
Using SetupSuite and TearDownSuite feature.
The main idea is to create a selected size network once from scratch before runs all integration test cases, and then shutdown it. Each test creates testNode with wrappers and hacks as needed
Now we can to run tests in the large and small networks

**- How to verify it**
nope, tests do not pass, debug needed
