### PR TITLE
INS-956: rename 'os' variable to 'st'

### DIFF
--- a/logicrunner/accessors.go
+++ b/logicrunner/accessors.go
@@ -63,7 +63,7 @@ func (lr *LogicRunner) UpsertObjectState(ref Ref) *ObjectState {
 func (lr *LogicRunner) MustObjectState(ref Ref) *ObjectState {
 	res := lr.GetObjectState(ref)
 	if res == nil {
-		panic("No requested execution state")
+		panic("No requested object state")
 	}
 	return res
 }
@@ -98,22 +98,22 @@ func (lr *LogicRunner) GetConsensus(ctx context.Context, ref Ref) *Consensus {
 	return state.Consensus
 }
 
-func (os *ObjectState) RefreshConsensus() {
-	if os.Consensus == nil {
+func (st *ObjectState) RefreshConsensus() {
+	if st.Consensus == nil {
 		return
 	}
 
-	os.Consensus.ready = true
-	os.Consensus = nil
+	st.Consensus.ready = true
+	st.Consensus = nil
 }
 
-func (os *ObjectState) StartValidation() *ExecutionState {
-	os.Lock()
-	defer os.Unlock()
+func (st *ObjectState) StartValidation() *ExecutionState {
+	st.Lock()
+	defer st.Unlock()
 
-	if os.Validation != nil {
+	if st.Validation != nil {
 		panic("Unexpected. Validation already in progress")
 	}
-	os.Validation = &ExecutionState{}
-	return os.Validation
+	st.Validation = &ExecutionState{}
+	return st.Validation
 }

--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -104,12 +104,12 @@ func (lre Error) Error() string {
 	return buffer.String()
 }
 
-func (os *ObjectState) MustModeState(mode string) (res *ExecutionState) {
+func (st *ObjectState) MustModeState(mode string) (res *ExecutionState) {
 	switch mode {
 	case "execution":
-		res = os.ExecutionState
+		res = st.ExecutionState
 	case "validation":
-		res = os.Validation
+		res = st.Validation
 	default:
 		panic("'" + mode + "' is unknown object processing mode")
 	}
@@ -119,7 +119,7 @@ func (os *ObjectState) MustModeState(mode string) (res *ExecutionState) {
 	return res
 }
 
-func (os *ObjectState) WrapError(err error, message string) error {
+func (st *ObjectState) WrapError(err error, message string) error {
 	if err == nil {
 		err = errors.New(message)
 	} else {
@@ -127,7 +127,7 @@ func (os *ObjectState) WrapError(err error, message string) error {
 	}
 	return Error{
 		Err:      err,
-		Contract: os.Ref,
+		Contract: st.Ref,
 	}
 }
 


### PR DESCRIPTION
os looks too much like abreviation from 'operating system', especially
when it's 'os.Lock()'