### PR TITLE
INS-1022: don't apply loop detection to NoWait calls

### DIFF
--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -352,7 +352,7 @@ func (lr *LogicRunner) Execute(ctx context.Context, parcel core.Parcel) (core.Re
 		return nil, errors.Wrap(err, "can't play role")
 	}
 
-	if loop := lr.CheckExecutionLoop(ctx, es, parcel); loop {
+	if lr.CheckExecutionLoop(ctx, es, parcel) {
 		return nil, os.WrapError(nil, "loop detected")
 	}
 

--- a/logicrunner/logicrunner_test.go
+++ b/logicrunner/logicrunner_test.go
@@ -1836,9 +1836,7 @@ package main
 	assert.Equal(t, *cb.Prototypes["two"], Ref{}.FromSlice(firstMethodRes(t, resp).([]byte)), "Compare Code Prototypes")
 }
 
-// TODO - unskip when we decide how to work with NotificationCalls (NoWaitMethods)
 func TestNoLoopsWhileNotificationCall(t *testing.T) {
-	t.Skip()
 	if parallel {
 		t.Parallel()
 	}


### PR DESCRIPTION
these were false positives: just call 1000 NoWaits on one object, they
all will be with the same TraceID and on executor and in one queue