### PR TITLE
FIX: Use validable MessageBuss when sending ReturnResults message

### DIFF
--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -584,7 +584,8 @@ func (lr *LogicRunner) executeOrValidate(
 	}
 	if es.Current.ReturnMode == message.ReturnResult {
 		inslogger.FromContext(ctx).Debugf("Sending Method Results for ", es.Current.Request)
-		_, err = lr.MessageBus.Send(ctx, &message.ReturnResults{
+
+		_, err = core.MessageBusFromContext(ctx, nil).Send(ctx, &message.ReturnResults{
 			Caller:  lr.NodeNetwork.GetOrigin().ID(),
 			Target:  *es.Current.RequesterNode,
 			Request: *es.Current.Request,


### PR DESCRIPTION
**Use right MB**