### PR TITLE
Ins-976: store errors on tape

### DIFF
--- a/core/messagebus.go
+++ b/core/messagebus.go
@@ -119,7 +119,9 @@ type MessageBus interface {
 	//
 	// Recorder can be created from MessageBus and passed as MessageBus instance.s
 	NewRecorder(ctx context.Context, currentPulse Pulse) (MessageBus, error)
+}
 
+type TapeWriter interface {
 	// WriteTape writes recorder's tape to the provided writer.
 	WriteTape(ctx context.Context, writer io.Writer) error
 }

--- a/core/reply/base.go
+++ b/core/reply/base.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"encoding/gob"
 	"io"
-	"io/ioutil"
 
 	"github.com/insolar/insolar/core"
 	"github.com/pkg/errors"
@@ -169,11 +168,7 @@ func ToBytes(rep core.Reply) []byte {
 	if err != nil {
 		panic("failed to serialize reply")
 	}
-	buff, err := ioutil.ReadAll(repBuff)
-	if err != nil {
-		panic("failed to serialize reply")
-	}
-	return buff
+	return repBuff.(*bytes.Buffer).Bytes()
 }
 
 func init() {

--- a/logicrunner/casebind.go
+++ b/logicrunner/casebind.go
@@ -81,15 +81,15 @@ func (cb *CaseBind) getCaseBindForMessage(ctx context.Context) []message.CaseBin
 	requests := make([]message.CaseBindRequest, len(cb.Requests))
 
 	for i, req := range cb.Requests {
-		var tape bytes.Buffer
-		err := req.MessageBus.(core.TapeWriter).WriteTape(ctx, &tape)
+		var buf bytes.Buffer
+		err := req.MessageBus.(core.TapeWriter).WriteTape(ctx, &buf)
 		if err != nil {
 			panic("couldn't write tape: " + err.Error())
 		}
 		requests[i] = message.CaseBindRequest{
 			Parcel:         req.Parcel,
 			Request:        req.Request,
-			MessageBusTape: tape.Bytes(),
+			MessageBusTape: buf.Bytes(),
 			Reply:          req.Reply,
 			Error:          req.Error,
 		}

--- a/logicrunner/casebind.go
+++ b/logicrunner/casebind.go
@@ -82,7 +82,7 @@ func (cb *CaseBind) getCaseBindForMessage(ctx context.Context) []message.CaseBin
 
 	for i, req := range cb.Requests {
 		var tape bytes.Buffer
-		err := req.MessageBus.WriteTape(ctx, &tape)
+		err := req.MessageBus.(core.TapeWriter).WriteTape(ctx, &tape)
 		if err != nil {
 			panic("couldn't write tape: " + err.Error())
 		}

--- a/messagebus/messagebus.go
+++ b/messagebus/messagebus.go
@@ -97,11 +97,6 @@ func (mb *MessageBus) Start(ctx context.Context) error {
 // Stop releases resources and stops the bus
 func (mb *MessageBus) Stop(ctx context.Context) error { return nil }
 
-// WriteTape for MessageBus is not available.
-func (mb *MessageBus) WriteTape(ctx context.Context, writer io.Writer) error {
-	panic("this is not a recorder")
-}
-
 func (mb *MessageBus) Lock(ctx context.Context) {
 	inslogger.FromContext(ctx).Info("Acquire GIL")
 	mb.globalLock.Lock()

--- a/messagebus/player.go
+++ b/messagebus/player.go
@@ -18,7 +18,6 @@ package messagebus
 
 import (
 	"context"
-	"io"
 
 	"github.com/insolar/insolar/core"
 	"github.com/insolar/insolar/ledger/localstorage"
@@ -43,11 +42,14 @@ func newPlayer(s sender, tape tape, scheme core.PlatformCryptographyScheme, puls
 	}
 }
 
+<<<<<<< HEAD
 // WriteTape for player is not available.
 func (p *player) WriteTape(ctx context.Context, w io.Writer) error {
 	panic("can't write the tape from player")
 }
 
+=======
+>>>>>>> INS-976: extract WriteTape method to separate interface
 // Send wraps MessageBus Send to reply replies from the tape. If reply for this message is not on the tape, an error
 // will be returned.
 func (p *player) Send(ctx context.Context, msg core.Message, ops *core.MessageSendOptions) (core.Reply, error) {

--- a/messagebus/player.go
+++ b/messagebus/player.go
@@ -42,22 +42,9 @@ func newPlayer(s sender, tape tape, scheme core.PlatformCryptographyScheme, puls
 	}
 }
 
-<<<<<<< HEAD
-// WriteTape for player is not available.
-func (p *player) WriteTape(ctx context.Context, w io.Writer) error {
-	panic("can't write the tape from player")
-}
-
-=======
->>>>>>> INS-976: extract WriteTape method to separate interface
 // Send wraps MessageBus Send to reply replies from the tape. If reply for this message is not on the tape, an error
 // will be returned.
 func (p *player) Send(ctx context.Context, msg core.Message, ops *core.MessageSendOptions) (core.Reply, error) {
-	var (
-		rep core.Reply
-		err error
-	)
-
 	currentPulse, err := p.pulseStorage.Current(ctx)
 	if err != nil {
 		return nil, err
@@ -69,13 +56,13 @@ func (p *player) Send(ctx context.Context, msg core.Message, ops *core.MessageSe
 	}
 	id := GetMessageHash(p.scheme, parcel)
 
-	rep, err = p.tape.GetReply(ctx, id)
-	if err == nil {
-		return rep, nil
-	}
-	if err == localstorage.ErrNotFound {
-		return nil, ErrNoReply
-	} else {
+	item, err := p.tape.Get(ctx, id)
+	if err != nil {
+		if err == localstorage.ErrNotFound {
+			return nil, ErrNoReply
+		}
 		return nil, err
 	}
+
+	return item.Reply, item.Error
 }

--- a/messagebus/player_test.go
+++ b/messagebus/player_test.go
@@ -63,7 +63,7 @@ func TestPlayer_Send(t *testing.T) {
 			Reply: &expectedRep,
 		}
 		tape.GetMock.Expect(ctx, msgHash).Return(&item, nil)
-		rep, err := player.Send(ctx, &msg, *core.GenesisPulse, nil)
+		rep, err := player.Send(ctx, &msg, nil)
 
 		require.NoError(t, err)
 		require.Equal(t, &expectedRep, rep)

--- a/messagebus/player_test.go
+++ b/messagebus/player_test.go
@@ -50,17 +50,20 @@ func TestPlayer_Send(t *testing.T) {
 	pulseStorageMock.CurrentMock.Return(core.GenesisPulse, nil)
 	player := newPlayer(s, tape, pcs, pulseStorageMock)
 
-	t.Run("with no reply on the storageTape doesn't send the message and returns an error", func(t *testing.T) {
-		tape.GetReplyMock.Expect(ctx, msgHash).Return(nil, ErrNoReply)
+	t.Run("with no reply on the Tape doesn't send the message and returns an error", func(t *testing.T) {
+		tape.GetMock.Expect(ctx, msgHash).Return(nil, ErrNoReply)
 
 		_, err := player.Send(ctx, &msg, nil)
 		require.Equal(t, ErrNoReply, err)
 	})
 
-	t.Run("with reply on the storageTape doesn't send the message and returns reply from the storageTape", func(t *testing.T) {
+	t.Run("with reply on the Tape doesn't send the message and returns reply from the storageTape", func(t *testing.T) {
 		expectedRep := reply.Object{Memory: []byte{1, 2, 3}}
-		tape.GetReplyMock.Expect(ctx, msgHash).Return(&expectedRep, nil)
-		rep, err := player.Send(ctx, &msg, nil)
+		item := TapeItem{
+			Reply: &expectedRep,
+		}
+		tape.GetMock.Expect(ctx, msgHash).Return(&item, nil)
+		rep, err := player.Send(ctx, &msg, *core.GenesisPulse, nil)
 
 		require.NoError(t, err)
 		require.Equal(t, &expectedRep, rep)

--- a/messagebus/recorder.go
+++ b/messagebus/recorder.go
@@ -50,11 +50,6 @@ func (r *recorder) WriteTape(ctx context.Context, w io.Writer) error {
 // Send wraps MessageBus Send to save received replies to the tape. This reply is also used to return directly from the
 // tape is the message is sent again, thus providing a cash for message replies.
 func (r *recorder) Send(ctx context.Context, msg core.Message, ops *core.MessageSendOptions) (core.Reply, error) {
-	var (
-		rep core.Reply
-		err error
-	)
-
 	currentPulse, err := r.pulseStorage.Current(ctx)
 	if err != nil {
 		return nil, err
@@ -66,17 +61,17 @@ func (r *recorder) Send(ctx context.Context, msg core.Message, ops *core.Message
 	}
 
 	// Actually send message.
-	rep, err = r.SendParcel(ctx, parcel, *currentPulse, ops)
-	if err != nil {
-		return nil, err
-	}
+	rep, sendErr := r.SendParcel(ctx, parcel, *currentPulse, ops)
 
 	// Save the received Value on the tape.
 	id := GetMessageHash(r.scheme, parcel)
-	err = r.tape.SetReply(ctx, id, rep)
+	err = r.tape.Set(ctx, id, rep, sendErr)
 	if err != nil {
 		return nil, err
 	}
 
+	if sendErr != nil {
+		return nil, sendErr
+	}
 	return rep, nil
 }

--- a/messagebus/recorder_test.go
+++ b/messagebus/recorder_test.go
@@ -52,7 +52,7 @@ func TestRecorder_Send(t *testing.T) {
 	recorder := newRecorder(s, tape, pcs, pulseStorageMock)
 
 	t.Run("with no reply on the tape sends the message and returns reply", func(t *testing.T) {
-		tape.SetReplyMock.Expect(ctx, msgHash, &expectedRep).Return(nil)
+		tape.SetMock.Expect(ctx, msgHash, &expectedRep, nil).Return(nil)
 		s.SendParcelMock.Expect(ctx, &parcel, *core.GenesisPulse, nil).Return(&expectedRep, nil)
 
 		recorderReply, err := recorder.Send(ctx, &msg, nil)

--- a/messagebus/sender_mock_test.go
+++ b/messagebus/sender_mock_test.go
@@ -55,11 +55,6 @@ type senderMock struct {
 	SendParcelCounter    uint64
 	SendParcelPreCounter uint64
 	SendParcelMock       msenderMockSendParcel
-
-	WriteTapeFunc       func(p context.Context, p1 io.Writer) (r error)
-	WriteTapeCounter    uint64
-	WriteTapePreCounter uint64
-	WriteTapeMock       msenderMockWriteTape
 }
 
 //NewsenderMock returns a mock for github.com/insolar/insolar/messagebus.sender
@@ -77,7 +72,6 @@ func NewsenderMock(t minimock.Tester) *senderMock {
 	m.RegisterMock = msenderMockRegister{mock: m}
 	m.SendMock = msenderMockSend{mock: m}
 	m.SendParcelMock = msenderMockSendParcel{mock: m}
-	m.WriteTapeMock = msenderMockWriteTape{mock: m}
 
 	return m
 }
@@ -1114,154 +1108,6 @@ func (m *senderMock) SendParcelFinished() bool {
 	return true
 }
 
-type msenderMockWriteTape struct {
-	mock              *senderMock
-	mainExpectation   *senderMockWriteTapeExpectation
-	expectationSeries []*senderMockWriteTapeExpectation
-}
-
-type senderMockWriteTapeExpectation struct {
-	input  *senderMockWriteTapeInput
-	result *senderMockWriteTapeResult
-}
-
-type senderMockWriteTapeInput struct {
-	p  context.Context
-	p1 io.Writer
-}
-
-type senderMockWriteTapeResult struct {
-	r error
-}
-
-//Expect specifies that invocation of sender.WriteTape is expected from 1 to Infinity times
-func (m *msenderMockWriteTape) Expect(p context.Context, p1 io.Writer) *msenderMockWriteTape {
-	m.mock.WriteTapeFunc = nil
-	m.expectationSeries = nil
-
-	if m.mainExpectation == nil {
-		m.mainExpectation = &senderMockWriteTapeExpectation{}
-	}
-	m.mainExpectation.input = &senderMockWriteTapeInput{p, p1}
-	return m
-}
-
-//Return specifies results of invocation of sender.WriteTape
-func (m *msenderMockWriteTape) Return(r error) *senderMock {
-	m.mock.WriteTapeFunc = nil
-	m.expectationSeries = nil
-
-	if m.mainExpectation == nil {
-		m.mainExpectation = &senderMockWriteTapeExpectation{}
-	}
-	m.mainExpectation.result = &senderMockWriteTapeResult{r}
-	return m.mock
-}
-
-//ExpectOnce specifies that invocation of sender.WriteTape is expected once
-func (m *msenderMockWriteTape) ExpectOnce(p context.Context, p1 io.Writer) *senderMockWriteTapeExpectation {
-	m.mock.WriteTapeFunc = nil
-	m.mainExpectation = nil
-
-	expectation := &senderMockWriteTapeExpectation{}
-	expectation.input = &senderMockWriteTapeInput{p, p1}
-	m.expectationSeries = append(m.expectationSeries, expectation)
-	return expectation
-}
-
-func (e *senderMockWriteTapeExpectation) Return(r error) {
-	e.result = &senderMockWriteTapeResult{r}
-}
-
-//Set uses given function f as a mock of sender.WriteTape method
-func (m *msenderMockWriteTape) Set(f func(p context.Context, p1 io.Writer) (r error)) *senderMock {
-	m.mainExpectation = nil
-	m.expectationSeries = nil
-
-	m.mock.WriteTapeFunc = f
-	return m.mock
-}
-
-//WriteTape implements github.com/insolar/insolar/messagebus.sender interface
-func (m *senderMock) WriteTape(p context.Context, p1 io.Writer) (r error) {
-	counter := atomic.AddUint64(&m.WriteTapePreCounter, 1)
-	defer atomic.AddUint64(&m.WriteTapeCounter, 1)
-
-	if len(m.WriteTapeMock.expectationSeries) > 0 {
-		if counter > uint64(len(m.WriteTapeMock.expectationSeries)) {
-			m.t.Fatalf("Unexpected call to senderMock.WriteTape. %v %v", p, p1)
-			return
-		}
-
-		input := m.WriteTapeMock.expectationSeries[counter-1].input
-		testify_assert.Equal(m.t, *input, senderMockWriteTapeInput{p, p1}, "sender.WriteTape got unexpected parameters")
-
-		result := m.WriteTapeMock.expectationSeries[counter-1].result
-		if result == nil {
-			m.t.Fatal("No results are set for the senderMock.WriteTape")
-			return
-		}
-
-		r = result.r
-
-		return
-	}
-
-	if m.WriteTapeMock.mainExpectation != nil {
-
-		input := m.WriteTapeMock.mainExpectation.input
-		if input != nil {
-			testify_assert.Equal(m.t, *input, senderMockWriteTapeInput{p, p1}, "sender.WriteTape got unexpected parameters")
-		}
-
-		result := m.WriteTapeMock.mainExpectation.result
-		if result == nil {
-			m.t.Fatal("No results are set for the senderMock.WriteTape")
-		}
-
-		r = result.r
-
-		return
-	}
-
-	if m.WriteTapeFunc == nil {
-		m.t.Fatalf("Unexpected call to senderMock.WriteTape. %v %v", p, p1)
-		return
-	}
-
-	return m.WriteTapeFunc(p, p1)
-}
-
-//WriteTapeMinimockCounter returns a count of senderMock.WriteTapeFunc invocations
-func (m *senderMock) WriteTapeMinimockCounter() uint64 {
-	return atomic.LoadUint64(&m.WriteTapeCounter)
-}
-
-//WriteTapeMinimockPreCounter returns the value of senderMock.WriteTape invocations
-func (m *senderMock) WriteTapeMinimockPreCounter() uint64 {
-	return atomic.LoadUint64(&m.WriteTapePreCounter)
-}
-
-//WriteTapeFinished returns true if mock invocations count is ok
-func (m *senderMock) WriteTapeFinished() bool {
-	// if expectation series were set then invocations count should be equal to expectations count
-	if len(m.WriteTapeMock.expectationSeries) > 0 {
-		return atomic.LoadUint64(&m.WriteTapeCounter) == uint64(len(m.WriteTapeMock.expectationSeries))
-	}
-
-	// if main expectation was set then invocations count should be greater than zero
-	if m.WriteTapeMock.mainExpectation != nil {
-		return atomic.LoadUint64(&m.WriteTapeCounter) > 0
-	}
-
-	// if func was set then invocations count should be greater than zero
-	if m.WriteTapeFunc != nil {
-		return atomic.LoadUint64(&m.WriteTapeCounter) > 0
-	}
-
-	return true
-}
-
 //ValidateCallCounters checks that all mocked methods of the interface have been called at least once
 //Deprecated: please use MinimockFinish method or use Finish method of minimock.Controller
 func (m *senderMock) ValidateCallCounters() {
@@ -1292,10 +1138,6 @@ func (m *senderMock) ValidateCallCounters() {
 
 	if !m.SendParcelFinished() {
 		m.t.Fatal("Expected call to senderMock.SendParcel")
-	}
-
-	if !m.WriteTapeFinished() {
-		m.t.Fatal("Expected call to senderMock.WriteTape")
 	}
 
 }
@@ -1343,10 +1185,6 @@ func (m *senderMock) MinimockFinish() {
 		m.t.Fatal("Expected call to senderMock.SendParcel")
 	}
 
-	if !m.WriteTapeFinished() {
-		m.t.Fatal("Expected call to senderMock.WriteTape")
-	}
-
 }
 
 //Wait waits for all mocked methods to be called at least once
@@ -1368,7 +1206,6 @@ func (m *senderMock) MinimockWait(timeout time.Duration) {
 		ok = ok && m.RegisterFinished()
 		ok = ok && m.SendFinished()
 		ok = ok && m.SendParcelFinished()
-		ok = ok && m.WriteTapeFinished()
 
 		if ok {
 			return
@@ -1403,10 +1240,6 @@ func (m *senderMock) MinimockWait(timeout time.Duration) {
 
 			if !m.SendParcelFinished() {
 				m.t.Error("Expected call to senderMock.SendParcel")
-			}
-
-			if !m.WriteTapeFinished() {
-				m.t.Error("Expected call to senderMock.WriteTape")
 			}
 
 			m.t.Fatalf("Some mocks were not called on time: %s", timeout)
@@ -1446,10 +1279,6 @@ func (m *senderMock) AllMocksCalled() bool {
 	}
 
 	if !m.SendParcelFinished() {
-		return false
-	}
-
-	if !m.WriteTapeFinished() {
 		return false
 	}
 

--- a/messagebus/tape.go
+++ b/messagebus/tape.go
@@ -59,40 +59,6 @@ func newStorageTape(ls core.LocalStorage, pulse core.PulseNumber) (*storageTape,
 	return &storageTape{ls: ls, pulse: pulse, id: id}, nil
 }
 
-// newStorageTapeFromReader creates and fills a new storageTape from a stream.
-//
-// This is a very long operation, as it saves replies in storage until the stream is exhausted.
-func newStorageTapeFromReader(ctx context.Context, ls core.LocalStorage, r io.Reader) (*storageTape, error) {
-	var err error
-	tape := storageTape{ls: ls}
-
-	decoder := gob.NewDecoder(r)
-	err = decoder.Decode(&tape.pulse)
-	if err != nil {
-		return nil, err
-	}
-	err = decoder.Decode(&tape.id)
-	if err != nil {
-		return nil, err
-	}
-	for {
-		var rep core.KV
-		err = decoder.Decode(&rep)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-		err = tape.setReplyBinary(ctx, rep.K, rep.V)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return &tape, nil
-}
-
 // Write writes all saved in tape replies to provided writer.
 func (t *storageTape) Write(ctx context.Context, w io.Writer) error {
 	var err error

--- a/messagebus/tape.go
+++ b/messagebus/tape.go
@@ -50,11 +50,6 @@ type storageTape struct {
 	id    uuid.UUID
 }
 
-type couple struct {
-	Key   []byte
-	Value []byte
-}
-
 // newStorageTape creates new storageTape with random id.
 func newStorageTape(ls core.LocalStorage, pulse core.PulseNumber) (*storageTape, error) {
 	id, err := uuid.NewV4()
@@ -81,7 +76,7 @@ func newStorageTapeFromReader(ctx context.Context, ls core.LocalStorage, r io.Re
 		return nil, err
 	}
 	for {
-		var rep couple
+		var rep core.KV
 		err = decoder.Decode(&rep)
 		if err == io.EOF {
 			break
@@ -89,7 +84,7 @@ func newStorageTapeFromReader(ctx context.Context, ls core.LocalStorage, r io.Re
 		if err != nil {
 			return nil, err
 		}
-		err = tape.setReplyBinary(ctx, rep.Key, rep.Value)
+		err = tape.setReplyBinary(ctx, rep.K, rep.V)
 		if err != nil {
 			return nil, err
 		}
@@ -113,9 +108,9 @@ func (t *storageTape) Write(ctx context.Context, w io.Writer) error {
 	}
 
 	err = t.ls.Iterate(ctx, t.pulse, t.id[:], func(k, v []byte) error {
-		return encoder.Encode(&couple{
-			Key:   k[len(t.id):],
-			Value: v,
+		return encoder.Encode(&core.KV{
+			K: k[len(t.id):],
+			V: v,
 		})
 	})
 

--- a/messagebus/tape_mock_test.go
+++ b/messagebus/tape_mock_test.go
@@ -21,15 +21,15 @@ import (
 type tapeMock struct {
 	t minimock.Tester
 
-	GetReplyFunc       func(p context.Context, p1 []byte) (r core.Reply, r1 error)
-	GetReplyCounter    uint64
-	GetReplyPreCounter uint64
-	GetReplyMock       mtapeMockGetReply
+	GetFunc       func(p context.Context, p1 []byte) (r *TapeItem, r1 error)
+	GetCounter    uint64
+	GetPreCounter uint64
+	GetMock       mtapeMockGet
 
-	SetReplyFunc       func(p context.Context, p1 []byte, p2 core.Reply) (r error)
-	SetReplyCounter    uint64
-	SetReplyPreCounter uint64
-	SetReplyMock       mtapeMockSetReply
+	SetFunc       func(p context.Context, p1 []byte, p2 core.Reply, p3 error) (r error)
+	SetCounter    uint64
+	SetPreCounter uint64
+	SetMock       mtapeMockSet
 
 	WriteFunc       func(p context.Context, p1 io.Writer) (r error)
 	WriteCounter    uint64
@@ -45,99 +45,99 @@ func NewtapeMock(t minimock.Tester) *tapeMock {
 		controller.RegisterMocker(m)
 	}
 
-	m.GetReplyMock = mtapeMockGetReply{mock: m}
-	m.SetReplyMock = mtapeMockSetReply{mock: m}
+	m.GetMock = mtapeMockGet{mock: m}
+	m.SetMock = mtapeMockSet{mock: m}
 	m.WriteMock = mtapeMockWrite{mock: m}
 
 	return m
 }
 
-type mtapeMockGetReply struct {
+type mtapeMockGet struct {
 	mock              *tapeMock
-	mainExpectation   *tapeMockGetReplyExpectation
-	expectationSeries []*tapeMockGetReplyExpectation
+	mainExpectation   *tapeMockGetExpectation
+	expectationSeries []*tapeMockGetExpectation
 }
 
-type tapeMockGetReplyExpectation struct {
-	input  *tapeMockGetReplyInput
-	result *tapeMockGetReplyResult
+type tapeMockGetExpectation struct {
+	input  *tapeMockGetInput
+	result *tapeMockGetResult
 }
 
-type tapeMockGetReplyInput struct {
+type tapeMockGetInput struct {
 	p  context.Context
 	p1 []byte
 }
 
-type tapeMockGetReplyResult struct {
-	r  core.Reply
+type tapeMockGetResult struct {
+	r  *TapeItem
 	r1 error
 }
 
-//Expect specifies that invocation of tape.GetReply is expected from 1 to Infinity times
-func (m *mtapeMockGetReply) Expect(p context.Context, p1 []byte) *mtapeMockGetReply {
-	m.mock.GetReplyFunc = nil
+//Expect specifies that invocation of tape.Get is expected from 1 to Infinity times
+func (m *mtapeMockGet) Expect(p context.Context, p1 []byte) *mtapeMockGet {
+	m.mock.GetFunc = nil
 	m.expectationSeries = nil
 
 	if m.mainExpectation == nil {
-		m.mainExpectation = &tapeMockGetReplyExpectation{}
+		m.mainExpectation = &tapeMockGetExpectation{}
 	}
-	m.mainExpectation.input = &tapeMockGetReplyInput{p, p1}
+	m.mainExpectation.input = &tapeMockGetInput{p, p1}
 	return m
 }
 
-//Return specifies results of invocation of tape.GetReply
-func (m *mtapeMockGetReply) Return(r core.Reply, r1 error) *tapeMock {
-	m.mock.GetReplyFunc = nil
+//Return specifies results of invocation of tape.Get
+func (m *mtapeMockGet) Return(r *TapeItem, r1 error) *tapeMock {
+	m.mock.GetFunc = nil
 	m.expectationSeries = nil
 
 	if m.mainExpectation == nil {
-		m.mainExpectation = &tapeMockGetReplyExpectation{}
+		m.mainExpectation = &tapeMockGetExpectation{}
 	}
-	m.mainExpectation.result = &tapeMockGetReplyResult{r, r1}
+	m.mainExpectation.result = &tapeMockGetResult{r, r1}
 	return m.mock
 }
 
-//ExpectOnce specifies that invocation of tape.GetReply is expected once
-func (m *mtapeMockGetReply) ExpectOnce(p context.Context, p1 []byte) *tapeMockGetReplyExpectation {
-	m.mock.GetReplyFunc = nil
+//ExpectOnce specifies that invocation of tape.Get is expected once
+func (m *mtapeMockGet) ExpectOnce(p context.Context, p1 []byte) *tapeMockGetExpectation {
+	m.mock.GetFunc = nil
 	m.mainExpectation = nil
 
-	expectation := &tapeMockGetReplyExpectation{}
-	expectation.input = &tapeMockGetReplyInput{p, p1}
+	expectation := &tapeMockGetExpectation{}
+	expectation.input = &tapeMockGetInput{p, p1}
 	m.expectationSeries = append(m.expectationSeries, expectation)
 	return expectation
 }
 
-func (e *tapeMockGetReplyExpectation) Return(r core.Reply, r1 error) {
-	e.result = &tapeMockGetReplyResult{r, r1}
+func (e *tapeMockGetExpectation) Return(r *TapeItem, r1 error) {
+	e.result = &tapeMockGetResult{r, r1}
 }
 
-//Set uses given function f as a mock of tape.GetReply method
-func (m *mtapeMockGetReply) Set(f func(p context.Context, p1 []byte) (r core.Reply, r1 error)) *tapeMock {
+//Set uses given function f as a mock of tape.Get method
+func (m *mtapeMockGet) Set(f func(p context.Context, p1 []byte) (r *TapeItem, r1 error)) *tapeMock {
 	m.mainExpectation = nil
 	m.expectationSeries = nil
 
-	m.mock.GetReplyFunc = f
+	m.mock.GetFunc = f
 	return m.mock
 }
 
-//GetReply implements github.com/insolar/insolar/messagebus.tape interface
-func (m *tapeMock) GetReply(p context.Context, p1 []byte) (r core.Reply, r1 error) {
-	counter := atomic.AddUint64(&m.GetReplyPreCounter, 1)
-	defer atomic.AddUint64(&m.GetReplyCounter, 1)
+//Get implements github.com/insolar/insolar/messagebus.tape interface
+func (m *tapeMock) Get(p context.Context, p1 []byte) (r *TapeItem, r1 error) {
+	counter := atomic.AddUint64(&m.GetPreCounter, 1)
+	defer atomic.AddUint64(&m.GetCounter, 1)
 
-	if len(m.GetReplyMock.expectationSeries) > 0 {
-		if counter > uint64(len(m.GetReplyMock.expectationSeries)) {
-			m.t.Fatalf("Unexpected call to tapeMock.GetReply. %v %v", p, p1)
+	if len(m.GetMock.expectationSeries) > 0 {
+		if counter > uint64(len(m.GetMock.expectationSeries)) {
+			m.t.Fatalf("Unexpected call to tapeMock.Get. %v %v", p, p1)
 			return
 		}
 
-		input := m.GetReplyMock.expectationSeries[counter-1].input
-		testify_assert.Equal(m.t, *input, tapeMockGetReplyInput{p, p1}, "tape.GetReply got unexpected parameters")
+		input := m.GetMock.expectationSeries[counter-1].input
+		testify_assert.Equal(m.t, *input, tapeMockGetInput{p, p1}, "tape.Get got unexpected parameters")
 
-		result := m.GetReplyMock.expectationSeries[counter-1].result
+		result := m.GetMock.expectationSeries[counter-1].result
 		if result == nil {
-			m.t.Fatal("No results are set for the tapeMock.GetReply")
+			m.t.Fatal("No results are set for the tapeMock.Get")
 			return
 		}
 
@@ -147,16 +147,16 @@ func (m *tapeMock) GetReply(p context.Context, p1 []byte) (r core.Reply, r1 erro
 		return
 	}
 
-	if m.GetReplyMock.mainExpectation != nil {
+	if m.GetMock.mainExpectation != nil {
 
-		input := m.GetReplyMock.mainExpectation.input
+		input := m.GetMock.mainExpectation.input
 		if input != nil {
-			testify_assert.Equal(m.t, *input, tapeMockGetReplyInput{p, p1}, "tape.GetReply got unexpected parameters")
+			testify_assert.Equal(m.t, *input, tapeMockGetInput{p, p1}, "tape.Get got unexpected parameters")
 		}
 
-		result := m.GetReplyMock.mainExpectation.result
+		result := m.GetMock.mainExpectation.result
 		if result == nil {
-			m.t.Fatal("No results are set for the tapeMock.GetReply")
+			m.t.Fatal("No results are set for the tapeMock.Get")
 		}
 
 		r = result.r
@@ -165,130 +165,131 @@ func (m *tapeMock) GetReply(p context.Context, p1 []byte) (r core.Reply, r1 erro
 		return
 	}
 
-	if m.GetReplyFunc == nil {
-		m.t.Fatalf("Unexpected call to tapeMock.GetReply. %v %v", p, p1)
+	if m.GetFunc == nil {
+		m.t.Fatalf("Unexpected call to tapeMock.Get. %v %v", p, p1)
 		return
 	}
 
-	return m.GetReplyFunc(p, p1)
+	return m.GetFunc(p, p1)
 }
 
-//GetReplyMinimockCounter returns a count of tapeMock.GetReplyFunc invocations
-func (m *tapeMock) GetReplyMinimockCounter() uint64 {
-	return atomic.LoadUint64(&m.GetReplyCounter)
+//GetMinimockCounter returns a count of tapeMock.GetFunc invocations
+func (m *tapeMock) GetMinimockCounter() uint64 {
+	return atomic.LoadUint64(&m.GetCounter)
 }
 
-//GetReplyMinimockPreCounter returns the value of tapeMock.GetReply invocations
-func (m *tapeMock) GetReplyMinimockPreCounter() uint64 {
-	return atomic.LoadUint64(&m.GetReplyPreCounter)
+//GetMinimockPreCounter returns the value of tapeMock.Get invocations
+func (m *tapeMock) GetMinimockPreCounter() uint64 {
+	return atomic.LoadUint64(&m.GetPreCounter)
 }
 
-//GetReplyFinished returns true if mock invocations count is ok
-func (m *tapeMock) GetReplyFinished() bool {
+//GetFinished returns true if mock invocations count is ok
+func (m *tapeMock) GetFinished() bool {
 	// if expectation series were set then invocations count should be equal to expectations count
-	if len(m.GetReplyMock.expectationSeries) > 0 {
-		return atomic.LoadUint64(&m.GetReplyCounter) == uint64(len(m.GetReplyMock.expectationSeries))
+	if len(m.GetMock.expectationSeries) > 0 {
+		return atomic.LoadUint64(&m.GetCounter) == uint64(len(m.GetMock.expectationSeries))
 	}
 
 	// if main expectation was set then invocations count should be greater than zero
-	if m.GetReplyMock.mainExpectation != nil {
-		return atomic.LoadUint64(&m.GetReplyCounter) > 0
+	if m.GetMock.mainExpectation != nil {
+		return atomic.LoadUint64(&m.GetCounter) > 0
 	}
 
 	// if func was set then invocations count should be greater than zero
-	if m.GetReplyFunc != nil {
-		return atomic.LoadUint64(&m.GetReplyCounter) > 0
+	if m.GetFunc != nil {
+		return atomic.LoadUint64(&m.GetCounter) > 0
 	}
 
 	return true
 }
 
-type mtapeMockSetReply struct {
+type mtapeMockSet struct {
 	mock              *tapeMock
-	mainExpectation   *tapeMockSetReplyExpectation
-	expectationSeries []*tapeMockSetReplyExpectation
+	mainExpectation   *tapeMockSetExpectation
+	expectationSeries []*tapeMockSetExpectation
 }
 
-type tapeMockSetReplyExpectation struct {
-	input  *tapeMockSetReplyInput
-	result *tapeMockSetReplyResult
+type tapeMockSetExpectation struct {
+	input  *tapeMockSetInput
+	result *tapeMockSetResult
 }
 
-type tapeMockSetReplyInput struct {
+type tapeMockSetInput struct {
 	p  context.Context
 	p1 []byte
 	p2 core.Reply
+	p3 error
 }
 
-type tapeMockSetReplyResult struct {
+type tapeMockSetResult struct {
 	r error
 }
 
-//Expect specifies that invocation of tape.SetReply is expected from 1 to Infinity times
-func (m *mtapeMockSetReply) Expect(p context.Context, p1 []byte, p2 core.Reply) *mtapeMockSetReply {
-	m.mock.SetReplyFunc = nil
+//Expect specifies that invocation of tape.Set is expected from 1 to Infinity times
+func (m *mtapeMockSet) Expect(p context.Context, p1 []byte, p2 core.Reply, p3 error) *mtapeMockSet {
+	m.mock.SetFunc = nil
 	m.expectationSeries = nil
 
 	if m.mainExpectation == nil {
-		m.mainExpectation = &tapeMockSetReplyExpectation{}
+		m.mainExpectation = &tapeMockSetExpectation{}
 	}
-	m.mainExpectation.input = &tapeMockSetReplyInput{p, p1, p2}
+	m.mainExpectation.input = &tapeMockSetInput{p, p1, p2, p3}
 	return m
 }
 
-//Return specifies results of invocation of tape.SetReply
-func (m *mtapeMockSetReply) Return(r error) *tapeMock {
-	m.mock.SetReplyFunc = nil
+//Return specifies results of invocation of tape.Set
+func (m *mtapeMockSet) Return(r error) *tapeMock {
+	m.mock.SetFunc = nil
 	m.expectationSeries = nil
 
 	if m.mainExpectation == nil {
-		m.mainExpectation = &tapeMockSetReplyExpectation{}
+		m.mainExpectation = &tapeMockSetExpectation{}
 	}
-	m.mainExpectation.result = &tapeMockSetReplyResult{r}
+	m.mainExpectation.result = &tapeMockSetResult{r}
 	return m.mock
 }
 
-//ExpectOnce specifies that invocation of tape.SetReply is expected once
-func (m *mtapeMockSetReply) ExpectOnce(p context.Context, p1 []byte, p2 core.Reply) *tapeMockSetReplyExpectation {
-	m.mock.SetReplyFunc = nil
+//ExpectOnce specifies that invocation of tape.Set is expected once
+func (m *mtapeMockSet) ExpectOnce(p context.Context, p1 []byte, p2 core.Reply, p3 error) *tapeMockSetExpectation {
+	m.mock.SetFunc = nil
 	m.mainExpectation = nil
 
-	expectation := &tapeMockSetReplyExpectation{}
-	expectation.input = &tapeMockSetReplyInput{p, p1, p2}
+	expectation := &tapeMockSetExpectation{}
+	expectation.input = &tapeMockSetInput{p, p1, p2, p3}
 	m.expectationSeries = append(m.expectationSeries, expectation)
 	return expectation
 }
 
-func (e *tapeMockSetReplyExpectation) Return(r error) {
-	e.result = &tapeMockSetReplyResult{r}
+func (e *tapeMockSetExpectation) Return(r error) {
+	e.result = &tapeMockSetResult{r}
 }
 
-//Set uses given function f as a mock of tape.SetReply method
-func (m *mtapeMockSetReply) Set(f func(p context.Context, p1 []byte, p2 core.Reply) (r error)) *tapeMock {
+//Set uses given function f as a mock of tape.Set method
+func (m *mtapeMockSet) Set(f func(p context.Context, p1 []byte, p2 core.Reply, p3 error) (r error)) *tapeMock {
 	m.mainExpectation = nil
 	m.expectationSeries = nil
 
-	m.mock.SetReplyFunc = f
+	m.mock.SetFunc = f
 	return m.mock
 }
 
-//SetReply implements github.com/insolar/insolar/messagebus.tape interface
-func (m *tapeMock) SetReply(p context.Context, p1 []byte, p2 core.Reply) (r error) {
-	counter := atomic.AddUint64(&m.SetReplyPreCounter, 1)
-	defer atomic.AddUint64(&m.SetReplyCounter, 1)
+//Set implements github.com/insolar/insolar/messagebus.tape interface
+func (m *tapeMock) Set(p context.Context, p1 []byte, p2 core.Reply, p3 error) (r error) {
+	counter := atomic.AddUint64(&m.SetPreCounter, 1)
+	defer atomic.AddUint64(&m.SetCounter, 1)
 
-	if len(m.SetReplyMock.expectationSeries) > 0 {
-		if counter > uint64(len(m.SetReplyMock.expectationSeries)) {
-			m.t.Fatalf("Unexpected call to tapeMock.SetReply. %v %v %v", p, p1, p2)
+	if len(m.SetMock.expectationSeries) > 0 {
+		if counter > uint64(len(m.SetMock.expectationSeries)) {
+			m.t.Fatalf("Unexpected call to tapeMock.Set. %v %v %v %v", p, p1, p2, p3)
 			return
 		}
 
-		input := m.SetReplyMock.expectationSeries[counter-1].input
-		testify_assert.Equal(m.t, *input, tapeMockSetReplyInput{p, p1, p2}, "tape.SetReply got unexpected parameters")
+		input := m.SetMock.expectationSeries[counter-1].input
+		testify_assert.Equal(m.t, *input, tapeMockSetInput{p, p1, p2, p3}, "tape.Set got unexpected parameters")
 
-		result := m.SetReplyMock.expectationSeries[counter-1].result
+		result := m.SetMock.expectationSeries[counter-1].result
 		if result == nil {
-			m.t.Fatal("No results are set for the tapeMock.SetReply")
+			m.t.Fatal("No results are set for the tapeMock.Set")
 			return
 		}
 
@@ -297,16 +298,16 @@ func (m *tapeMock) SetReply(p context.Context, p1 []byte, p2 core.Reply) (r erro
 		return
 	}
 
-	if m.SetReplyMock.mainExpectation != nil {
+	if m.SetMock.mainExpectation != nil {
 
-		input := m.SetReplyMock.mainExpectation.input
+		input := m.SetMock.mainExpectation.input
 		if input != nil {
-			testify_assert.Equal(m.t, *input, tapeMockSetReplyInput{p, p1, p2}, "tape.SetReply got unexpected parameters")
+			testify_assert.Equal(m.t, *input, tapeMockSetInput{p, p1, p2, p3}, "tape.Set got unexpected parameters")
 		}
 
-		result := m.SetReplyMock.mainExpectation.result
+		result := m.SetMock.mainExpectation.result
 		if result == nil {
-			m.t.Fatal("No results are set for the tapeMock.SetReply")
+			m.t.Fatal("No results are set for the tapeMock.Set")
 		}
 
 		r = result.r
@@ -314,39 +315,39 @@ func (m *tapeMock) SetReply(p context.Context, p1 []byte, p2 core.Reply) (r erro
 		return
 	}
 
-	if m.SetReplyFunc == nil {
-		m.t.Fatalf("Unexpected call to tapeMock.SetReply. %v %v %v", p, p1, p2)
+	if m.SetFunc == nil {
+		m.t.Fatalf("Unexpected call to tapeMock.Set. %v %v %v %v", p, p1, p2, p3)
 		return
 	}
 
-	return m.SetReplyFunc(p, p1, p2)
+	return m.SetFunc(p, p1, p2, p3)
 }
 
-//SetReplyMinimockCounter returns a count of tapeMock.SetReplyFunc invocations
-func (m *tapeMock) SetReplyMinimockCounter() uint64 {
-	return atomic.LoadUint64(&m.SetReplyCounter)
+//SetMinimockCounter returns a count of tapeMock.SetFunc invocations
+func (m *tapeMock) SetMinimockCounter() uint64 {
+	return atomic.LoadUint64(&m.SetCounter)
 }
 
-//SetReplyMinimockPreCounter returns the value of tapeMock.SetReply invocations
-func (m *tapeMock) SetReplyMinimockPreCounter() uint64 {
-	return atomic.LoadUint64(&m.SetReplyPreCounter)
+//SetMinimockPreCounter returns the value of tapeMock.Set invocations
+func (m *tapeMock) SetMinimockPreCounter() uint64 {
+	return atomic.LoadUint64(&m.SetPreCounter)
 }
 
-//SetReplyFinished returns true if mock invocations count is ok
-func (m *tapeMock) SetReplyFinished() bool {
+//SetFinished returns true if mock invocations count is ok
+func (m *tapeMock) SetFinished() bool {
 	// if expectation series were set then invocations count should be equal to expectations count
-	if len(m.SetReplyMock.expectationSeries) > 0 {
-		return atomic.LoadUint64(&m.SetReplyCounter) == uint64(len(m.SetReplyMock.expectationSeries))
+	if len(m.SetMock.expectationSeries) > 0 {
+		return atomic.LoadUint64(&m.SetCounter) == uint64(len(m.SetMock.expectationSeries))
 	}
 
 	// if main expectation was set then invocations count should be greater than zero
-	if m.SetReplyMock.mainExpectation != nil {
-		return atomic.LoadUint64(&m.SetReplyCounter) > 0
+	if m.SetMock.mainExpectation != nil {
+		return atomic.LoadUint64(&m.SetCounter) > 0
 	}
 
 	// if func was set then invocations count should be greater than zero
-	if m.SetReplyFunc != nil {
-		return atomic.LoadUint64(&m.SetReplyCounter) > 0
+	if m.SetFunc != nil {
+		return atomic.LoadUint64(&m.SetCounter) > 0
 	}
 
 	return true
@@ -504,12 +505,12 @@ func (m *tapeMock) WriteFinished() bool {
 //Deprecated: please use MinimockFinish method or use Finish method of minimock.Controller
 func (m *tapeMock) ValidateCallCounters() {
 
-	if !m.GetReplyFinished() {
-		m.t.Fatal("Expected call to tapeMock.GetReply")
+	if !m.GetFinished() {
+		m.t.Fatal("Expected call to tapeMock.Get")
 	}
 
-	if !m.SetReplyFinished() {
-		m.t.Fatal("Expected call to tapeMock.SetReply")
+	if !m.SetFinished() {
+		m.t.Fatal("Expected call to tapeMock.Set")
 	}
 
 	if !m.WriteFinished() {
@@ -533,12 +534,12 @@ func (m *tapeMock) Finish() {
 //MinimockFinish checks that all mocked methods of the interface have been called at least once
 func (m *tapeMock) MinimockFinish() {
 
-	if !m.GetReplyFinished() {
-		m.t.Fatal("Expected call to tapeMock.GetReply")
+	if !m.GetFinished() {
+		m.t.Fatal("Expected call to tapeMock.Get")
 	}
 
-	if !m.SetReplyFinished() {
-		m.t.Fatal("Expected call to tapeMock.SetReply")
+	if !m.SetFinished() {
+		m.t.Fatal("Expected call to tapeMock.Set")
 	}
 
 	if !m.WriteFinished() {
@@ -559,8 +560,8 @@ func (m *tapeMock) MinimockWait(timeout time.Duration) {
 	timeoutCh := time.After(timeout)
 	for {
 		ok := true
-		ok = ok && m.GetReplyFinished()
-		ok = ok && m.SetReplyFinished()
+		ok = ok && m.GetFinished()
+		ok = ok && m.SetFinished()
 		ok = ok && m.WriteFinished()
 
 		if ok {
@@ -570,12 +571,12 @@ func (m *tapeMock) MinimockWait(timeout time.Duration) {
 		select {
 		case <-timeoutCh:
 
-			if !m.GetReplyFinished() {
-				m.t.Error("Expected call to tapeMock.GetReply")
+			if !m.GetFinished() {
+				m.t.Error("Expected call to tapeMock.Get")
 			}
 
-			if !m.SetReplyFinished() {
-				m.t.Error("Expected call to tapeMock.SetReply")
+			if !m.SetFinished() {
+				m.t.Error("Expected call to tapeMock.Set")
 			}
 
 			if !m.WriteFinished() {
@@ -594,11 +595,11 @@ func (m *tapeMock) MinimockWait(timeout time.Duration) {
 //it can be used with assert/require, i.e. assert.True(mock.AllMocksCalled())
 func (m *tapeMock) AllMocksCalled() bool {
 
-	if !m.GetReplyFinished() {
+	if !m.GetFinished() {
 		return false
 	}
 
-	if !m.SetReplyFinished() {
+	if !m.SetFinished() {
 		return false
 	}
 

--- a/messagebus/tape_test.go
+++ b/messagebus/tape_test.go
@@ -35,7 +35,7 @@ func TestGetMessageHash(t *testing.T) {
 	require.Equal(t, 64, len(GetMessageHash(pcs, &message.Parcel{Msg: &message.GenesisRequest{}})))
 }
 
-func TestTape_SetReply(t *testing.T) {
+func TestTape_Set(t *testing.T) {
 	mc := minimock.NewController(t)
 	defer mc.Finish()
 
@@ -49,7 +49,7 @@ func TestTape_SetReply(t *testing.T) {
 	require.NoError(t, err)
 
 	tp := newMemoryTape(pn)
-	err = tp.SetReply(ctx, []byte{4, 5, 6}, &rep)
+	err = tp.Set(ctx, []byte{4, 5, 6}, &rep, nil)
 	require.NoError(t, err)
 }
 

--- a/messagebus/tape_test.go
+++ b/messagebus/tape_test.go
@@ -138,7 +138,7 @@ func TestNewTapeFromReader(t *testing.T) {
 		return nil
 	}
 
-	_, err := newStorageTapeFromReader(ctx, ls, bytes.NewBuffer(buff.Bytes()))
-	require.NoError(t, err)
-	require.Equal(t, expectedValues, values)
+	// _, err := newStorageTapeFromReader(ctx, ls, bytes.NewBuffer(buff.Bytes()))
+	// require.NoError(t, err)
+	// require.Equal(t, expectedValues, values)
 }

--- a/messagebus/tape_test.go
+++ b/messagebus/tape_test.go
@@ -107,8 +107,8 @@ func TestTape_Write(t *testing.T) {
 	enc := gob.NewEncoder(expectedBuff)
 	enc.Encode(tp.pulse)
 	enc.Encode(tp.id)
-	enc.Encode(couple{Key: []byte{1}, Value: []byte{2}})
-	enc.Encode(couple{Key: []byte{3}, Value: []byte{4}})
+	enc.Encode(core.KV{K: []byte{1}, V: []byte{2}})
+	enc.Encode(core.KV{K: []byte{3}, V: []byte{4}})
 
 	require.Equal(t, expectedBuff.Bytes(), buff.Bytes())
 }
@@ -124,17 +124,17 @@ func TestNewTapeFromReader(t *testing.T) {
 	enc := gob.NewEncoder(buff)
 	enc.Encode(core.PulseNumber(42))
 	enc.Encode(id)
-	enc.Encode(couple{Key: []byte{1}, Value: []byte{2}})
-	enc.Encode(couple{Key: []byte{3}, Value: []byte{4}})
+	enc.Encode(core.KV{K: []byte{1}, V: []byte{2}})
+	enc.Encode(core.KV{K: []byte{3}, V: []byte{4}})
 
-	var values []couple
-	expectedValues := []couple{
-		{Key: bytes.Join([][]byte{id[:], {1}}, nil), Value: []byte{2}},
-		{Key: bytes.Join([][]byte{id[:], {3}}, nil), Value: []byte{4}},
+	var values []core.KV
+	expectedValues := []core.KV{
+		{K: bytes.Join([][]byte{id[:], {1}}, nil), V: []byte{2}},
+		{K: bytes.Join([][]byte{id[:], {3}}, nil), V: []byte{4}},
 	}
 	ls := testutils.NewLocalStorageMock(mc)
 	ls.SetFunc = func(ctx context.Context, pulse core.PulseNumber, k, v []byte) (r error) {
-		values = append(values, couple{Key: k, Value: v})
+		values = append(values, core.KV{K: k, V: v})
 		return nil
 	}
 

--- a/messagebus/tape_test.go
+++ b/messagebus/tape_test.go
@@ -112,33 +112,3 @@ func TestTape_Write(t *testing.T) {
 
 	require.Equal(t, expectedBuff.Bytes(), buff.Bytes())
 }
-
-func TestNewTapeFromReader(t *testing.T) {
-	mc := minimock.NewController(t)
-	defer mc.Finish()
-
-	// Prepare test data.
-	ctx := inslogger.TestContext(t)
-	id := uuid.UUID{1, 2, 3}
-	buff := bytes.NewBuffer(nil)
-	enc := gob.NewEncoder(buff)
-	enc.Encode(core.PulseNumber(42))
-	enc.Encode(id)
-	enc.Encode(core.KV{K: []byte{1}, V: []byte{2}})
-	enc.Encode(core.KV{K: []byte{3}, V: []byte{4}})
-
-	var values []core.KV
-	expectedValues := []core.KV{
-		{K: bytes.Join([][]byte{id[:], {1}}, nil), V: []byte{2}},
-		{K: bytes.Join([][]byte{id[:], {3}}, nil), V: []byte{4}},
-	}
-	ls := testutils.NewLocalStorageMock(mc)
-	ls.SetFunc = func(ctx context.Context, pulse core.PulseNumber, k, v []byte) (r error) {
-		values = append(values, core.KV{K: k, V: v})
-		return nil
-	}
-
-	// _, err := newStorageTapeFromReader(ctx, ls, bytes.NewBuffer(buff.Bytes()))
-	// require.NoError(t, err)
-	// require.Equal(t, expectedValues, values)
-}

--- a/testutils/message_bus_mock.go
+++ b/testutils/message_bus_mock.go
@@ -45,11 +45,6 @@ type MessageBusMock struct {
 	SendCounter    uint64
 	SendPreCounter uint64
 	SendMock       mMessageBusMockSend
-
-	WriteTapeFunc       func(p context.Context, p1 io.Writer) (r error)
-	WriteTapeCounter    uint64
-	WriteTapePreCounter uint64
-	WriteTapeMock       mMessageBusMockWriteTape
 }
 
 //NewMessageBusMock returns a mock for github.com/insolar/insolar/core.MessageBus
@@ -65,7 +60,6 @@ func NewMessageBusMock(t minimock.Tester) *MessageBusMock {
 	m.NewRecorderMock = mMessageBusMockNewRecorder{mock: m}
 	m.RegisterMock = mMessageBusMockRegister{mock: m}
 	m.SendMock = mMessageBusMockSend{mock: m}
-	m.WriteTapeMock = mMessageBusMockWriteTape{mock: m}
 
 	return m
 }
@@ -796,154 +790,6 @@ func (m *MessageBusMock) SendFinished() bool {
 	return true
 }
 
-type mMessageBusMockWriteTape struct {
-	mock              *MessageBusMock
-	mainExpectation   *MessageBusMockWriteTapeExpectation
-	expectationSeries []*MessageBusMockWriteTapeExpectation
-}
-
-type MessageBusMockWriteTapeExpectation struct {
-	input  *MessageBusMockWriteTapeInput
-	result *MessageBusMockWriteTapeResult
-}
-
-type MessageBusMockWriteTapeInput struct {
-	p  context.Context
-	p1 io.Writer
-}
-
-type MessageBusMockWriteTapeResult struct {
-	r error
-}
-
-//Expect specifies that invocation of MessageBus.WriteTape is expected from 1 to Infinity times
-func (m *mMessageBusMockWriteTape) Expect(p context.Context, p1 io.Writer) *mMessageBusMockWriteTape {
-	m.mock.WriteTapeFunc = nil
-	m.expectationSeries = nil
-
-	if m.mainExpectation == nil {
-		m.mainExpectation = &MessageBusMockWriteTapeExpectation{}
-	}
-	m.mainExpectation.input = &MessageBusMockWriteTapeInput{p, p1}
-	return m
-}
-
-//Return specifies results of invocation of MessageBus.WriteTape
-func (m *mMessageBusMockWriteTape) Return(r error) *MessageBusMock {
-	m.mock.WriteTapeFunc = nil
-	m.expectationSeries = nil
-
-	if m.mainExpectation == nil {
-		m.mainExpectation = &MessageBusMockWriteTapeExpectation{}
-	}
-	m.mainExpectation.result = &MessageBusMockWriteTapeResult{r}
-	return m.mock
-}
-
-//ExpectOnce specifies that invocation of MessageBus.WriteTape is expected once
-func (m *mMessageBusMockWriteTape) ExpectOnce(p context.Context, p1 io.Writer) *MessageBusMockWriteTapeExpectation {
-	m.mock.WriteTapeFunc = nil
-	m.mainExpectation = nil
-
-	expectation := &MessageBusMockWriteTapeExpectation{}
-	expectation.input = &MessageBusMockWriteTapeInput{p, p1}
-	m.expectationSeries = append(m.expectationSeries, expectation)
-	return expectation
-}
-
-func (e *MessageBusMockWriteTapeExpectation) Return(r error) {
-	e.result = &MessageBusMockWriteTapeResult{r}
-}
-
-//Set uses given function f as a mock of MessageBus.WriteTape method
-func (m *mMessageBusMockWriteTape) Set(f func(p context.Context, p1 io.Writer) (r error)) *MessageBusMock {
-	m.mainExpectation = nil
-	m.expectationSeries = nil
-
-	m.mock.WriteTapeFunc = f
-	return m.mock
-}
-
-//WriteTape implements github.com/insolar/insolar/core.MessageBus interface
-func (m *MessageBusMock) WriteTape(p context.Context, p1 io.Writer) (r error) {
-	counter := atomic.AddUint64(&m.WriteTapePreCounter, 1)
-	defer atomic.AddUint64(&m.WriteTapeCounter, 1)
-
-	if len(m.WriteTapeMock.expectationSeries) > 0 {
-		if counter > uint64(len(m.WriteTapeMock.expectationSeries)) {
-			m.t.Fatalf("Unexpected call to MessageBusMock.WriteTape. %v %v", p, p1)
-			return
-		}
-
-		input := m.WriteTapeMock.expectationSeries[counter-1].input
-		testify_assert.Equal(m.t, *input, MessageBusMockWriteTapeInput{p, p1}, "MessageBus.WriteTape got unexpected parameters")
-
-		result := m.WriteTapeMock.expectationSeries[counter-1].result
-		if result == nil {
-			m.t.Fatal("No results are set for the MessageBusMock.WriteTape")
-			return
-		}
-
-		r = result.r
-
-		return
-	}
-
-	if m.WriteTapeMock.mainExpectation != nil {
-
-		input := m.WriteTapeMock.mainExpectation.input
-		if input != nil {
-			testify_assert.Equal(m.t, *input, MessageBusMockWriteTapeInput{p, p1}, "MessageBus.WriteTape got unexpected parameters")
-		}
-
-		result := m.WriteTapeMock.mainExpectation.result
-		if result == nil {
-			m.t.Fatal("No results are set for the MessageBusMock.WriteTape")
-		}
-
-		r = result.r
-
-		return
-	}
-
-	if m.WriteTapeFunc == nil {
-		m.t.Fatalf("Unexpected call to MessageBusMock.WriteTape. %v %v", p, p1)
-		return
-	}
-
-	return m.WriteTapeFunc(p, p1)
-}
-
-//WriteTapeMinimockCounter returns a count of MessageBusMock.WriteTapeFunc invocations
-func (m *MessageBusMock) WriteTapeMinimockCounter() uint64 {
-	return atomic.LoadUint64(&m.WriteTapeCounter)
-}
-
-//WriteTapeMinimockPreCounter returns the value of MessageBusMock.WriteTape invocations
-func (m *MessageBusMock) WriteTapeMinimockPreCounter() uint64 {
-	return atomic.LoadUint64(&m.WriteTapePreCounter)
-}
-
-//WriteTapeFinished returns true if mock invocations count is ok
-func (m *MessageBusMock) WriteTapeFinished() bool {
-	// if expectation series were set then invocations count should be equal to expectations count
-	if len(m.WriteTapeMock.expectationSeries) > 0 {
-		return atomic.LoadUint64(&m.WriteTapeCounter) == uint64(len(m.WriteTapeMock.expectationSeries))
-	}
-
-	// if main expectation was set then invocations count should be greater than zero
-	if m.WriteTapeMock.mainExpectation != nil {
-		return atomic.LoadUint64(&m.WriteTapeCounter) > 0
-	}
-
-	// if func was set then invocations count should be greater than zero
-	if m.WriteTapeFunc != nil {
-		return atomic.LoadUint64(&m.WriteTapeCounter) > 0
-	}
-
-	return true
-}
-
 //ValidateCallCounters checks that all mocked methods of the interface have been called at least once
 //Deprecated: please use MinimockFinish method or use Finish method of minimock.Controller
 func (m *MessageBusMock) ValidateCallCounters() {
@@ -966,10 +812,6 @@ func (m *MessageBusMock) ValidateCallCounters() {
 
 	if !m.SendFinished() {
 		m.t.Fatal("Expected call to MessageBusMock.Send")
-	}
-
-	if !m.WriteTapeFinished() {
-		m.t.Fatal("Expected call to MessageBusMock.WriteTape")
 	}
 
 }
@@ -1009,10 +851,6 @@ func (m *MessageBusMock) MinimockFinish() {
 		m.t.Fatal("Expected call to MessageBusMock.Send")
 	}
 
-	if !m.WriteTapeFinished() {
-		m.t.Fatal("Expected call to MessageBusMock.WriteTape")
-	}
-
 }
 
 //Wait waits for all mocked methods to be called at least once
@@ -1032,7 +870,6 @@ func (m *MessageBusMock) MinimockWait(timeout time.Duration) {
 		ok = ok && m.NewRecorderFinished()
 		ok = ok && m.RegisterFinished()
 		ok = ok && m.SendFinished()
-		ok = ok && m.WriteTapeFinished()
 
 		if ok {
 			return
@@ -1059,10 +896,6 @@ func (m *MessageBusMock) MinimockWait(timeout time.Duration) {
 
 			if !m.SendFinished() {
 				m.t.Error("Expected call to MessageBusMock.Send")
-			}
-
-			if !m.WriteTapeFinished() {
-				m.t.Error("Expected call to MessageBusMock.WriteTape")
 			}
 
 			m.t.Fatalf("Some mocks were not called on time: %s", timeout)
@@ -1094,10 +927,6 @@ func (m *MessageBusMock) AllMocksCalled() bool {
 	}
 
 	if !m.SendFinished() {
-		return false
-	}
-
-	if !m.WriteTapeFinished() {
 		return false
 	}
 


### PR DESCRIPTION
**- What I did**

- store send errors on tape and returns it on replay
- remove unuse code
