### PR TITLE
INS-1075: crrectly work with locks and subfields

### DIFF
--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -666,23 +666,22 @@ func (lr *LogicRunner) prepareObjectState(ctx context.Context, msg *message.Exec
 			Behaviour:       &ValidationSaver{lr: lr, caseBind: NewCaseBind()},
 		}
 	}
+	es := state.ExecutionState
 	state.Unlock()
 
-	state.ExecutionState.Lock()
+	es.Lock()
 
 	// prepare pending
-	if state.ExecutionState.pending == PendingUnknown {
+	if es.pending == PendingUnknown {
 		if msg.Pending {
-			state.ExecutionState.pending = InPending
+			es.pending = InPending
 		} else {
-			state.ExecutionState.pending = NotPending
+			es.pending = NotPending
 		}
 	}
 
 	//prepare Queue
 	if msg.Queue != nil {
-		state := lr.UpsertObjectState(msg.GetReference())
-
 		queueFromMessage := make([]ExecutionQueueElement, 0)
 		for _, qe := range msg.Queue {
 			queueFromMessage = append(
@@ -694,13 +693,12 @@ func (lr *LogicRunner) prepareObjectState(ctx context.Context, msg *message.Exec
 					pulse:   qe.Pulse,
 				})
 		}
-		state.ExecutionState.Queue = append(queueFromMessage, state.ExecutionState.Queue...)
-
+		es.Queue = append(queueFromMessage, es.Queue...)
 	}
 
-	state.ExecutionState.Unlock()
+	es.Unlock()
 
-	err := lr.StartQueueProcessorIfNeeded(ctx, state.ExecutionState, msg)
+	err := lr.StartQueueProcessorIfNeeded(ctx, es, msg)
 	if err != nil {
 		return errors.Wrap(err, "can't start Queue Processor from prepareObjectState")
 	}


### PR DESCRIPTION
state.ExecutionState.xxx

is not the same as:

es:= state.ExecutionState
es.xxx