### PR TITLE
INS-1077: update CBOR version to the latest, get rid of lock issue

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -430,11 +430,11 @@
   revision = "e606233f194d6c314156dc6a35f21a42a470c6f6"
 
 [[projects]]
-  digest = "1:59a32808dc731a74dba0fefcac75c5b66ebeeeadae04538b95b81c986722ccaa"
+  digest = "1:56a1ddd7eb11b4e46f7c8b8137194f6e33f2faa64afb25d0412002603452f274"
   name = "github.com/ugorji/go"
   packages = ["codec"]
   pruneopts = "UT"
-  revision = "587a7e6ca264903eb19416288533bea8ff898ec0"
+  revision = "772ced7fd4c2f6322c07537a9a93b68d74551fa6"
 
 [[projects]]
   digest = "1:cd0a556f7c6e6946fbe39b1bbc61db209967c64cbbf0aed5e4108081cd43aea0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,7 +50,7 @@
 
 [[constraint]]
   name = "github.com/ugorji/go"
-  revision = "587a7e6ca264903eb19416288533bea8ff898ec0"
+  revision = "772ced7fd4c2f6322c07537a9a93b68d74551fa6"
 
 [[constraint]]
   name = "github.com/dgraph-io/badger"

--- a/functest/create_member_test.go
+++ b/functest/create_member_test.go
@@ -34,7 +34,7 @@ func TestCreateMember(t *testing.T) {
 
 func TestCreateMemberWrongNameType(t *testing.T) {
 	_, err := signedRequest(&root, "CreateMember", 111, "000")
-	require.EqualError(t, err, "[ makeCall ] Error in called method: [ createMemberCall ]: [ Deserialize ]: unexpected EOF")
+	require.EqualError(t, err, "[ makeCall ] Error in called method: [ createMemberCall ]: [ Deserialize ]: EOF")
 }
 
 func TestCreateMemberWrongKeyType(t *testing.T) {

--- a/messagebus/tape.go
+++ b/messagebus/tape.go
@@ -114,6 +114,10 @@ func (t *memoryTape) Write(ctx context.Context, w io.Writer) error {
 		return errors.Wrap(err, "[ MemoryTape ] can't write pulse")
 	}
 
+	// TODO: remove once https://github.com/ugorji/go/issues/278
+	// is resolved
+	encoder.Reset(w)
+
 	storageBlobs := make([]itemBlob, 0, len(t.storage))
 	for _, record := range t.storage {
 		blob := itemBlob{


### PR DESCRIPTION
we had an issue with lock in CBOR codec, in code that finds
encoder/decoder implementation by argument type. New commits on git
has this problem fixed. We confirmed with mutex pprof'ing.
