### PR TITLE
rw mutex for state map in logic runner should be more effective

### DIFF
--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -209,7 +209,7 @@ type LogicRunner struct {
 	Cfg          *configuration.LogicRunner
 
 	state      map[Ref]*ObjectState // if object exists, we are validating or executing it right now
-	stateMutex sync.Mutex
+	stateMutex sync.RWMutex
 
 	sock net.Listener
 }


### PR DESCRIPTION
we access the map when contracts do sub-calls and we never write
there, so we can take RLock and all concurrent contracts can do
this at the same time. WLock is held when we insert new records
and on pulse change.