### PR TITLE
es.Current is a pointer, es is a pointer, protect from change under us

### DIFF
--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -72,7 +72,6 @@ type ExecutionState struct {
 }
 
 type CurrentExecution struct {
-	sync.Mutex
 	Context       context.Context
 	LogicContext  *core.LogicCallContext
 	Request       *Ref

--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -505,16 +505,17 @@ func (lr *LogicRunner) ProcessExecutionQueue(ctx context.Context, es *ExecutionS
 		es.Queue = q
 
 		sender := qe.parcel.GetSender()
-		es.Current = &CurrentExecution{
+		current := CurrentExecution{
 			Request:       qe.request,
 			RequesterNode: &sender,
 		}
+		es.Current = &current
 
 		if msg, ok := qe.parcel.Message().(*message.CallMethod); ok {
-			es.Current.ReturnMode = msg.ReturnMode
+			current.ReturnMode = msg.ReturnMode
 		}
 		if msg, ok := qe.parcel.Message().(message.IBaseLogicMessage); ok {
-			es.Current.Sequence = msg.GetBaseLogicMessage().Sequence
+			current.Sequence = msg.GetBaseLogicMessage().Sequence
 		}
 
 		es.Unlock()
@@ -527,12 +528,12 @@ func (lr *LogicRunner) ProcessExecutionQueue(ctx context.Context, es *ExecutionS
 			continue
 		}
 
-		es.Current.Context = core.ContextWithMessageBus(qe.ctx, recordingBus)
+		current.Context = core.ContextWithMessageBus(qe.ctx, recordingBus)
 
 		inslogger.FromContext(qe.ctx).Debug("Registering request within execution behaviour")
 		es.Behaviour.(*ValidationSaver).NewRequest(qe.parcel, *qe.request, recordingBus)
 
-		res.reply, res.err = lr.executeOrValidate(es.Current.Context, es, qe.parcel)
+		res.reply, res.err = lr.executeOrValidate(current.Context, es, qe.parcel)
 
 		inslogger.FromContext(qe.ctx).Debug("Registering result within execution behaviour")
 		err = es.Behaviour.Result(res.reply, res.err)


### PR DESCRIPTION
it shouldn't happen, but it feels that some code replaces es.Current
while we are executing "call constructor". We start with one es.Current.Request
and return different one. Protect this code by making a copy of
*es.Current into a local variable, so data stays the same within one
function. Do it for call constructor and for call method as well.