### PR TITLE
INS-1032: only ended pulses data for exporter.Export

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -43,7 +43,8 @@ func main() {
 		panic(err)
 	}
 	db.PlatformCryptographyScheme = platformpolicy.NewPlatformCryptographyScheme()
-	exp := exporter.NewExporter(db)
+	ps := storage.NewPulseStorage(db)
+	exp := exporter.NewExporter(db, ps)
 	err = db.Init(ctx)
 	if err != nil {
 		panic(err)

--- a/ledger/exporter/exporter_test.go
+++ b/ledger/exporter/exporter_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/insolar/insolar/core"
 	"github.com/insolar/insolar/core/message"
 	"github.com/insolar/insolar/instrumentation/inslogger"
+	"github.com/insolar/insolar/ledger/storage"
 	"github.com/insolar/insolar/ledger/storage/record"
 	"github.com/insolar/insolar/ledger/storage/storagetest"
 	"github.com/jbenet/go-base58"
@@ -37,7 +38,8 @@ func TestExporter_Export(t *testing.T) {
 	db, clean := storagetest.TmpDB(ctx, t)
 	defer clean()
 	jetID := core.TODOJetID
-	exporter := NewExporter(db)
+	ps := storage.NewPulseStorage(db)
+	exporter := NewExporter(db, ps)
 
 	err := db.AddPulse(ctx, core.Pulse{PulseNumber: core.FirstPulseNumber, PulseTimestamp: 1})
 	require.NoError(t, err)
@@ -74,8 +76,8 @@ func TestExporter_Export(t *testing.T) {
 
 	result, err := exporter.Export(ctx, 0, 10)
 	require.NoError(t, err)
-	assert.Equal(t, 3, len(result.Data))
-	assert.Equal(t, 3, result.Size)
+	assert.Equal(t, 2, len(result.Data))
+	assert.Equal(t, 2, result.Size)
 	assert.Nil(t, result.NextFrom)
 
 	result, err = exporter.Export(ctx, 0, 2)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -103,7 +103,6 @@ func GetLedgerComponents(conf configuration.Ledger) []interface{} {
 		artifactmanager.NewMessageHandler(db, &conf),
 		localstorage.NewLocalStorage(db),
 		heavyserver.NewSync(db),
-		heavyserver.NewHeavyJetSync(db),
 		exporter.NewExporter(db, ps),
 	}
 }

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -91,9 +91,11 @@ func GetLedgerComponents(conf configuration.Ledger) []interface{} {
 		panic(errors.Wrap(err, "failed to initialize DB"))
 	}
 
+	ps := storage.NewPulseStorage(db)
+
 	return []interface{}{
 		db,
-		storage.NewPulseStorage(db),
+		ps,
 		storage.NewRecentStorageProvider(conf.RecentStorage.DefaultTTL),
 		artifactmanager.NewArtifactManger(db),
 		jetcoordinator.NewJetCoordinator(db, conf.JetCoordinator),
@@ -101,7 +103,8 @@ func GetLedgerComponents(conf configuration.Ledger) []interface{} {
 		artifactmanager.NewMessageHandler(db, &conf),
 		localstorage.NewLocalStorage(db),
 		heavyserver.NewSync(db),
-		exporter.NewExporter(db),
+		heavyserver.NewHeavyJetSync(db),
+		exporter.NewExporter(db, ps),
 	}
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
We don't need data from current pulse, because of
not all data for this pulse is persisted at this moment.
Only ended pulses data for exporter.Export 
**- How I did it**
break for-loop when current pulse number equals iteration pulse number

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->