### PR TITLE
NOISSUE: add microseconds in logrus formatter

### DIFF
--- a/log/logrus.go
+++ b/log/logrus.go
@@ -30,7 +30,11 @@ type logrusAdapter struct {
 }
 
 func newLogrusAdapter() logrusAdapter {
-	return logrusAdapter{entry: logrus.NewEntry(logrus.New()), skipCallNumber: defaultSkipCallNumber}
+	log := logrus.New()
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = "2006-01-02 15:04:05.000000"
+	log.SetFormatter(formatter)
+	return logrusAdapter{entry: logrus.NewEntry(log), skipCallNumber: defaultSkipCallNumber}
 }
 
 // sourced adds a source info fields that contains


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add microseconds in logrus formatter
**- How I did it**
formatter.TimestampFormat = "2006-01-02 15:04:05.000000"
We haven't timezone now. 

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->