### PR TITLE
NOISSUE: fix pulsar distribution

### DIFF
--- a/configuration/servicenetwork.go
+++ b/configuration/servicenetwork.go
@@ -16,16 +16,14 @@
 
 package configuration
 
-// Service is configuration struct for servicenetwork.Service.
-type Service struct {
-}
-
 // ServiceNetwork is configuration for ServiceNetwork.
 type ServiceNetwork struct {
-	Service Service
+	Skip int // magic number that indicates what delta after last ignored pulse we should wait
 }
 
 // NewServiceNetwork creates a new ServiceNetwork configuration.
 func NewServiceNetwork() ServiceNetwork {
-	return ServiceNetwork{}
+	return ServiceNetwork{
+		Skip: 10,
+	}
 }

--- a/core/network.go
+++ b/core/network.go
@@ -47,5 +47,5 @@ type Network interface {
 //go:generate minimock -i github.com/insolar/insolar/core.PulseDistributor -o ../testutils -s _mock.go
 type PulseDistributor interface {
 	// Distribute distributes a pulse across the network.
-	Distribute(context.Context, *Pulse)
+	Distribute(context.Context, Pulse)
 }

--- a/network/controller/bootstrap/bootstrap.go
+++ b/network/controller/bootstrap/bootstrap.go
@@ -158,6 +158,7 @@ func (bc *Bootstrapper) forceSetLastPulse(number core.PulseNumber) {
 	bc.lastPulseLock.Lock()
 	defer bc.lastPulseLock.Unlock()
 
+	log.Debugf("Network will start from pulse %d", number)
 	bc.lastPulse = number
 }
 

--- a/network/pulsenetwork/distributor.go
+++ b/network/pulsenetwork/distributor.go
@@ -18,13 +18,14 @@ package pulsenetwork
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/insolar/insolar/configuration"
 	"github.com/insolar/insolar/core"
 	"github.com/insolar/insolar/instrumentation/inslogger"
+	"github.com/insolar/insolar/network"
+	"github.com/insolar/insolar/network/sequence"
 	"github.com/insolar/insolar/network/transport"
 	"github.com/insolar/insolar/network/transport/host"
 	"github.com/insolar/insolar/network/transport/packet"
@@ -33,7 +34,8 @@ import (
 )
 
 type distributor struct {
-	Transport transport.Transport `inject:""`
+	Transport   transport.Transport `inject:""`
+	idGenerator sequence.Generator
 
 	pingRequestTimeout        time.Duration
 	randomHostsRequestTimeout time.Duration
@@ -56,6 +58,8 @@ func NewDistributor(conf configuration.PulseDistributor) (core.PulseDistributor,
 	}
 
 	return &distributor{
+		idGenerator: sequence.NewGeneratorImpl(),
+
 		pingRequestTimeout:        time.Duration(conf.PingRequestTimeout) * time.Millisecond,
 		randomHostsRequestTimeout: time.Duration(conf.RandomHostsRequestTimeout) * time.Millisecond,
 		pulseRequestTimeout:       time.Duration(conf.PulseRequestTimeout) * time.Millisecond,
@@ -76,7 +80,7 @@ func (d *distributor) Start(ctx context.Context) error {
 	return nil
 }
 
-func (d *distributor) Distribute(ctx context.Context, pulse *core.Pulse) {
+func (d *distributor) Distribute(ctx context.Context, pulse core.Pulse) {
 	logger := inslogger.FromContext(ctx)
 	defer func() {
 		if r := recover(); r != nil {
@@ -91,46 +95,38 @@ func (d *distributor) Distribute(ctx context.Context, pulse *core.Pulse) {
 	wg.Add(len(d.bootstrapHosts))
 
 	for _, bootstrapHost := range d.bootstrapHosts {
-		go func(bootstrapHost host.Host) {
+		go func(ctx context.Context, pulse core.Pulse, bootstrapHost *host.Host) {
 			defer wg.Done()
 
 			if bootstrapHost.NodeID.IsEmpty() {
-				err := d.pingHost(ctx, &bootstrapHost)
+				err := d.pingHost(ctx, bootstrapHost)
 				if err != nil {
-					logger.Error("[ Distribute ] failed to ping and fill node id", err)
+					logger.Errorf("[ Distribute pulse %d ] Failed to ping and fill node id: %s", pulse.PulseNumber, err)
 					return
 				}
 			}
 
-			hosts, err := d.getRandomHosts(ctx, &bootstrapHost)
+			err := d.sendPulseToHost(ctx, &pulse, bootstrapHost)
 			if err != nil {
-				logger.Errorf(
-					"[ Distribute ] Failed to send pulse to host: %s, error: %s",
-					bootstrapHost.String(),
-					err.Error(),
-				)
-			}
-
-			if len(hosts) == 0 {
-				err := d.sendPulseToHost(ctx, pulse, &bootstrapHost)
-				if err != nil {
-					logger.Error(err)
-				}
+				logger.Errorf("[ Distribute pulse %d ] Failed to send pulse: %s", pulse.PulseNumber, err)
 				return
 			}
-
-			d.sendPulseToHosts(ctx, pulse, hosts)
-		}(*bootstrapHost)
+			logger.Infof("[ Distribute pulse %d ] Successfully sent pulse to node %s", pulse.PulseNumber, bootstrapHost)
+		}(ctx, pulse, bootstrapHost)
 	}
 
 	wg.Wait()
+}
+
+func (d *distributor) generateID() network.RequestID {
+	return network.RequestID(d.idGenerator.Generate())
 }
 
 func (d *distributor) pingHost(ctx context.Context, host *host.Host) error {
 	logger := inslogger.FromContext(ctx)
 
 	builder := packet.NewBuilder(d.pulsarHost)
-	pingPacket := builder.Receiver(host).Type(types.Ping).Build()
+	pingPacket := builder.Receiver(host).Type(types.Ping).RequestID(d.generateID()).Build()
 	pingCall, err := d.Transport.SendRequest(ctx, pingPacket)
 	if err != nil {
 		logger.Error(err)
@@ -153,45 +149,6 @@ func (d *distributor) pingHost(ctx context.Context, host *host.Host) error {
 	logger.Debugf("ping request is done")
 
 	return nil
-}
-
-func (d *distributor) getRandomHosts(ctx context.Context, host *host.Host) ([]host.Host, error) {
-	logger := inslogger.FromContext(ctx)
-
-	builder := packet.NewBuilder(d.pulsarHost)
-	request := builder.
-		Receiver(host).
-		Request(&packet.RequestGetRandomHosts{HostsNumber: d.randomNodesCount}).
-		Type(types.GetRandomHosts).
-		Build()
-
-	logger.Debugf("[ getRandomHosts ] before get random hosts request")
-	call, err := d.Transport.SendRequest(ctx, request)
-	if err != nil {
-		logger.Errorf("[ getRandomHosts ] Failed to send request to host: %s, error: %s", host.String(), err)
-		return nil, errors.Wrap(err, "[ getRandomHosts ] failed to send getRandomHosts request")
-	}
-
-	result, err := call.GetResult(d.randomHostsRequestTimeout)
-	if err != nil {
-		logger.Errorf("[ getRandomHosts ] Failed to get result from host: %s, error: %s", host.String(), err)
-		return nil, errors.Wrap(err, "[ getRandomHosts ] failed to get getRandomHosts result")
-	}
-
-	if result.Error != nil {
-		logger.Errorf("[ getRandomHosts ] Host %s returned error: %s", host.String(), result.Error.Error())
-		return nil, errors.Wrap(result.Error, "[ getRandomHosts ] getRandomHosts result returned error")
-	}
-
-	logger.Debugf("[ getRandomHosts ] getRandomHosts request is done")
-
-	body := result.Data.(*packet.ResponseGetRandomHosts)
-	if len(body.Error) != 0 {
-		logger.Errorf("[ getRandomHosts ] Body result from host %s is error %s", host.String(), body.Error)
-		return nil, fmt.Errorf("[ getRandomHosts ] getRandomHosts data returned error: %s", body.Error)
-	}
-
-	return body.Hosts, nil
 }
 
 func (d *distributor) sendPulseToHosts(ctx context.Context, pulse *core.Pulse, hosts []host.Host) {
@@ -227,7 +184,7 @@ func (d *distributor) sendPulseToHost(ctx context.Context, pulse *core.Pulse, ho
 	}()
 
 	pb := packet.NewBuilder(d.pulsarHost)
-	pulseRequest := pb.Receiver(host).Request(&packet.RequestPulse{Pulse: *pulse}).Type(types.Pulse).Build()
+	pulseRequest := pb.Receiver(host).Request(&packet.RequestPulse{Pulse: *pulse}).RequestID(d.generateID()).Type(types.Pulse).Build()
 	call, err := d.Transport.SendRequest(ctx, pulseRequest)
 	if err != nil {
 		return err

--- a/network/servicenetwork/servicenetwork.go
+++ b/network/servicenetwork/servicenetwork.go
@@ -216,7 +216,7 @@ func (n *ServiceNetwork) HandlePulse(ctx context.Context, pulse core.Pulse) {
 		return
 	}
 	if pulse.PulseNumber <= n.controller.GetLastIgnoredPulse() {
-		log.Info("Ignore pulse %d: network is not yet initialized")
+		log.Infof("Ignore pulse %d: network is not yet initialized", pulse.PulseNumber)
 		return
 	}
 	currentPulse, err := n.PulseStorage.Current(ctx)

--- a/network/servicenetwork/servicenetwork.go
+++ b/network/servicenetwork/servicenetwork.go
@@ -64,11 +64,12 @@ type ServiceNetwork struct {
 
 	// fakePulsar *fakepulsar.FakePulsar
 	isGenesis bool
+	skip      int
 }
 
 // NewServiceNetwork returns a new ServiceNetwork.
 func NewServiceNetwork(conf configuration.Configuration, scheme core.PlatformCryptographyScheme, isGenesis bool) (*ServiceNetwork, error) {
-	serviceNetwork := &ServiceNetwork{cfg: conf, CryptographyScheme: scheme, isGenesis: isGenesis}
+	serviceNetwork := &ServiceNetwork{cfg: conf, CryptographyScheme: scheme, isGenesis: isGenesis, skip: conf.Service.Skip}
 	return serviceNetwork, nil
 }
 
@@ -215,7 +216,7 @@ func (n *ServiceNetwork) HandlePulse(ctx context.Context, pulse core.Pulse) {
 		n.controller.SetLastIgnoredPulse(pulse.NextPulseNumber)
 		return
 	}
-	if pulse.PulseNumber <= n.controller.GetLastIgnoredPulse() {
+	if pulse.PulseNumber <= n.controller.GetLastIgnoredPulse()+core.PulseNumber(n.skip) {
 		log.Infof("Ignore pulse %d: network is not yet initialized", pulse.PulseNumber)
 		return
 	}

--- a/network/transport/base.go
+++ b/network/transport/base.go
@@ -144,6 +144,6 @@ func (t *baseTransport) SendPacket(ctx context.Context, p *packet.Packet) error 
 		return errors.Wrap(err, "Failed to serialize packet")
 	}
 
-	inslogger.FromContext(ctx).Debugf("Send packet to %s with RequestID = %d", recvAddress, p.RequestID)
+	inslogger.FromContext(ctx).Debugf("Send %s packet to %s with RequestID = %d", p.Type, recvAddress, p.RequestID)
 	return t.sendFunc(recvAddress, data)
 }

--- a/pulsar/pulsar_integration_test.go
+++ b/pulsar/pulsar_integration_test.go
@@ -129,7 +129,7 @@ func TestPulsar_SendPulseToNode(t *testing.T) {
 	stateSwitcher := &StateSwitcherImpl{}
 
 	pulseDistributor := testutils.NewPulseDistributorMock(t)
-	pulseDistributor.DistributeFunc = func(p context.Context, p1 *core.Pulse) {
+	pulseDistributor.DistributeFunc = func(p context.Context, p1 core.Pulse) {
 		require.Equal(t, core.FirstPulseNumber+1, int(p1.PulseNumber))
 	}
 
@@ -189,7 +189,7 @@ func TestTwoPulsars_Full_Consensus(t *testing.T) {
 	}
 
 	pulseDistributor := testutils.NewPulseDistributorMock(t)
-	pulseDistributor.DistributeFunc = func(p context.Context, p1 *core.Pulse) {
+	pulseDistributor.DistributeFunc = func(p context.Context, p1 core.Pulse) {
 		require.Equal(t, core.FirstPulseNumber+1, int(p1.PulseNumber))
 	}
 
@@ -335,7 +335,7 @@ func TestSevenPulsars_Full_Consensus(t *testing.T) {
 	}
 
 	pulseDistributorMock := testutils.NewPulseDistributorMock(t)
-	pulseDistributorMock.DistributeFunc = func(p context.Context, p1 *core.Pulse) {
+	pulseDistributorMock.DistributeFunc = func(p context.Context, p1 core.Pulse) {
 		require.Equal(t, core.FirstPulseNumber+1, int(p1.PulseNumber))
 	}
 

--- a/pulsar/pulsarbroadcasters.go
+++ b/pulsar/pulsarbroadcasters.go
@@ -247,7 +247,7 @@ func (currentPulsar *Pulsar) sendPulseToNodesAndPulsars(ctx context.Context) {
 	logger.Debug("Start a process of sending pulse")
 	go func() {
 		logger.Debug("Before sending to network")
-		currentPulsar.PulseDistributor.Distribute(ctx, &pulseForSending)
+		currentPulsar.PulseDistributor.Distribute(ctx, pulseForSending)
 	}()
 	go currentPulsar.sendPulseToPulsars(ctx, pulseForSending)
 

--- a/scripts/insolard/launchnet.sh
+++ b/scripts/insolard/launchnet.sh
@@ -108,7 +108,7 @@ create_required_dirs()
 
 generate_insolard_configs()
 {
-    go run scripts/generate_insolar_configs.go -o $GENERATED_CONFIGS_DIR -p $INSGORUND_PORT_FILE -g $GENESIS_CONFIG
+    go run scripts/generate_insolar_configs.go -o $GENERATED_CONFIGS_DIR -p $INSGORUND_PORT_FILE -g $GENESIS_CONFIG -t $BASE_DIR/pulsar_template.yaml
 }
 
 prepare()
@@ -274,7 +274,7 @@ check_working_dir
 process_input_params $@
 
 printf "start pulsar ... \n"
-$PULSARD -c $BASE_DIR/pulsar.yaml &> $NODES_DATA/pulsar_output.log &
+$PULSARD -c $GENERATED_CONFIGS_DIR/pulsar.yaml &> $NODES_DATA/pulsar_output.log &
 
 if [ "$run_insgorund" == "true" ]
 then

--- a/scripts/insolard/pulsar_template.yaml
+++ b/scripts/insolard/pulsar_template.yaml
@@ -16,9 +16,6 @@ pulsar:
     protocol: TCP
     address: 127.0.0.1:58091
     behindnat: false
-  pulsedistributor:
-    bootstraphosts:
-    - 127.0.0.1:13831
 keyspath: "scripts/insolard/configs/bootstrap_keys.json"
 log:
   level: Debug

--- a/testutils/pulse_distributor_mock.go
+++ b/testutils/pulse_distributor_mock.go
@@ -20,7 +20,7 @@ import (
 type PulseDistributorMock struct {
 	t minimock.Tester
 
-	DistributeFunc       func(p context.Context, p1 *core.Pulse)
+	DistributeFunc       func(p context.Context, p1 core.Pulse)
 	DistributeCounter    uint64
 	DistributePreCounter uint64
 	DistributeMock       mPulseDistributorMockDistribute
@@ -51,11 +51,11 @@ type PulseDistributorMockDistributeExpectation struct {
 
 type PulseDistributorMockDistributeInput struct {
 	p  context.Context
-	p1 *core.Pulse
+	p1 core.Pulse
 }
 
 //Expect specifies that invocation of PulseDistributor.Distribute is expected from 1 to Infinity times
-func (m *mPulseDistributorMockDistribute) Expect(p context.Context, p1 *core.Pulse) *mPulseDistributorMockDistribute {
+func (m *mPulseDistributorMockDistribute) Expect(p context.Context, p1 core.Pulse) *mPulseDistributorMockDistribute {
 	m.mock.DistributeFunc = nil
 	m.expectationSeries = nil
 
@@ -79,7 +79,7 @@ func (m *mPulseDistributorMockDistribute) Return() *PulseDistributorMock {
 }
 
 //ExpectOnce specifies that invocation of PulseDistributor.Distribute is expected once
-func (m *mPulseDistributorMockDistribute) ExpectOnce(p context.Context, p1 *core.Pulse) *PulseDistributorMockDistributeExpectation {
+func (m *mPulseDistributorMockDistribute) ExpectOnce(p context.Context, p1 core.Pulse) *PulseDistributorMockDistributeExpectation {
 	m.mock.DistributeFunc = nil
 	m.mainExpectation = nil
 
@@ -90,7 +90,7 @@ func (m *mPulseDistributorMockDistribute) ExpectOnce(p context.Context, p1 *core
 }
 
 //Set uses given function f as a mock of PulseDistributor.Distribute method
-func (m *mPulseDistributorMockDistribute) Set(f func(p context.Context, p1 *core.Pulse)) *PulseDistributorMock {
+func (m *mPulseDistributorMockDistribute) Set(f func(p context.Context, p1 core.Pulse)) *PulseDistributorMock {
 	m.mainExpectation = nil
 	m.expectationSeries = nil
 
@@ -99,7 +99,7 @@ func (m *mPulseDistributorMockDistribute) Set(f func(p context.Context, p1 *core
 }
 
 //Distribute implements github.com/insolar/insolar/core.PulseDistributor interface
-func (m *PulseDistributorMock) Distribute(p context.Context, p1 *core.Pulse) {
+func (m *PulseDistributorMock) Distribute(p context.Context, p1 core.Pulse) {
 	counter := atomic.AddUint64(&m.DistributePreCounter, 1)
 	defer atomic.AddUint64(&m.DistributeCounter, 1)
 


### PR DESCRIPTION
**- What I did**
1. Fixed bug in pulsar distributor that caused timeouts
2. Now pulsar sends pulses only to the nodes from `pulsedistributor.bootstraphosts` configuration params (getRandomHosts is not called)
3. Added magic number `Skip` to servicenetwork configuration that allows to skip a couple of pulses before network bootstrap to have synchronized first pulse on all nodes (very helpful on short pulses < 3000ms)
4. Pulsar config in launchnet is now generated based on `pulsar_template.yaml` (all settings except bootstraphosts) and `genesis.yaml` (bootstraphosts)

**- How to verify it**
Run launchnet.sh on 20+ nodes and check with script `ag -m1 'persist' scripts/insolard/nodes/*/output.log 2>/dev/null | awk '{print $4}' | sort -u` that all nodes start from one pulse

ps: previous pull request was automatically closed without merge because of force push in `NOISSUE-fix-pulsar-distribution` branch