### PR TITLE
INS-1172 OnPulse dont wait sending all messages to next executor

### DIFF
--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -458,12 +458,11 @@ func TestLogicRunner_OnPulse_StillExecuting(t *testing.T) {
 	lr.state[objectRef] = &ObjectState{
 		ExecutionState: &ExecutionState{
 			Behaviour: &ValidationSaver{},
-			Current: &CurrentExecution{},
+			Current:   &CurrentExecution{},
 		},
 	}
 	mb.SendMock.Return(&reply.OK{}, nil)
 	err := lr.OnPulse(ctx, pulse)
 	require.NoError(t, err)
 	assert.NotNil(t, lr.state[objectRef].ExecutionState)
-	assert.Equal(t, uint64(2), mb.SendCounter)
 }


### PR DESCRIPTION
**- What I did**
emprove OnPulse performance
**- How I did it**
remove waitgroup
**- How to verify it**
run metrics
