### PR TITLE
INS-1167: add error for exporter api when fromPulse bigger then current

### DIFF
--- a/ledger/exporter/exporter.go
+++ b/ledger/exporter/exporter.go
@@ -102,7 +102,8 @@ func (e *Exporter) Export(ctx context.Context, fromPulse core.PulseNumber, size 
 	fromPulsePN := core.PulseNumber(math.Max(float64(fromPulse), float64(core.GenesisPulse.PulseNumber)))
 
 	if fromPulsePN > currentPulse.PulseNumber {
-		return nil, errors.New("failed to fetch data: from-pulse > current-pulse")
+		return nil, errors.Errorf("failed to fetch data: from-pulse[%v] > current-pulse[%v]",
+			fromPulsePN, currentPulse.PulseNumber)
 	}
 
 	_, err = e.pulseTracker.GetPulse(ctx, fromPulsePN)

--- a/ledger/exporter/exporter.go
+++ b/ledger/exporter/exporter.go
@@ -101,24 +101,24 @@ func (e *Exporter) Export(ctx context.Context, fromPulse core.PulseNumber, size 
 	counter := 0
 	fromPulsePN := core.PulseNumber(math.Max(float64(fromPulse), float64(core.GenesisPulse.PulseNumber)))
 
-	if fromPulsePN >= currentPulse.PulseNumber {
-		fromPulsePN = currentPulse.PulseNumber
-	} else {
-		_, err = e.pulseTracker.GetPulse(ctx, fromPulsePN)
-		if err != nil {
-			tryPulse, err := e.pulseTracker.GetPulse(ctx, core.GenesisPulse.PulseNumber)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to fetch genesis pulse data")
-			}
+	if fromPulsePN > currentPulse.PulseNumber {
+		return nil, errors.New("failed to fetch data: from-pulse > current-pulse")
+	}
 
-			for fromPulsePN > *tryPulse.Next {
-				tryPulse, err = e.pulseTracker.GetPulse(ctx, *tryPulse.Next)
-				if err != nil {
-					return nil, errors.Wrap(err, "failed to iterate through first pulses")
-				}
-			}
-			fromPulsePN = *tryPulse.Next
+	_, err = e.pulseTracker.GetPulse(ctx, fromPulsePN)
+	if err != nil {
+		tryPulse, err := e.pulseTracker.GetPulse(ctx, core.GenesisPulse.PulseNumber)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to fetch genesis pulse data")
 		}
+
+		for fromPulsePN > *tryPulse.Next {
+			tryPulse, err = e.pulseTracker.GetPulse(ctx, *tryPulse.Next)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to iterate through first pulses")
+			}
+		}
+		fromPulsePN = *tryPulse.Next
 	}
 
 	iterPulse := &fromPulsePN

--- a/ledger/exporter/exporter_test.go
+++ b/ledger/exporter/exporter_test.go
@@ -113,4 +113,10 @@ func TestExporter_Export(t *testing.T) {
 		assert.Equal(t, pl, request.Data.(*record.RequestRecord).Payload)
 		assert.Equal(t, core.TypeCallConstructor.String(), request.Payload["Type"])
 	}
+
+	_, err = exporter.Export(ctx, 100000, 2)
+	require.Error(t, err, "From-pulse should be smaller (or equal) current-pulse")
+
+	_, err = exporter.Export(ctx, 60000, 2)
+	require.NoError(t, err, "From-pulse should be smaller (or equal) current-pulse")
 }


### PR DESCRIPTION
**- What I did**
Error for exporter api when fromPulse bigger then current was added
**- How I did it**
```
if fromPulsePN > currentPulse.PulseNumber {
	return nil, errors.New("failed to fetch data: from-pulse > current-pulse")
}
```
