### PR TITLE
Noissue instruments improvements

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -3,9 +3,9 @@ services:
   prometheus:
     image: "prom/prometheus:v2.7.0"
     volumes:
-      - ./insolard/configs/generated_configs/prometheus.yaml:/etc/prometheus/prometheus.yml:ro
+      - ${PWD}/insolard/configs/generated_configs/:/etc/prometheus:ro
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--config.file=/etc/prometheus/prometheus.yaml'
     ports:
       - '9090:9090'
 

--- a/scripts/insolard/launchnet.sh
+++ b/scripts/insolard/launchnet.sh
@@ -17,7 +17,7 @@ GENESIS_CONFIG=$BASE_DIR/genesis.yaml
 GENERATED_CONFIGS_DIR=$BASE_DIR/$CONFIGS_DIR/generated_configs
 INSGORUND_PORT_FILE=$BASE_DIR/$CONFIGS_DIR/insgorund_ports.txt
 
-insolar_log_level=Debug
+insolar_log_level=${INSOLAR_LOG_LEVEL:-"Debug"}
 gorund_log_level=$insolar_log_level
 
 NUM_NODES=$(grep "host: " $GENESIS_CONFIG | grep -cv "#" )

--- a/scripts/insolard/profile.sh
+++ b/scripts/insolard/profile.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-prof_time=30
+#
+# Example of profiling 60 second profile on all insolard node
+# (by default profiles 30 seconds):
+#
+# ./scripts/insolard/profile.sh [60]
+
+prof_time=${1:-"30"}
 prof_files_dir=pprof
 current_dir=$( dirname $0 )
 web_profile_port=8080
@@ -14,8 +20,8 @@ killall() {
     echo DONE
 }
 
-confs=${current_dir}"/configs/generated_configs/"
-prof_ports=$( grep listenaddress ${confs}/* |  grep -o ":\d\+" | grep -o "\d\+" | tr '\n' ' ' )
+confs=${current_dir}"/configs/generated_configs"
+prof_ports=$( grep listenaddress ${confs}/insolar_*.yaml |  grep -o ":\d\+" | grep -o "\d\+" | tr '\n' ' ' )
 
 mkdir -p ${current_dir}/${prof_files_dir}
 


### PR DESCRIPTION
* allow redefine logging level for `launchnet.sh`
* make profiling time configurable in `profile.sh`
* issue with insolard configs parsing in `profile.sh` fixed
* issue with Prometheus config path conflict with docker compose dir creation solved
