### PR TITLE
INS-1291: start consensus when receive first phase packet

### DIFF
--- a/consensus/packets/data_test.go
+++ b/consensus/packets/data_test.go
@@ -163,7 +163,7 @@ func TestNodePulseProofReadWrite_BadData(t *testing.T) {
 }
 
 func TestPhase1Packet_SetPulseProof(t *testing.T) {
-	p := NewPhase1Packet()
+	p := NewPhase1Packet(core.Pulse{})
 	proofStateHash := genRandomSlice(HashLength)
 	proofSignature := genRandomSlice(SignatureLength)
 
@@ -252,7 +252,7 @@ func TestParseAndCompactPulseAndCustomFlags(t *testing.T) {
 }
 
 func makePhase1Packet() *Phase1Packet {
-	phase1Packet := NewPhase1Packet()
+	phase1Packet := NewPhase1Packet(core.Pulse{})
 	phase1Packet.packetHeader = *makeDefaultPacketHeader(Phase1)
 	phase1Packet.pulseData = makeDefaultPulseDataExt()
 	phase1Packet.proofNodePulse = NodePulseProof{NodeSignature: randomArray66(), NodeStateHash: randomArray64()}

--- a/consensus/packets/phase2packet.go
+++ b/consensus/packets/phase2packet.go
@@ -45,9 +45,10 @@ func (p2p *Phase2Packet) Clone() ConsensusPacket {
 	return &clone
 }
 
-func NewPhase2Packet() *Phase2Packet {
+func NewPhase2Packet(number core.PulseNumber) *Phase2Packet {
 	result := &Phase2Packet{}
 	result.packetHeader.PacketT = Phase2
+	result.packetHeader.Pulse = uint32(number)
 	return result
 }
 

--- a/consensus/packets/phase3packet.go
+++ b/consensus/packets/phase3packet.go
@@ -82,12 +82,13 @@ func (p3p *Phase3Packet) Sign(cryptographyService core.CryptographyService) erro
 	return nil
 }
 
-func NewPhase3Packet(globuleHashSignature GlobuleHashSignature, bitSet BitSet) *Phase3Packet {
+func NewPhase3Packet(number core.PulseNumber, globuleHashSignature GlobuleHashSignature, bitSet BitSet) *Phase3Packet {
 	result := &Phase3Packet{
 		globuleHashSignature: globuleHashSignature,
 		bitset:               bitSet,
 	}
 	result.packetHeader.PacketT = Phase3
+	result.packetHeader.Pulse = uint32(number)
 	return result
 }
 

--- a/consensus/phases/communicator.go
+++ b/consensus/phases/communicator.go
@@ -192,7 +192,7 @@ func (nc *NaiveCommunicator) generatePhase2Response(origReq, req *packets.Phase2
 			answers = append(answers, &claimAnswer)
 		}
 	}
-	response := packets.NewPhase2Packet()
+	response := packets.NewPhase2Packet(origReq.GetPulseNumber())
 	response.SetBitSet(origReq.GetBitSet())
 	ghs := origReq.GetGlobuleHashSignature()
 	err := response.SetGlobuleHashSignature(ghs[:])
@@ -257,7 +257,7 @@ func (nc *NaiveCommunicator) ExchangePhase1(
 		select {
 		case res := <-nc.phase1result:
 			log.Debugf("got phase1 request from %s", res.id)
-			if res.packet.GetPulseNumber() != core.PulseNumber(nc.currentPulseNumber) {
+			if res.packet.GetPulseNumber() != nc.getPulseNumber() {
 				continue
 			}
 
@@ -324,7 +324,7 @@ func (nc *NaiveCommunicator) ExchangePhase2(ctx context.Context, list network.Un
 		select {
 		case res := <-nc.phase2result:
 			log.Debugf("got phase2 request from %s", res.id)
-			if res.packet.GetPulseNumber() != core.PulseNumber(nc.currentPulseNumber) {
+			if res.packet.GetPulseNumber() != nc.getPulseNumber() {
 				continue
 			}
 
@@ -416,7 +416,7 @@ func (nc *NaiveCommunicator) ExchangePhase21(ctx context.Context, list network.U
 	for {
 		select {
 		case res := <-nc.phase2result:
-			if res.packet.GetPulseNumber() != core.PulseNumber(nc.currentPulseNumber) {
+			if res.packet.GetPulseNumber() != nc.getPulseNumber() {
 				continue
 			}
 

--- a/consensus/phases/communicator.go
+++ b/consensus/phases/communicator.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"sync/atomic"
 
+	"github.com/insolar/insolar/component"
 	"github.com/insolar/insolar/consensus/packets"
 	"github.com/insolar/insolar/core"
 	"github.com/insolar/insolar/instrumentation/inslogger"
@@ -48,7 +49,7 @@ type Communicator interface {
 	// ExchangePhase3 used in third consensus step to exchange data between participants
 	ExchangePhase3(ctx context.Context, participants []core.Node, packet *packets.Phase3Packet) (map[core.RecordRef]*packets.Phase3Packet, error)
 
-	Start(ctx context.Context) error
+	component.Initer
 }
 
 type phase1Result struct {
@@ -86,7 +87,7 @@ func NewNaiveCommunicator() *NaiveCommunicator {
 }
 
 // Start method implements Starter interface
-func (nc *NaiveCommunicator) Start(ctx context.Context) error {
+func (nc *NaiveCommunicator) Init(ctx context.Context) error {
 	nc.phase1result = make(chan phase1Result)
 	nc.phase2result = make(chan phase2Result)
 	nc.phase3result = make(chan phase3Result)

--- a/consensus/phases/communicator_mock.go
+++ b/consensus/phases/communicator_mock.go
@@ -42,10 +42,15 @@ type CommunicatorMock struct {
 	ExchangePhase3PreCounter uint64
 	ExchangePhase3Mock       mCommunicatorMockExchangePhase3
 
-	StartFunc       func(p context.Context) (r error)
-	StartCounter    uint64
-	StartPreCounter uint64
-	StartMock       mCommunicatorMockStart
+	InitFunc       func(p context.Context) (r error)
+	InitCounter    uint64
+	InitPreCounter uint64
+	InitMock       mCommunicatorMockInit
+
+	StopFunc       func(p context.Context) (r error)
+	StopCounter    uint64
+	StopPreCounter uint64
+	StopMock       mCommunicatorMockStop
 }
 
 //NewCommunicatorMock returns a mock for github.com/insolar/insolar/consensus/phases.Communicator
@@ -60,7 +65,8 @@ func NewCommunicatorMock(t minimock.Tester) *CommunicatorMock {
 	m.ExchangePhase2Mock = mCommunicatorMockExchangePhase2{mock: m}
 	m.ExchangePhase21Mock = mCommunicatorMockExchangePhase21{mock: m}
 	m.ExchangePhase3Mock = mCommunicatorMockExchangePhase3{mock: m}
-	m.StartMock = mCommunicatorMockStart{mock: m}
+	m.InitMock = mCommunicatorMockInit{mock: m}
+	m.StopMock = mCommunicatorMockStop{mock: m}
 
 	return m
 }
@@ -676,90 +682,90 @@ func (m *CommunicatorMock) ExchangePhase3Finished() bool {
 	return true
 }
 
-type mCommunicatorMockStart struct {
+type mCommunicatorMockInit struct {
 	mock              *CommunicatorMock
-	mainExpectation   *CommunicatorMockStartExpectation
-	expectationSeries []*CommunicatorMockStartExpectation
+	mainExpectation   *CommunicatorMockInitExpectation
+	expectationSeries []*CommunicatorMockInitExpectation
 }
 
-type CommunicatorMockStartExpectation struct {
-	input  *CommunicatorMockStartInput
-	result *CommunicatorMockStartResult
+type CommunicatorMockInitExpectation struct {
+	input  *CommunicatorMockInitInput
+	result *CommunicatorMockInitResult
 }
 
-type CommunicatorMockStartInput struct {
+type CommunicatorMockInitInput struct {
 	p context.Context
 }
 
-type CommunicatorMockStartResult struct {
+type CommunicatorMockInitResult struct {
 	r error
 }
 
-//Expect specifies that invocation of Communicator.Start is expected from 1 to Infinity times
-func (m *mCommunicatorMockStart) Expect(p context.Context) *mCommunicatorMockStart {
-	m.mock.StartFunc = nil
+//Expect specifies that invocation of Communicator.Init is expected from 1 to Infinity times
+func (m *mCommunicatorMockInit) Expect(p context.Context) *mCommunicatorMockInit {
+	m.mock.InitFunc = nil
 	m.expectationSeries = nil
 
 	if m.mainExpectation == nil {
-		m.mainExpectation = &CommunicatorMockStartExpectation{}
+		m.mainExpectation = &CommunicatorMockInitExpectation{}
 	}
-	m.mainExpectation.input = &CommunicatorMockStartInput{p}
+	m.mainExpectation.input = &CommunicatorMockInitInput{p}
 	return m
 }
 
-//Return specifies results of invocation of Communicator.Start
-func (m *mCommunicatorMockStart) Return(r error) *CommunicatorMock {
-	m.mock.StartFunc = nil
+//Return specifies results of invocation of Communicator.Init
+func (m *mCommunicatorMockInit) Return(r error) *CommunicatorMock {
+	m.mock.InitFunc = nil
 	m.expectationSeries = nil
 
 	if m.mainExpectation == nil {
-		m.mainExpectation = &CommunicatorMockStartExpectation{}
+		m.mainExpectation = &CommunicatorMockInitExpectation{}
 	}
-	m.mainExpectation.result = &CommunicatorMockStartResult{r}
+	m.mainExpectation.result = &CommunicatorMockInitResult{r}
 	return m.mock
 }
 
-//ExpectOnce specifies that invocation of Communicator.Start is expected once
-func (m *mCommunicatorMockStart) ExpectOnce(p context.Context) *CommunicatorMockStartExpectation {
-	m.mock.StartFunc = nil
+//ExpectOnce specifies that invocation of Communicator.Init is expected once
+func (m *mCommunicatorMockInit) ExpectOnce(p context.Context) *CommunicatorMockInitExpectation {
+	m.mock.InitFunc = nil
 	m.mainExpectation = nil
 
-	expectation := &CommunicatorMockStartExpectation{}
-	expectation.input = &CommunicatorMockStartInput{p}
+	expectation := &CommunicatorMockInitExpectation{}
+	expectation.input = &CommunicatorMockInitInput{p}
 	m.expectationSeries = append(m.expectationSeries, expectation)
 	return expectation
 }
 
-func (e *CommunicatorMockStartExpectation) Return(r error) {
-	e.result = &CommunicatorMockStartResult{r}
+func (e *CommunicatorMockInitExpectation) Return(r error) {
+	e.result = &CommunicatorMockInitResult{r}
 }
 
-//Set uses given function f as a mock of Communicator.Start method
-func (m *mCommunicatorMockStart) Set(f func(p context.Context) (r error)) *CommunicatorMock {
+//Set uses given function f as a mock of Communicator.Init method
+func (m *mCommunicatorMockInit) Set(f func(p context.Context) (r error)) *CommunicatorMock {
 	m.mainExpectation = nil
 	m.expectationSeries = nil
 
-	m.mock.StartFunc = f
+	m.mock.InitFunc = f
 	return m.mock
 }
 
-//Start implements github.com/insolar/insolar/consensus/phases.Communicator interface
-func (m *CommunicatorMock) Start(p context.Context) (r error) {
-	counter := atomic.AddUint64(&m.StartPreCounter, 1)
-	defer atomic.AddUint64(&m.StartCounter, 1)
+//Init implements github.com/insolar/insolar/consensus/phases.Communicator interface
+func (m *CommunicatorMock) Init(p context.Context) (r error) {
+	counter := atomic.AddUint64(&m.InitPreCounter, 1)
+	defer atomic.AddUint64(&m.InitCounter, 1)
 
-	if len(m.StartMock.expectationSeries) > 0 {
-		if counter > uint64(len(m.StartMock.expectationSeries)) {
-			m.t.Fatalf("Unexpected call to CommunicatorMock.Start. %v", p)
+	if len(m.InitMock.expectationSeries) > 0 {
+		if counter > uint64(len(m.InitMock.expectationSeries)) {
+			m.t.Fatalf("Unexpected call to CommunicatorMock.Init. %v", p)
 			return
 		}
 
-		input := m.StartMock.expectationSeries[counter-1].input
-		testify_assert.Equal(m.t, *input, CommunicatorMockStartInput{p}, "Communicator.Start got unexpected parameters")
+		input := m.InitMock.expectationSeries[counter-1].input
+		testify_assert.Equal(m.t, *input, CommunicatorMockInitInput{p}, "Communicator.Init got unexpected parameters")
 
-		result := m.StartMock.expectationSeries[counter-1].result
+		result := m.InitMock.expectationSeries[counter-1].result
 		if result == nil {
-			m.t.Fatal("No results are set for the CommunicatorMock.Start")
+			m.t.Fatal("No results are set for the CommunicatorMock.Init")
 			return
 		}
 
@@ -768,16 +774,16 @@ func (m *CommunicatorMock) Start(p context.Context) (r error) {
 		return
 	}
 
-	if m.StartMock.mainExpectation != nil {
+	if m.InitMock.mainExpectation != nil {
 
-		input := m.StartMock.mainExpectation.input
+		input := m.InitMock.mainExpectation.input
 		if input != nil {
-			testify_assert.Equal(m.t, *input, CommunicatorMockStartInput{p}, "Communicator.Start got unexpected parameters")
+			testify_assert.Equal(m.t, *input, CommunicatorMockInitInput{p}, "Communicator.Init got unexpected parameters")
 		}
 
-		result := m.StartMock.mainExpectation.result
+		result := m.InitMock.mainExpectation.result
 		if result == nil {
-			m.t.Fatal("No results are set for the CommunicatorMock.Start")
+			m.t.Fatal("No results are set for the CommunicatorMock.Init")
 		}
 
 		r = result.r
@@ -785,39 +791,186 @@ func (m *CommunicatorMock) Start(p context.Context) (r error) {
 		return
 	}
 
-	if m.StartFunc == nil {
-		m.t.Fatalf("Unexpected call to CommunicatorMock.Start. %v", p)
+	if m.InitFunc == nil {
+		m.t.Fatalf("Unexpected call to CommunicatorMock.Init. %v", p)
 		return
 	}
 
-	return m.StartFunc(p)
+	return m.InitFunc(p)
 }
 
-//StartMinimockCounter returns a count of CommunicatorMock.StartFunc invocations
-func (m *CommunicatorMock) StartMinimockCounter() uint64 {
-	return atomic.LoadUint64(&m.StartCounter)
+//InitMinimockCounter returns a count of CommunicatorMock.InitFunc invocations
+func (m *CommunicatorMock) InitMinimockCounter() uint64 {
+	return atomic.LoadUint64(&m.InitCounter)
 }
 
-//StartMinimockPreCounter returns the value of CommunicatorMock.Start invocations
-func (m *CommunicatorMock) StartMinimockPreCounter() uint64 {
-	return atomic.LoadUint64(&m.StartPreCounter)
+//InitMinimockPreCounter returns the value of CommunicatorMock.Init invocations
+func (m *CommunicatorMock) InitMinimockPreCounter() uint64 {
+	return atomic.LoadUint64(&m.InitPreCounter)
 }
 
-//StartFinished returns true if mock invocations count is ok
-func (m *CommunicatorMock) StartFinished() bool {
+//InitFinished returns true if mock invocations count is ok
+func (m *CommunicatorMock) InitFinished() bool {
 	// if expectation series were set then invocations count should be equal to expectations count
-	if len(m.StartMock.expectationSeries) > 0 {
-		return atomic.LoadUint64(&m.StartCounter) == uint64(len(m.StartMock.expectationSeries))
+	if len(m.InitMock.expectationSeries) > 0 {
+		return atomic.LoadUint64(&m.InitCounter) == uint64(len(m.InitMock.expectationSeries))
 	}
 
 	// if main expectation was set then invocations count should be greater than zero
-	if m.StartMock.mainExpectation != nil {
-		return atomic.LoadUint64(&m.StartCounter) > 0
+	if m.InitMock.mainExpectation != nil {
+		return atomic.LoadUint64(&m.InitCounter) > 0
 	}
 
 	// if func was set then invocations count should be greater than zero
-	if m.StartFunc != nil {
-		return atomic.LoadUint64(&m.StartCounter) > 0
+	if m.InitFunc != nil {
+		return atomic.LoadUint64(&m.InitCounter) > 0
+	}
+
+	return true
+}
+
+type mCommunicatorMockStop struct {
+	mock              *CommunicatorMock
+	mainExpectation   *CommunicatorMockStopExpectation
+	expectationSeries []*CommunicatorMockStopExpectation
+}
+
+type CommunicatorMockStopExpectation struct {
+	input  *CommunicatorMockStopInput
+	result *CommunicatorMockStopResult
+}
+
+type CommunicatorMockStopInput struct {
+	p context.Context
+}
+
+type CommunicatorMockStopResult struct {
+	r error
+}
+
+//Expect specifies that invocation of Communicator.Stop is expected from 1 to Infinity times
+func (m *mCommunicatorMockStop) Expect(p context.Context) *mCommunicatorMockStop {
+	m.mock.StopFunc = nil
+	m.expectationSeries = nil
+
+	if m.mainExpectation == nil {
+		m.mainExpectation = &CommunicatorMockStopExpectation{}
+	}
+	m.mainExpectation.input = &CommunicatorMockStopInput{p}
+	return m
+}
+
+//Return specifies results of invocation of Communicator.Stop
+func (m *mCommunicatorMockStop) Return(r error) *CommunicatorMock {
+	m.mock.StopFunc = nil
+	m.expectationSeries = nil
+
+	if m.mainExpectation == nil {
+		m.mainExpectation = &CommunicatorMockStopExpectation{}
+	}
+	m.mainExpectation.result = &CommunicatorMockStopResult{r}
+	return m.mock
+}
+
+//ExpectOnce specifies that invocation of Communicator.Stop is expected once
+func (m *mCommunicatorMockStop) ExpectOnce(p context.Context) *CommunicatorMockStopExpectation {
+	m.mock.StopFunc = nil
+	m.mainExpectation = nil
+
+	expectation := &CommunicatorMockStopExpectation{}
+	expectation.input = &CommunicatorMockStopInput{p}
+	m.expectationSeries = append(m.expectationSeries, expectation)
+	return expectation
+}
+
+func (e *CommunicatorMockStopExpectation) Return(r error) {
+	e.result = &CommunicatorMockStopResult{r}
+}
+
+//Set uses given function f as a mock of Communicator.Stop method
+func (m *mCommunicatorMockStop) Set(f func(p context.Context) (r error)) *CommunicatorMock {
+	m.mainExpectation = nil
+	m.expectationSeries = nil
+
+	m.mock.StopFunc = f
+	return m.mock
+}
+
+//Stop implements github.com/insolar/insolar/consensus/phases.Communicator interface
+func (m *CommunicatorMock) Stop(p context.Context) (r error) {
+	counter := atomic.AddUint64(&m.StopPreCounter, 1)
+	defer atomic.AddUint64(&m.StopCounter, 1)
+
+	if len(m.StopMock.expectationSeries) > 0 {
+		if counter > uint64(len(m.StopMock.expectationSeries)) {
+			m.t.Fatalf("Unexpected call to CommunicatorMock.Stop. %v", p)
+			return
+		}
+
+		input := m.StopMock.expectationSeries[counter-1].input
+		testify_assert.Equal(m.t, *input, CommunicatorMockStopInput{p}, "Communicator.Stop got unexpected parameters")
+
+		result := m.StopMock.expectationSeries[counter-1].result
+		if result == nil {
+			m.t.Fatal("No results are set for the CommunicatorMock.Stop")
+			return
+		}
+
+		r = result.r
+
+		return
+	}
+
+	if m.StopMock.mainExpectation != nil {
+
+		input := m.StopMock.mainExpectation.input
+		if input != nil {
+			testify_assert.Equal(m.t, *input, CommunicatorMockStopInput{p}, "Communicator.Stop got unexpected parameters")
+		}
+
+		result := m.StopMock.mainExpectation.result
+		if result == nil {
+			m.t.Fatal("No results are set for the CommunicatorMock.Stop")
+		}
+
+		r = result.r
+
+		return
+	}
+
+	if m.StopFunc == nil {
+		m.t.Fatalf("Unexpected call to CommunicatorMock.Stop. %v", p)
+		return
+	}
+
+	return m.StopFunc(p)
+}
+
+//StopMinimockCounter returns a count of CommunicatorMock.StopFunc invocations
+func (m *CommunicatorMock) StopMinimockCounter() uint64 {
+	return atomic.LoadUint64(&m.StopCounter)
+}
+
+//StopMinimockPreCounter returns the value of CommunicatorMock.Stop invocations
+func (m *CommunicatorMock) StopMinimockPreCounter() uint64 {
+	return atomic.LoadUint64(&m.StopPreCounter)
+}
+
+//StopFinished returns true if mock invocations count is ok
+func (m *CommunicatorMock) StopFinished() bool {
+	// if expectation series were set then invocations count should be equal to expectations count
+	if len(m.StopMock.expectationSeries) > 0 {
+		return atomic.LoadUint64(&m.StopCounter) == uint64(len(m.StopMock.expectationSeries))
+	}
+
+	// if main expectation was set then invocations count should be greater than zero
+	if m.StopMock.mainExpectation != nil {
+		return atomic.LoadUint64(&m.StopCounter) > 0
+	}
+
+	// if func was set then invocations count should be greater than zero
+	if m.StopFunc != nil {
+		return atomic.LoadUint64(&m.StopCounter) > 0
 	}
 
 	return true
@@ -843,8 +996,12 @@ func (m *CommunicatorMock) ValidateCallCounters() {
 		m.t.Fatal("Expected call to CommunicatorMock.ExchangePhase3")
 	}
 
-	if !m.StartFinished() {
-		m.t.Fatal("Expected call to CommunicatorMock.Start")
+	if !m.InitFinished() {
+		m.t.Fatal("Expected call to CommunicatorMock.Init")
+	}
+
+	if !m.StopFinished() {
+		m.t.Fatal("Expected call to CommunicatorMock.Stop")
 	}
 
 }
@@ -880,8 +1037,12 @@ func (m *CommunicatorMock) MinimockFinish() {
 		m.t.Fatal("Expected call to CommunicatorMock.ExchangePhase3")
 	}
 
-	if !m.StartFinished() {
-		m.t.Fatal("Expected call to CommunicatorMock.Start")
+	if !m.InitFinished() {
+		m.t.Fatal("Expected call to CommunicatorMock.Init")
+	}
+
+	if !m.StopFinished() {
+		m.t.Fatal("Expected call to CommunicatorMock.Stop")
 	}
 
 }
@@ -902,7 +1063,8 @@ func (m *CommunicatorMock) MinimockWait(timeout time.Duration) {
 		ok = ok && m.ExchangePhase2Finished()
 		ok = ok && m.ExchangePhase21Finished()
 		ok = ok && m.ExchangePhase3Finished()
-		ok = ok && m.StartFinished()
+		ok = ok && m.InitFinished()
+		ok = ok && m.StopFinished()
 
 		if ok {
 			return
@@ -927,8 +1089,12 @@ func (m *CommunicatorMock) MinimockWait(timeout time.Duration) {
 				m.t.Error("Expected call to CommunicatorMock.ExchangePhase3")
 			}
 
-			if !m.StartFinished() {
-				m.t.Error("Expected call to CommunicatorMock.Start")
+			if !m.InitFinished() {
+				m.t.Error("Expected call to CommunicatorMock.Init")
+			}
+
+			if !m.StopFinished() {
+				m.t.Error("Expected call to CommunicatorMock.Stop")
 			}
 
 			m.t.Fatalf("Some mocks were not called on time: %s", timeout)
@@ -959,7 +1125,11 @@ func (m *CommunicatorMock) AllMocksCalled() bool {
 		return false
 	}
 
-	if !m.StartFinished() {
+	if !m.InitFinished() {
+		return false
+	}
+
+	if !m.StopFinished() {
 		return false
 	}
 

--- a/consensus/phases/firstphase.go
+++ b/consensus/phases/firstphase.go
@@ -86,7 +86,7 @@ func (fp *FirstPhaseImpl) Execute(ctx context.Context, pulse *core.Pulse) (*Firs
 		return nil, errors.Wrap(err, "[ FirstPhase ] Failed to calculate pulse proof.")
 	}
 
-	packet := packets.NewPhase1Packet()
+	packet := packets.NewPhase1Packet(*pulse)
 	err = packet.SetPulseProof(pulseProof.StateHash, pulseProof.Signature.Bytes())
 	if err != nil {
 		return nil, errors.Wrap(err, "[ FirstPhase ] Failed to set pulse proof in Phase1Packet.")

--- a/network/controller/bootstrap/authorization.go
+++ b/network/controller/bootstrap/authorization.go
@@ -35,7 +35,7 @@ import (
 )
 
 type AuthorizationController interface {
-	component.Starter
+	component.Initer
 
 	Authorize(ctx context.Context, discoveryNode *DiscoveryNode, cert core.AuthorizationCertificate) (SessionID, error)
 	Register(ctx context.Context, discoveryNode *DiscoveryNode, sessionID SessionID) error
@@ -184,7 +184,7 @@ func (ac *authorizationController) processAuthorizeRequest(ctx context.Context, 
 	return ac.transport.BuildResponse(ctx, request, &AuthorizationResponse{Code: OpConfirmed, SessionID: session}), nil
 }
 
-func (ac *authorizationController) Start(ctx context.Context) error {
+func (ac *authorizationController) Init(ctx context.Context) error {
 	ac.transport.RegisterPacketHandler(types.Register, ac.processRegisterRequest)
 	ac.transport.RegisterPacketHandler(types.Authorize, ac.processAuthorizeRequest)
 	return nil

--- a/network/controller/bootstrap/bootstrap.go
+++ b/network/controller/bootstrap/bootstrap.go
@@ -50,7 +50,7 @@ type DiscoveryNode struct {
 }
 
 type Bootstrapper interface {
-	component.Starter
+	component.Initer
 
 	Bootstrap(ctx context.Context) (*network.BootstrapResult, *DiscoveryNode, error)
 	BootstrapDiscovery(ctx context.Context) (*network.BootstrapResult, error)
@@ -496,7 +496,7 @@ func (bc *bootstrapper) processGenesis(ctx context.Context, request network.Requ
 	}), nil
 }
 
-func (bc *bootstrapper) Start(ctx context.Context) error {
+func (bc *bootstrapper) Init(ctx context.Context) error {
 	bc.firstPulseTime = time.Now()
 	bc.transport.RegisterPacketHandler(types.Bootstrap, bc.processBootstrap)
 	bc.transport.RegisterPacketHandler(types.Genesis, bc.processGenesis)

--- a/network/controller/bootstrap/challenge_response.go
+++ b/network/controller/bootstrap/challenge_response.go
@@ -34,7 +34,7 @@ import (
 )
 
 type ChallengeResponseController interface {
-	component.Starter
+	component.Initer
 
 	Execute(ctx context.Context, discoveryNode *DiscoveryNode, sessionID SessionID) (*ChallengePayload, error)
 }
@@ -187,7 +187,7 @@ func (cr *challengeResponseController) buildChallenge2ErrorResponse(ctx context.
 	})
 }
 
-func (cr *challengeResponseController) Start(ctx context.Context) error {
+func (cr *challengeResponseController) Init(ctx context.Context) error {
 	cr.transport.RegisterPacketHandler(types.Challenge1, cr.processChallenge1)
 	cr.transport.RegisterPacketHandler(types.Challenge2, cr.processChallenge2)
 	return nil

--- a/network/controller/controller.go
+++ b/network/controller/controller.go
@@ -66,7 +66,7 @@ func (c *Controller) Bootstrap(ctx context.Context) (*network.BootstrapResult, e
 }
 
 // Inject inject components.
-func (c *Controller) Start(ctx context.Context) error {
+func (c *Controller) Init(ctx context.Context) error {
 	c.network.RegisterRequestHandler(types.Ping, func(ctx context.Context, request network.Request) (network.Response, error) {
 		return c.network.BuildResponse(ctx, request, nil), nil
 	})

--- a/network/controller/pulsecontroller.go
+++ b/network/controller/pulsecontroller.go
@@ -27,7 +27,7 @@ import (
 )
 
 type PulseController interface {
-	component.Starter
+	component.Initer
 }
 
 type pulseController struct {
@@ -37,7 +37,7 @@ type pulseController struct {
 	routingTable network.RoutingTable
 }
 
-func (pc *pulseController) Start(ctx context.Context) error {
+func (pc *pulseController) Init(ctx context.Context) error {
 	pc.hostNetwork.RegisterRequestHandler(types.Pulse, pc.processPulse)
 	pc.hostNetwork.RegisterRequestHandler(types.GetRandomHosts, pc.processGetRandomHosts)
 	return nil

--- a/network/controller/rpc_controller.go
+++ b/network/controller/rpc_controller.go
@@ -38,7 +38,7 @@ import (
 )
 
 type RPCController interface {
-	component.Starter
+	component.Initer
 
 	// hack for DI, else we receive ServiceNetwork injection in RPCController instead of rpcController that leads to stack overflow
 	IAmRPCController()
@@ -250,7 +250,7 @@ func (rpc *rpcController) processCascade(ctx context.Context, request network.Re
 	return rpc.hostNetwork.BuildResponse(ctx, request, &ResponseCascade{Success: true}), nil
 }
 
-func (rpc *rpcController) Start(ctx context.Context) error {
+func (rpc *rpcController) Init(ctx context.Context) error {
 	rpc.hostNetwork.RegisterRequestHandler(types.RPC, rpc.processMessage)
 	rpc.hostNetwork.RegisterRequestHandler(types.Cascade, rpc.processCascade)
 	return nil

--- a/network/hostnetwork/transport_consensus_test.go
+++ b/network/hostnetwork/transport_consensus_test.go
@@ -107,7 +107,7 @@ func (t *consensusTransportSuite) sendPacket(packet consensus.ConsensusPacket) (
 }
 
 func newPhase1Packet() *consensus.Phase1Packet {
-	return consensus.NewPhase1Packet()
+	return consensus.NewPhase1Packet(core.Pulse{})
 }
 
 func newPhase2Packet() (*consensus.Phase2Packet, error) {
@@ -115,7 +115,7 @@ func newPhase2Packet() (*consensus.Phase2Packet, error) {
 	if err != nil {
 		return nil, err
 	}
-	result := consensus.NewPhase2Packet()
+	result := consensus.NewPhase2Packet(core.PulseNumber(0))
 	result.SetBitSet(bitset)
 	return result, nil
 }
@@ -126,7 +126,7 @@ func newPhase3Packet() (*consensus.Phase3Packet, error) {
 	if err != nil {
 		return nil, err
 	}
-	return consensus.NewPhase3Packet(ghs, bitset), nil
+	return consensus.NewPhase3Packet(core.PulseNumber(0), ghs, bitset), nil
 }
 
 func (t *consensusTransportSuite) TestSendPacketPhase1() {

--- a/network/interfaces.go
+++ b/network/interfaces.go
@@ -36,7 +36,7 @@ type BootstrapResult struct {
 
 // Controller contains network logic.
 type Controller interface {
-	component.Starter
+	component.Initer
 	// SendParcel send message to nodeID.
 	SendMessage(nodeID core.RecordRef, name string, msg core.Parcel) ([]byte, error)
 	// RemoteProcedureRegister register remote procedure that will be executed when message is received.

--- a/network/servicenetwork/communicator_mock.go
+++ b/network/servicenetwork/communicator_mock.go
@@ -82,6 +82,6 @@ func (cm *CommunicatorMock) ExchangePhase3(ctx context.Context, participants []c
 	return cm.communicator.ExchangePhase3(ctx, participants, packet)
 }
 
-func (cm *CommunicatorMock) Start(ctx context.Context) error {
-	return cm.communicator.Start(ctx)
+func (cm *CommunicatorMock) Init(ctx context.Context) error {
+	return cm.communicator.Init(ctx)
 }

--- a/network/servicenetwork/servicenetwork.go
+++ b/network/servicenetwork/servicenetwork.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/insolar/insolar/component"
 	"github.com/insolar/insolar/configuration"
@@ -66,6 +67,8 @@ type ServiceNetwork struct {
 	isGenesis   bool
 	isDiscovery bool
 	skip        int
+
+	lock sync.Mutex
 }
 
 // NewServiceNetwork returns a new ServiceNetwork.
@@ -213,6 +216,9 @@ func (n *ServiceNetwork) Stop(ctx context.Context) error {
 }
 
 func (n *ServiceNetwork) HandlePulse(ctx context.Context, newPulse core.Pulse) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
 	if n.isGenesis {
 		return
 	}
@@ -242,7 +248,7 @@ func (n *ServiceNetwork) HandlePulse(ctx context.Context, newPulse core.Pulse) {
 	// }
 
 	if !isNextPulse(currentPulse, &newPulse) {
-		logger.Infof("Incorrect newPulse number. Current: %+v. New: %+v", currentPulse, newPulse)
+		logger.Infof("Incorrect pulse number. Current: %+v. New: %+v", currentPulse, newPulse)
 		return
 	}
 

--- a/network/servicenetwork/suite_test.go
+++ b/network/servicenetwork/suite_test.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/insolar/insolar/certificate"
@@ -109,7 +110,6 @@ func (s *testSuite) SetupTest() {
 	for _, node := range s.fixture().bootstrapNodes {
 		pulseReceivers = append(pulseReceivers, node.host)
 	}
-	// pulseReceivers = append(pulseReceivers, s.fixture().testNode.host)
 
 	log.Info("Start test pulsar")
 	err = s.fixture().pulsar.Start(s.fixture().ctx, pulseReceivers)
@@ -354,6 +354,31 @@ func (t *terminationHandler) Abort() {
 	log.Errorf("Abort node: %s", t.NodeID)
 }
 
+type pulseManagerMock struct {
+	pulse core.Pulse
+	lock  sync.Mutex
+
+	keeper network.NodeKeeper
+}
+
+func newPulseManagerMock(keeper network.NodeKeeper) *pulseManagerMock {
+	return &pulseManagerMock{pulse: *core.GenesisPulse, keeper: keeper}
+}
+
+func (p *pulseManagerMock) Current(ctx context.Context) (*core.Pulse, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	return &p.pulse, nil
+}
+
+func (p *pulseManagerMock) Set(ctx context.Context, pulse core.Pulse, persist bool) error {
+	p.lock.Lock()
+	p.pulse = pulse
+	p.lock.Unlock()
+
+	return p.keeper.MoveSyncToActive()
+}
+
 // preInitNode inits previously created node with mocks and external dependencies
 func (s *testSuite) preInitNode(node *networkNode) {
 	cfg := configuration.NewConfiguration()
@@ -365,14 +390,6 @@ func (s *testSuite) preInitNode(node *networkNode) {
 	node.componentManager.Register(platformpolicy.NewPlatformCryptographyScheme())
 	serviceNetwork, err := NewServiceNetwork(cfg, node.componentManager, false)
 	s.NoError(err)
-
-	pulseStorageMock := testutils.NewPulseStorageMock(s.T())
-	pulseStorageMock.CurrentMock.Set(func(p context.Context) (r *core.Pulse, r1 error) {
-		return &core.Pulse{PulseNumber: 0}, nil
-
-	})
-
-	pulseManagerMock := testutils.NewPulseManagerMock(s.T())
 
 	netCoordinator := testutils.NewNetworkCoordinatorMock(s.T())
 	netCoordinator.ValidateCertMock.Set(func(p context.Context, p1 core.AuthorizationCertificate) (bool, error) {
@@ -402,12 +419,8 @@ func (s *testSuite) preInitNode(node *networkNode) {
 		realKeeper.AddActiveNodes([]core.Node{origin})
 	}
 
-	node.componentManager.Register(terminationHandler, realKeeper, pulseManagerMock, pulseStorageMock, netCoordinator, amMock)
+	node.componentManager.Register(terminationHandler, realKeeper, newPulseManagerMock(realKeeper), netCoordinator, amMock)
 	node.componentManager.Register(certManager, cryptographyService)
 	node.componentManager.Inject(serviceNetwork, NewTestNetworkSwitcher())
 	node.serviceNetwork = serviceNetwork
-
-	pulseManagerMock.SetMock.Set(func(p context.Context, p1 core.Pulse, p2 bool) (r error) {
-		return serviceNetwork.NodeKeeper.MoveSyncToActive()
-	})
 }

--- a/network/servicenetwork/suite_test.go
+++ b/network/servicenetwork/suite_test.go
@@ -109,7 +109,7 @@ func (s *testSuite) SetupTest() {
 	for _, node := range s.fixture().bootstrapNodes {
 		pulseReceivers = append(pulseReceivers, node.host)
 	}
-	pulseReceivers = append(pulseReceivers, s.fixture().testNode.host)
+	// pulseReceivers = append(pulseReceivers, s.fixture().testNode.host)
 
 	log.Info("Start test pulsar")
 	err = s.fixture().pulsar.Start(s.fixture().ctx, pulseReceivers)


### PR DESCRIPTION
**- What I did**
Nodes now resend pulse on first consensus phase. If the pulse is received via first phase, the consensus starts if not started yet. Also fixed races on start of the network components.
**- How to verify it**
Run unit and integration tests.
