### PR TITLE
Add to all non file targets a .PHONY directive, improve coverage calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,10 @@ vm/wasm/test/data/*.wat
 data
 data_pulsar
 
+# generated/compiled files
 /bin
+/.artefacts
+coverage.txt
 
 # GoReleaser dist dir
 /dist

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_DIR ?= bin
-ARTIFACTS_DIR ?= .artifacts
+ARTIFACTS_DIR ?= .artefacts
 INSOLAR = insolar
 INSOLARD = insolard
 INSGOCC = $(BIN_DIR)/insgocc

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BIN_DIR ?= bin
+ARTIFACTS_DIR ?= .artifacts
 INSOLAR = insolar
 INSOLARD = insolard
 INSGOCC = $(BIN_DIR)/insgocc
@@ -13,8 +14,8 @@ CERTGEN = $(BIN_DIR)/certgen
 
 ALL_PACKAGES = ./...
 MOCKS_PACKAGE = github.com/insolar/insolar/testutils
-TESTED_PACKAGES = $(shell go list ${ALL_PACKAGES} | grep -v "${MOCKS_PACKAGE}")
-COVERPROFILE = coverage.txt
+TESTED_PACKAGES ?= $(shell go list ${ALL_PACKAGES} | grep -v "${MOCKS_PACKAGE}")
+COVERPROFILE ?= coverage.txt
 TEST_ARGS ?=
 
 BUILD_NUMBER := $(TRAVIS_BUILD_NUMBER)
@@ -134,9 +135,13 @@ test:
 test_fast:
 	go test $(TEST_ARGS) -count 1 -v $(ALL_PACKAGES)
 
+$(ARTIFACTS_DIR):
+	mkdir -p $(ARTIFACTS_DIR)
+
 .PHONY: test_with_coverage
-test_with_coverage:
-	CGO_ENABLED=1 go test $(TEST_ARGS) --coverprofile=$(COVERPROFILE) --covermode=atomic $(TESTED_PACKAGES)
+test_with_coverage: $(ARTIFACTS_DIR)
+	CGO_ENABLED=1 go test $(TEST_ARGS) --coverprofile=$(ARTIFACTS_DIR)/cover.all --covermode=atomic $(TESTED_PACKAGES)
+	@cat $(ARTIFACTS_DIR)/cover.all | ./scripts/dev/cover-filter.sh > $(COVERPROFILE)
 
 .PHONY: test_with_coverage_fast
 test_with_coverage_fast:

--- a/scripts/dev/cover-filter.sh
+++ b/scripts/dev/cover-filter.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# filters coverage stats for code that could be tested, but should not affect coverage metric
+#
+# * generated code (mock and stringer)
+# * command line tools code
+# * test utils
+grep -v "_mock.go:" | \
+    grep -v "_string.go:" | \
+    grep -v 'github.com/insolar/insolar/cmd/' | \
+    grep -v "github.com/insolar/insolar/testutils" | \
+    grep -v "storage/storagetest"

--- a/scripts/dev/cover-tool.sh
+++ b/scripts/dev/cover-tool.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Tool for simple code coverage inspection.
+#
+# Usage examples:
+#
+# ./scripts/dev/cover-tool.sh
+#
+# ./scripts/dev/cover-tool.sh ledger
+#
+# ./scripts/dev/cover-tool.sh instrumentation -v
+#
+# depends on gocov:
+#
+#   go get github.com/axw/gocov/gocov
+#
+# optional tool (adds browser report in verbose mode):
+#
+#   go get gopkg.in/matm/v1/gocov-html
+#
+
+# set 'bash strict mode'
+set -euo pipefail
+IFS=$'\n\t'
+# set -x
+
+# parse arguments
+COVER_TARGET=${1:-""}
+shift || true
+# echo "ok"
+
+ARG=${1:-""}
+VERBOSE=""
+if [[ ! -z "$ARG" ]]; then
+    case $ARG in
+        -v|--verbose)
+            VERBOSE="1"
+        ;;
+        *)
+            echo "Unknown option $ARG"
+            exit 1
+    esac
+fi
+
+# set vars
+OUTPUT_DIR=${OUTPUT_DIR:-""}
+if [[ -z "$OUTPUT_DIR" ]]; then
+    OUTPUT_DIR=$(mktemp -d)
+fi
+
+TESTED_PACKAGES=./$COVER_TARGET/...
+if [[ -z "$COVER_TARGET" ]]; then
+    TESTED_PACKAGES=./...
+    COVER_TARGET="all"
+fi
+
+# collect coverage
+export COVERPROFILE=$OUTPUT_DIR/$COVER_TARGET.out
+export TESTED_PACKAGES
+make test_with_coverage
+
+# produce report
+GOCOV_FILE=$OUTPUT_DIR/$COVER_TARGET.gocov
+gocov convert $COVERPROFILE > $GOCOV_FILE
+if [[ -z "$VERBOSE" ]]; then
+    gocov report $GOCOV_FILE | grep -E -v '\S+.go\s+' | grep '.' | awk '/^(.*)([[:space:]]+-+[[:space:]]+)(.*)$/{print $1 "\t" $3}'
+    gocov report $GOCOV_FILE | grep 'Total'
+else
+    gocov report $GOCOV_FILE
+
+    if which gocov-html; then
+        gocov convert $COVERPROFILE > $GOCOV_FILE.json
+        gocov-html $GOCOV_FILE.json > $GOCOV_FILE.html
+        open $GOCOV_FILE.html
+    fi
+    go tool cover -html=$COVERPROFILE
+fi

--- a/scripts/dev/cover-tool.sh
+++ b/scripts/dev/cover-tool.sh
@@ -54,10 +54,13 @@ if [[ -z "$COVER_TARGET" ]]; then
     COVER_TARGET="all"
 fi
 
-# collect coverage
-export COVERPROFILE=$OUTPUT_DIR/$COVER_TARGET.out
-export TESTED_PACKAGES
-make test_with_coverage
+COVERPROFILE=${COVERPROFILE:-""}
+if [[ -z $"COVERPROFILE" ]]; then
+    # collect coverage
+    export COVERPROFILE=$OUTPUT_DIR/$COVER_TARGET.out
+    export TESTED_PACKAGES
+    make test_with_coverage
+fi
 
 # produce report
 GOCOV_FILE=$OUTPUT_DIR/$COVER_TARGET.gocov


### PR DESCRIPTION
move .PHONY close to target itself, it is too easily forget to add a target to .PHONY if use lists
(without .PHONY it could be painful to figure out why your go binary doesn't compile)
