### PR TITLE
INS-1493: refactor LR a bit

### DIFF
--- a/logicrunner/accessors.go
+++ b/logicrunner/accessors.go
@@ -60,7 +60,7 @@ func (lr *LogicRunner) UpsertObjectState(ref Ref) *ObjectState {
 	lr.stateMutex.Lock()
 	defer lr.stateMutex.Unlock()
 	if _, ok := lr.state[ref]; !ok {
-		lr.state[ref] = &ObjectState{Ref: &ref}
+		lr.state[ref] = &ObjectState{}
 	}
 	return lr.state[ref]
 }
@@ -112,13 +112,13 @@ func (st *ObjectState) RefreshConsensus() {
 	st.Consensus = nil
 }
 
-func (st *ObjectState) StartValidation() *ExecutionState {
+func (st *ObjectState) StartValidation(ref Ref) *ExecutionState {
 	st.Lock()
 	defer st.Unlock()
 
 	if st.Validation != nil {
 		panic("Unexpected. Validation already in progress")
 	}
-	st.Validation = &ExecutionState{}
+	st.Validation = &ExecutionState{Ref: ref}
 	return st.Validation
 }

--- a/logicrunner/casebind.go
+++ b/logicrunner/casebind.go
@@ -145,8 +145,7 @@ func (r *CaseBindReplay) NextRequest() *CaseRequest {
 
 func (lr *LogicRunner) Validate(ctx context.Context, ref Ref, p core.Pulse, cb CaseBind) (int, error) {
 	os := lr.UpsertObjectState(ref)
-	vs := os.StartValidation()
-	vs.ArtifactManager = lr.ArtifactManager
+	vs := os.StartValidation(ref)
 
 	vs.Lock()
 	defer vs.Unlock()

--- a/logicrunner/executionstate.go
+++ b/logicrunner/executionstate.go
@@ -1,0 +1,69 @@
+package logicrunner
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+
+	"github.com/insolar/insolar/core/message"
+)
+
+type ExecutionState struct {
+	sync.Mutex
+
+	Ref Ref
+
+	objectbody *ObjectBody
+	deactivate bool
+	nonce      uint64
+
+	Behaviour ValidationBehaviour
+
+	Current               *CurrentExecution
+	Queue                 []ExecutionQueueElement
+	QueueProcessorActive  bool
+	LedgerHasMoreRequests bool
+	LedgerQueueElement    *ExecutionQueueElement
+	getLedgerPendingMutex sync.Mutex
+
+	// TODO not using in validation, need separate ObjectState.ExecutionState and ObjectState.Validation from ExecutionState struct
+	pending          message.PendingState
+	PendingConfirmed bool
+}
+
+func (es *ExecutionState) WrapError(err error, message string) error {
+	if err == nil {
+		err = errors.New(message)
+	} else {
+		err = errors.Wrap(err, message)
+	}
+	res := Error{Err: err}
+	if es.objectbody != nil {
+		res.Contract = es.objectbody.objDescriptor.HeadRef()
+	}
+	if es.Current != nil {
+		res.Request = es.Current.Request
+	}
+	return res
+}
+
+// releaseQueue must be calling only with es.Lock
+func (es *ExecutionState) releaseQueue() ([]ExecutionQueueElement, bool) {
+	ledgerHasMoreRequest := false
+	q := es.Queue
+
+	if len(q) > maxQueueLength {
+		q = q[:maxQueueLength]
+		ledgerHasMoreRequest = true
+	}
+
+	es.Queue = make([]ExecutionQueueElement, 0)
+
+	return q, ledgerHasMoreRequest
+}
+
+func (es *ExecutionState) haveSomeToProcess() bool {
+	return len(es.Queue) > 0 || es.LedgerHasMoreRequests || es.LedgerQueueElement != nil
+}
+
+

--- a/logicrunner/executionstate.go
+++ b/logicrunner/executionstate.go
@@ -27,8 +27,9 @@ type ExecutionState struct {
 	getLedgerPendingMutex sync.Mutex
 
 	// TODO not using in validation, need separate ObjectState.ExecutionState and ObjectState.Validation from ExecutionState struct
-	pending          message.PendingState
-	PendingConfirmed bool
+	pending              message.PendingState
+	PendingConfirmed     bool
+	HasPendingCheckMutex sync.Mutex
 }
 
 func (es *ExecutionState) WrapError(err error, message string) error {
@@ -65,5 +66,3 @@ func (es *ExecutionState) releaseQueue() ([]ExecutionQueueElement, bool) {
 func (es *ExecutionState) haveSomeToProcess() bool {
 	return len(es.Queue) > 0 || es.LedgerHasMoreRequests || es.LedgerQueueElement != nil
 }
-
-


### PR DESCRIPTION
* delete Ref from ObjectState, it was not used
* add Ref to ExecutionState, it was needed in a few places
* take Ref from E.S. in a few methods instead of passing as argument
* logicrunner/executionstate.go file with one type
* ClarifyPendingState that checks Parcel and converts Unknown pending
  state into known
* no more need for message in StartQueueProcessorIfNeeded, message was
  needed in one place only
