### PR TITLE
NOISSUE: add init genesis for in-memory pulse tracker

### DIFF
--- a/ledger/storage/pulsetrackermemory.go
+++ b/ledger/storage/pulsetrackermemory.go
@@ -137,19 +137,25 @@ func (p *pulseTrackerMemory) DeletePulse(ctx context.Context, num core.PulseNumb
 	return nil
 }
 
-func (p *pulseTrackerMemory) getPulse(ctx context.Context, num core.PulseNumber) (*Pulse, error) {
-	// TODO: @imarkin 14.02.18 - it's a hack for fill genesis pulse in memory realization
-	if num == core.FirstPulseNumber {
-		pulse := &Pulse{
-			Pulse: core.Pulse{
-				PulseNumber: core.FirstPulseNumber,
-				Entropy:     core.GenesisPulse.Entropy,
-			},
-			SerialNumber: 1,
-		}
-		return pulse, nil
-	}
+// TODO: @imarkin 14.02.18 - it's a hack for fill genesis pulse in memory realization
+func (p *pulseTrackerMemory) Init(ctx context.Context) error {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
 
+	pulse := &Pulse{
+		Pulse: core.Pulse{
+			PulseNumber: core.FirstPulseNumber,
+			Entropy:     core.GenesisPulse.Entropy,
+		},
+		SerialNumber: 1,
+	}
+	p.memory[core.FirstPulseNumber] = *pulse
+	p.latestPulse = core.FirstPulseNumber
+
+	return nil
+}
+
+func (p *pulseTrackerMemory) getPulse(ctx context.Context, num core.PulseNumber) (*Pulse, error) {
 	pulse, ok := p.memory[num]
 
 	if !ok {

--- a/ledger/storage/pulsetrackermemory.go
+++ b/ledger/storage/pulsetrackermemory.go
@@ -139,20 +139,12 @@ func (p *pulseTrackerMemory) DeletePulse(ctx context.Context, num core.PulseNumb
 
 // TODO: @imarkin 14.02.18 - it's a hack for fill genesis pulse in memory realization
 func (p *pulseTrackerMemory) Init(ctx context.Context) error {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	pulse := &Pulse{
-		Pulse: core.Pulse{
-			PulseNumber: core.FirstPulseNumber,
-			Entropy:     core.GenesisPulse.Entropy,
-		},
-		SerialNumber: 1,
+	pulse := core.Pulse{
+		PulseNumber: core.FirstPulseNumber,
+		Entropy:     core.GenesisPulse.Entropy,
 	}
-	p.memory[core.FirstPulseNumber] = *pulse
-	p.latestPulse = core.FirstPulseNumber
 
-	return nil
+	return p.AddPulse(ctx, pulse)
 }
 
 func (p *pulseTrackerMemory) getPulse(ctx context.Context, num core.PulseNumber) (*Pulse, error) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
add init genesis for in-memory pulse tracker
**- How I did it**
Move genesis pulse to Init method 

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->