### PR TITLE
INS-1416: clean in-memory pulseTracker pulses

### DIFF
--- a/ledger/pulsemanager/pulsemanager.go
+++ b/ledger/pulsemanager/pulsemanager.go
@@ -664,6 +664,10 @@ func (m *PulseManager) cleanLightData(ctx context.Context, newPulse core.Pulse, 
 		return
 	}
 	m.JetStorage.DeleteJetTree(ctx, p.Pulse.PulseNumber)
+	err = m.PulseTracker.DeletePulse(ctx, p.Pulse.PulseNumber)
+	if err != nil {
+		inslogger.FromContext(ctx).Errorf("Can't clean pulse-tracker from pulse: %s", err)
+	}
 }
 
 func (m *PulseManager) prepareArtifactManagerMessageHandlerForNextPulse(ctx context.Context, newPulse core.Pulse, jets []jetInfo) {

--- a/ledger/storage/metrics.go
+++ b/ledger/storage/metrics.go
@@ -32,6 +32,9 @@ var (
 	statCleanScanned = stats.Int64("lightcleanup/scanned", "How many records have been scanned on LM cleanup", stats.UnitDimensionless)
 	statCleanRemoved = stats.Int64("lightcleanup/removed", "How many records have been removed on LM cleanup", stats.UnitDimensionless)
 	statCleanFailed  = stats.Int64("lightcleanup/rmfailed", "How many records have not been removed because of error", stats.UnitDimensionless)
+
+	statPulseDeleted = stats.Int64("lightcleanup/pulses/removed/total", "How many pulses deleted from pulseTracker on LM cleanup", stats.UnitDimensionless)
+	statPulseAdded   = stats.Int64("lightcleanup/pulses/added/total", "How many pulses added to pulseTracker", stats.UnitDimensionless)
 )
 
 func init() {
@@ -56,6 +59,18 @@ func init() {
 			Measure:     statCleanFailed,
 			Aggregation: view.Sum(),
 			TagKeys:     []tag.Key{recordType},
+		},
+		&view.View{
+			Name:        statPulseDeleted.Name(),
+			Description: statPulseDeleted.Description(),
+			Measure:     statPulseDeleted,
+			Aggregation: view.Count(),
+		},
+		&view.View{
+			Name:        statPulseAdded.Name(),
+			Description: statPulseAdded.Description(),
+			Measure:     statPulseAdded,
+			Aggregation: view.Count(),
 		},
 	)
 	if err != nil {

--- a/ledger/storage/pulsetrackermemory.go
+++ b/ledger/storage/pulsetrackermemory.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/insolar/insolar/core"
 	"github.com/insolar/insolar/instrumentation/inslogger"
+	"go.opencensus.io/stats"
 )
 
 type pulseTrackerMemory struct {
@@ -113,6 +114,10 @@ func (p *pulseTrackerMemory) AddPulse(ctx context.Context, pulse core.Pulse) err
 	p.memory[pn] = newPulse
 	p.latestPulse = pn
 
+	stats.Record(ctx,
+		statPulseAdded.M(1),
+	)
+
 	return nil
 }
 
@@ -133,6 +138,10 @@ func (p *pulseTrackerMemory) DeletePulse(ctx context.Context, num core.PulseNumb
 	}
 
 	delete(p.memory, num)
+
+	stats.Record(ctx,
+		statPulseDeleted.M(1),
+	)
 
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add DeletePulse in cleanLightData
add 2 metrics
**- How I did it**
metrics
```
statPulseDeleted = "lightcleanup/pulses/removed/total" - "How many pulses deleted from pulseTracker on LM cleanup"
statPulseAdded   = "lightcleanup/pulses/added/total" - "How many pulses added to pulseTracker"
```

