### PR TITLE
INS-1533: change pulseTracker storage for nodes

### DIFF
--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -98,9 +98,10 @@ func GetLedgerComponents(conf configuration.Ledger, certificate core.Certificate
 
 	var pulseTracker storage.PulseTracker
 	// TODO: @imarkin 18.02.18 - Comparision with core.StaticRoleUnknown is a hack for genesis pulse (INS-1537)
-	if certificate.GetRole() == core.StaticRoleHeavyMaterial || certificate.GetRole() == core.StaticRoleUnknown {
+	switch certificate.GetRole() {
+	case core.StaticRoleUnknown, core.StaticRoleHeavyMaterial:
 		pulseTracker = storage.NewPulseTracker()
-	} else {
+	default:
 		pulseTracker = storage.NewPulseTrackerMemory()
 	}
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -97,10 +97,11 @@ func GetLedgerComponents(conf configuration.Ledger, certificate core.Certificate
 	}
 
 	var pulseTracker storage.PulseTracker
-	if certificate.GetRole() == core.StaticRoleLightMaterial {
-		pulseTracker = storage.NewPulseTrackerMemory()
-	} else {
+	// TODO: @imarkin 18.02.18 - Comparision with core.StaticRoleUnknown is a hack for genesis pulse (INS-1537)
+	if certificate.GetRole() == core.StaticRoleHeavyMaterial || certificate.GetRole() == core.StaticRoleUnknown {
 		pulseTracker = storage.NewPulseTracker()
+	} else {
+		pulseTracker = storage.NewPulseTrackerMemory()
 	}
 
 	return []interface{}{


### PR DESCRIPTION
**- What I did**
Change pulseTracker storage for nodes:
```
HEAVY-MATERIAL - DB
LIGHT-MATERIAL - in-memory
VIRTUAL        - in-memory
```
**- How I did it**
```
if certificate.GetRole() == core.StaticRoleHeavyMaterial || certificate.GetRole() == core.StaticRoleUnknown {
	pulseTracker = storage.NewPulseTracker()
} else {
	pulseTracker = storage.NewPulseTrackerMemory()
}
```