### PR TITLE
INS-1238: refactoring AM with new method - Pulse(...)

### DIFF
--- a/core/ledger.go
+++ b/core/ledger.go
@@ -224,6 +224,9 @@ type ArtifactManager interface {
 
 	// State returns hash state for artifact manager.
 	State() ([]byte, error)
+
+	// Pulse returns current PulseNumber for artifact manager
+	Pulse(ctx context.Context) (PulseNumber, error)
 }
 
 // CodeDescriptor represents meta info required to fetch all code data.

--- a/core/ledger.go
+++ b/core/ledger.go
@@ -224,9 +224,6 @@ type ArtifactManager interface {
 
 	// State returns hash state for artifact manager.
 	State() ([]byte, error)
-
-	// Pulse returns current PulseNumber for artifact manager
-	Pulse(ctx context.Context) (PulseNumber, error)
 }
 
 // CodeDescriptor represents meta info required to fetch all code data.

--- a/ledger/artifactmanager/artifactmanager.go
+++ b/ledger/artifactmanager/artifactmanager.go
@@ -58,17 +58,6 @@ func (m *LedgerArtifactManager) State() ([]byte, error) {
 	return m.PlatformCryptographyScheme.IntegrityHasher().Hash([]byte{1, 2, 3}), nil
 }
 
-// Pulse returns current PulseNumber for artifact manager
-func (m *LedgerArtifactManager) Pulse(ctx context.Context) (pn core.PulseNumber, err error) {
-	pulse, err := m.PulseStorage.Current(ctx)
-	if err != nil {
-		return
-	}
-
-	pn = pulse.PulseNumber
-	return
-}
-
 // NewArtifactManger creates new manager instance.
 func NewArtifactManger() *LedgerArtifactManager {
 	return &LedgerArtifactManager{
@@ -100,7 +89,7 @@ func (m *LedgerArtifactManager) RegisterRequest(
 		instrumenter.end()
 	}()
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +130,7 @@ func (m *LedgerArtifactManager) GetCode(
 		instrumenter.end()
 	}()
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +198,7 @@ func (m *LedgerArtifactManager) GetObject(
 		Approved: approved,
 	}
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +251,7 @@ func (m *LedgerArtifactManager) GetPendingRequest(ctx context.Context, objectID 
 		instrumenter.end()
 	}()
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 
 	bus := core.MessageBusFromContext(ctx, m.DefaultBus)
 	sender := BuildSender(
@@ -331,7 +320,7 @@ func (m *LedgerArtifactManager) HasPendingRequests(
 	object core.RecordRef,
 ) (bool, error) {
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -376,7 +365,7 @@ func (m *LedgerArtifactManager) GetDelegate(
 		instrumenter.end()
 	}()
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +408,7 @@ func (m *LedgerArtifactManager) GetChildren(
 		instrumenter.end()
 	}()
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +436,7 @@ func (m *LedgerArtifactManager) DeclareType(
 		instrumenter.end()
 	}()
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -488,7 +477,7 @@ func (m *LedgerArtifactManager) DeployCode(
 		instrumenter.end()
 	}()
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +575,7 @@ func (m *LedgerArtifactManager) DeactivateObject(
 		instrumenter.end()
 	}()
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 
 	desc, err := m.sendUpdateObject(
 		ctx,
@@ -694,7 +683,7 @@ func (m *LedgerArtifactManager) RegisterValidation(
 		ValidationMessages: validationMessages,
 	}
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 	if err != nil {
 		return err
 	}
@@ -721,7 +710,7 @@ func (m *LedgerArtifactManager) RegisterResult(
 		instrumenter.end()
 	}()
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -739,6 +728,17 @@ func (m *LedgerArtifactManager) RegisterResult(
 	return recid, err
 }
 
+// pulse returns current PulseNumber for artifact manager
+func (m *LedgerArtifactManager) pulse(ctx context.Context) (pn core.PulseNumber, err error) {
+	pulse, err := m.PulseStorage.Current(ctx)
+	if err != nil {
+		return
+	}
+
+	pn = pulse.PulseNumber
+	return
+}
+
 func (m *LedgerArtifactManager) activateObject(
 	ctx context.Context,
 	domain core.RecordRef,
@@ -753,7 +753,7 @@ func (m *LedgerArtifactManager) activateObject(
 	if err != nil {
 		return nil, err
 	}
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -842,7 +842,7 @@ func (m *LedgerArtifactManager) updateObject(
 		return nil, errors.Wrap(err, "failed to update object")
 	}
 
-	currentPN, err := m.Pulse(ctx)
+	currentPN, err := m.pulse(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/artifactmanager/artifactmanager.go
+++ b/ledger/artifactmanager/artifactmanager.go
@@ -58,6 +58,17 @@ func (m *LedgerArtifactManager) State() ([]byte, error) {
 	return m.PlatformCryptographyScheme.IntegrityHasher().Hash([]byte{1, 2, 3}), nil
 }
 
+// Pulse returns current PulseNumber for artifact manager
+func (m *LedgerArtifactManager) Pulse(ctx context.Context) (pn core.PulseNumber, err error) {
+	pulse, err := m.PulseStorage.Current(ctx)
+	if err != nil {
+		return
+	}
+
+	pn = pulse.PulseNumber
+	return
+}
+
 // NewArtifactManger creates new manager instance.
 func NewArtifactManger() *LedgerArtifactManager {
 	return &LedgerArtifactManager{
@@ -89,7 +100,7 @@ func (m *LedgerArtifactManager) RegisterRequest(
 		instrumenter.end()
 	}()
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -101,14 +112,14 @@ func (m *LedgerArtifactManager) RegisterRequest(
 	}
 	recID := record.NewRecordIDFromRecord(
 		m.PlatformCryptographyScheme,
-		currentPulse.PulseNumber,
+		currentPN,
 		rec)
 	recRef := core.NewRecordRef(*parcel.DefaultTarget().Domain(), *recID)
 	id, err := m.setRecord(
 		ctx,
 		rec,
 		*recRef,
-		*currentPulse,
+		currentPN,
 	)
 	return id, errors.Wrap(err, "[ RegisterRequest ] ")
 }
@@ -130,7 +141,7 @@ func (m *LedgerArtifactManager) GetCode(
 		instrumenter.end()
 	}()
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +151,7 @@ func (m *LedgerArtifactManager) GetCode(
 		bus.Send,
 		m.senders.cachedSender(m.PlatformCryptographyScheme),
 		followRedirectSender(bus),
-		retryJetSender(currentPulse.PulseNumber, m.JetStorage),
+		retryJetSender(currentPN, m.JetStorage),
 	)
 
 	genericReact, err := sender(ctx, &message.GetCode{Code: code}, nil)
@@ -198,7 +209,7 @@ func (m *LedgerArtifactManager) GetObject(
 		Approved: approved,
 	}
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +218,7 @@ func (m *LedgerArtifactManager) GetObject(
 	sender := BuildSender(
 		bus.Send,
 		followRedirectSender(bus),
-		retryJetSender(currentPulse.PulseNumber, m.JetStorage),
+		retryJetSender(currentPN, m.JetStorage),
 	)
 
 	genericReact, err := sender(ctx, getObjectMsg, nil)
@@ -251,12 +262,12 @@ func (m *LedgerArtifactManager) GetPendingRequest(ctx context.Context, objectID 
 		instrumenter.end()
 	}()
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 
 	bus := core.MessageBusFromContext(ctx, m.DefaultBus)
 	sender := BuildSender(
 		bus.Send,
-		retryJetSender(currentPulse.PulseNumber, m.JetStorage),
+		retryJetSender(currentPN, m.JetStorage),
 	)
 
 	genericReply, err := sender(ctx, &message.GetPendingRequestID{
@@ -276,7 +287,7 @@ func (m *LedgerArtifactManager) GetPendingRequest(ctx context.Context, objectID 
 		return nil, fmt.Errorf("GetPendingRequest: unexpected reply: %#v", requestIDReply)
 	}
 
-	node, err := m.JetCoordinator.NodeForObject(ctx, objectID, currentPulse.PulseNumber, requestIDReply.ID.Pulse())
+	node, err := m.JetCoordinator.NodeForObject(ctx, objectID, currentPN, requestIDReply.ID.Pulse())
 
 	if err != nil {
 		return nil, err
@@ -284,7 +295,7 @@ func (m *LedgerArtifactManager) GetPendingRequest(ctx context.Context, objectID 
 
 	sender = BuildSender(
 		bus.Send,
-		retryJetSender(currentPulse.PulseNumber, m.JetStorage),
+		retryJetSender(currentPN, m.JetStorage),
 	)
 	genericReply, err = sender(
 		ctx,
@@ -320,7 +331,7 @@ func (m *LedgerArtifactManager) HasPendingRequests(
 	object core.RecordRef,
 ) (bool, error) {
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -328,7 +339,7 @@ func (m *LedgerArtifactManager) HasPendingRequests(
 	bus := core.MessageBusFromContext(ctx, m.DefaultBus)
 	sender := BuildSender(
 		bus.Send,
-		retryJetSender(currentPulse.PulseNumber, m.JetStorage),
+		retryJetSender(currentPN, m.JetStorage),
 	)
 
 	genericReact, err := sender(ctx, &message.GetPendingRequests{Object: object}, nil)
@@ -365,13 +376,13 @@ func (m *LedgerArtifactManager) GetDelegate(
 		instrumenter.end()
 	}()
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	bus := core.MessageBusFromContext(ctx, m.DefaultBus)
-	sender := BuildSender(bus.Send, followRedirectSender(bus), retryJetSender(currentPulse.PulseNumber, m.JetStorage))
+	sender := BuildSender(bus.Send, followRedirectSender(bus), retryJetSender(currentPN, m.JetStorage))
 	genericReact, err := sender(ctx, &message.GetDelegate{
 		Head:   head,
 		AsType: asType,
@@ -408,13 +419,13 @@ func (m *LedgerArtifactManager) GetChildren(
 		instrumenter.end()
 	}()
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	bus := core.MessageBusFromContext(ctx, m.DefaultBus)
-	sender := BuildSender(bus.Send, followRedirectSender(bus), retryJetSender(currentPulse.PulseNumber, m.JetStorage))
+	sender := BuildSender(bus.Send, followRedirectSender(bus), retryJetSender(currentPN, m.JetStorage))
 	iter, err := NewChildIterator(ctx, sender, parent, pulse, m.getChildrenChunkSize)
 	return iter, err
 }
@@ -436,7 +447,7 @@ func (m *LedgerArtifactManager) DeclareType(
 		instrumenter.end()
 	}()
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -451,7 +462,7 @@ func (m *LedgerArtifactManager) DeclareType(
 			TypeDeclaration: typeDec,
 		},
 		request,
-		*currentPulse,
+		currentPN,
 	)
 	return recid, err
 }
@@ -477,7 +488,7 @@ func (m *LedgerArtifactManager) DeployCode(
 		instrumenter.end()
 	}()
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -487,13 +498,13 @@ func (m *LedgerArtifactManager) DeployCode(
 			Domain:  domain,
 			Request: request,
 		},
-		Code:        record.CalculateIDForBlob(m.PlatformCryptographyScheme, currentPulse.PulseNumber, code),
+		Code:        record.CalculateIDForBlob(m.PlatformCryptographyScheme, currentPN, code),
 		MachineType: machineType,
 	}
-	codeID := record.NewRecordIDFromRecord(m.PlatformCryptographyScheme, currentPulse.PulseNumber, codeRec)
+	codeID := record.NewRecordIDFromRecord(m.PlatformCryptographyScheme, currentPN, codeRec)
 	codeRef := core.NewRecordRef(*domain.Record(), *codeID)
 
-	_, err = m.setBlob(ctx, code, *codeRef, *currentPulse)
+	_, err = m.setBlob(ctx, code, *codeRef, currentPN)
 	if err != nil {
 		return nil, err
 	}
@@ -501,7 +512,7 @@ func (m *LedgerArtifactManager) DeployCode(
 		ctx,
 		codeRec,
 		*codeRef,
-		*currentPulse,
+		currentPN,
 	)
 	if err != nil {
 		return nil, err
@@ -575,7 +586,7 @@ func (m *LedgerArtifactManager) DeactivateObject(
 		instrumenter.end()
 	}()
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 
 	desc, err := m.sendUpdateObject(
 		ctx,
@@ -588,7 +599,7 @@ func (m *LedgerArtifactManager) DeactivateObject(
 		},
 		*object.HeadRef(),
 		nil,
-		*currentPulse,
+		currentPN,
 	)
 	if err != nil {
 		return nil, err
@@ -683,13 +694,13 @@ func (m *LedgerArtifactManager) RegisterValidation(
 		ValidationMessages: validationMessages,
 	}
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 	if err != nil {
 		return err
 	}
 
 	bus := core.MessageBusFromContext(ctx, m.DefaultBus)
-	sender := BuildSender(bus.Send, retryJetSender(currentPulse.PulseNumber, m.JetStorage))
+	sender := BuildSender(bus.Send, retryJetSender(currentPN, m.JetStorage))
 	_, err = sender(ctx, &msg, nil)
 
 	return err
@@ -710,7 +721,7 @@ func (m *LedgerArtifactManager) RegisterResult(
 		instrumenter.end()
 	}()
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -723,7 +734,7 @@ func (m *LedgerArtifactManager) RegisterResult(
 			Payload: payload,
 		},
 		request,
-		*currentPulse,
+		currentPN,
 	)
 	return recid, err
 }
@@ -742,7 +753,7 @@ func (m *LedgerArtifactManager) activateObject(
 	if err != nil {
 		return nil, err
 	}
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -755,7 +766,7 @@ func (m *LedgerArtifactManager) activateObject(
 				Request: object,
 			},
 			ObjectStateRecord: record.ObjectStateRecord{
-				Memory:      record.CalculateIDForBlob(m.PlatformCryptographyScheme, currentPulse.PulseNumber, memory),
+				Memory:      record.CalculateIDForBlob(m.PlatformCryptographyScheme, currentPN, memory),
 				Image:       prototype,
 				IsPrototype: isPrototype,
 			},
@@ -764,7 +775,7 @@ func (m *LedgerArtifactManager) activateObject(
 		},
 		object,
 		memory,
-		*currentPulse,
+		currentPN,
 	)
 	if err != nil {
 		return nil, err
@@ -789,7 +800,7 @@ func (m *LedgerArtifactManager) activateObject(
 		parent,
 		object,
 		asType,
-		*currentPulse,
+		currentPN,
 	)
 	if err != nil {
 		return nil, err
@@ -831,7 +842,7 @@ func (m *LedgerArtifactManager) updateObject(
 		return nil, errors.Wrap(err, "failed to update object")
 	}
 
-	currentPulse, err := m.PulseStorage.Current(ctx)
+	currentPN, err := m.Pulse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -854,7 +865,7 @@ func (m *LedgerArtifactManager) updateObject(
 		},
 		*object.HeadRef(),
 		memory,
-		*currentPulse,
+		currentPN,
 	)
 	if err != nil {
 		return nil, err
@@ -876,11 +887,11 @@ func (m *LedgerArtifactManager) setRecord(
 	ctx context.Context,
 	rec record.Record,
 	target core.RecordRef,
-	currentPulse core.Pulse,
+	currentPN core.PulseNumber,
 ) (*core.RecordID, error) {
 	bus := core.MessageBusFromContext(ctx, m.DefaultBus)
 
-	sender := BuildSender(bus.Send, retryJetSender(currentPulse.PulseNumber, m.JetStorage))
+	sender := BuildSender(bus.Send, retryJetSender(currentPN, m.JetStorage))
 	genericReply, err := sender(ctx, &message.SetRecord{
 		Record:    record.SerializeRecord(rec),
 		TargetRef: target,
@@ -904,11 +915,11 @@ func (m *LedgerArtifactManager) setBlob(
 	ctx context.Context,
 	blob []byte,
 	target core.RecordRef,
-	currentPulse core.Pulse,
+	currentPN core.PulseNumber,
 ) (*core.RecordID, error) {
 
 	bus := core.MessageBusFromContext(ctx, m.DefaultBus)
-	sender := BuildSender(bus.Send, retryJetSender(currentPulse.PulseNumber, m.JetStorage))
+	sender := BuildSender(bus.Send, retryJetSender(currentPN, m.JetStorage))
 	genericReact, err := sender(ctx, &message.SetBlob{
 		Memory:    blob,
 		TargetRef: target,
@@ -933,7 +944,7 @@ func (m *LedgerArtifactManager) sendUpdateObject(
 	rec record.Record,
 	object core.RecordRef,
 	memory []byte,
-	currentPulse core.Pulse,
+	currentPN core.PulseNumber,
 ) (*reply.Object, error) {
 	// TODO: @andreyromancev. 14.01.19. Uncomment when message streaming or validation is ready.
 	// genericRep, err := sendAndRetryJet(ctx, m.bus(ctx), m.db, &message.SetBlob{
@@ -948,7 +959,7 @@ func (m *LedgerArtifactManager) sendUpdateObject(
 	// }
 
 	bus := core.MessageBusFromContext(ctx, m.DefaultBus)
-	sender := BuildSender(bus.Send, retryJetSender(currentPulse.PulseNumber, m.JetStorage))
+	sender := BuildSender(bus.Send, retryJetSender(currentPN, m.JetStorage))
 	genericReply, err := sender(
 		ctx,
 		&message.UpdateObject{
@@ -977,10 +988,10 @@ func (m *LedgerArtifactManager) registerChild(
 	parent core.RecordRef,
 	child core.RecordRef,
 	asType *core.RecordRef,
-	currentPulse core.Pulse,
+	currentPN core.PulseNumber,
 ) (*core.RecordID, error) {
 	bus := core.MessageBusFromContext(ctx, m.DefaultBus)
-	sender := BuildSender(bus.Send, retryJetSender(currentPulse.PulseNumber, m.JetStorage))
+	sender := BuildSender(bus.Send, retryJetSender(currentPN, m.JetStorage))
 	genericReact, err := sender(ctx, &message.RegisterChild{
 		Record: record.SerializeRecord(rec),
 		Parent: parent,

--- a/ledger/artifactmanager/middleware.go
+++ b/ledger/artifactmanager/middleware.go
@@ -58,9 +58,9 @@ func newMiddleware(
 
 func (m *middleware) addFieldsToLogger(handler core.MessageHandler) core.MessageHandler {
 	return func(ctx context.Context, parcel core.Parcel) (core.Reply, error) {
-		cntext, _ := inslogger.WithField(ctx, "targetid", parcel.DefaultTarget().String())
+		ctx, _ = inslogger.WithField(ctx, "targetid", parcel.DefaultTarget().String())
 
-		return handler(cntext, parcel)
+		return handler(ctx, parcel)
 	}
 }
 

--- a/ledger/artifactmanager/middleware.go
+++ b/ledger/artifactmanager/middleware.go
@@ -58,9 +58,9 @@ func newMiddleware(
 
 func (m *middleware) addFieldsToLogger(handler core.MessageHandler) core.MessageHandler {
 	return func(ctx context.Context, parcel core.Parcel) (core.Reply, error) {
-		context, _ := inslogger.WithField(ctx, "targetid", parcel.DefaultTarget().String())
+		cntext, _ := inslogger.WithField(ctx, "targetid", parcel.DefaultTarget().String())
 
-		return handler(context, parcel)
+		return handler(cntext, parcel)
 	}
 }
 
@@ -159,22 +159,6 @@ func (m *middleware) checkJet(handler core.MessageHandler) core.MessageHandler {
 		ctx = addJetIDToLogger(ctx, jetID)
 
 		return handler(contextWithJet(ctx, jetID), parcel)
-	}
-}
-
-func (m *middleware) saveParcel(handler core.MessageHandler) core.MessageHandler {
-	return func(ctx context.Context, parcel core.Parcel) (core.Reply, error) {
-		jetID := jetFromContext(ctx)
-		pulse, err := m.pulseStorage.Current(ctx)
-		if err != nil {
-			return nil, err
-		}
-		err = m.objectStorage.SetMessage(ctx, jetID, pulse.PulseNumber, parcel)
-		if err != nil {
-			return nil, err
-		}
-
-		return handler(ctx, parcel)
 	}
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
New method named Pulse added for ArtifactManager.
m.PulseManager.Current() replaced with m.Pulse()
**- How I did it**
```
func (m *LedgerArtifactManager) Pulse(ctx context.Context) (pn core.PulseNumber, err error) {
	pulse, err := m.PulseStorage.Current(ctx)
	if err != nil {
		return
	}

	pn = pulse.PulseNumber
	return
}
```
