### PR TITLE
INS-1612: make Save/SaveAs to work as expected

### DIFF
--- a/cmd/insolard/main.go
+++ b/cmd/insolard/main.go
@@ -86,11 +86,6 @@ func main() {
 		log.Warn("failed to load configuration from file: ", err.Error())
 	}
 
-	err = cfgHolder.LoadEnv()
-	if err != nil {
-		log.Warn("failed to load configuration from env:", err.Error())
-	}
-
 	cfg := &cfgHolder.Configuration
 	cfg.Metrics.Namespace = "insolard"
 

--- a/cmd/pulsard/main.go
+++ b/cmd/pulsard/main.go
@@ -81,11 +81,6 @@ func main() {
 		log.Warn("failed to load configuration from file: ", err.Error())
 	}
 
-	err = cfgHolder.LoadEnv()
-	if err != nil {
-		log.Warn("failed to load configuration from env:", err.Error())
-	}
-
 	traceID := utils.RandTraceID()
 	ctx, inslog := initLogger(context.Background(), cfgHolder.Configuration.Log, traceID)
 	log.SetGlobalLogger(inslog)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -90,11 +90,47 @@ func (c *Holder) Init(required bool) (*Holder, error) {
 			return nil, err
 		}
 	}
-	err = c.LoadEnv()
-	if err != nil {
-		return nil, err
-	}
 	return c, nil
+}
+
+func (c *Holder) registerDefaultValue(val reflect.Value, parts ...string) {
+	varName := "INSOLAR_" + strings.ToUpper(strings.Join(parts, "_"))
+	variablePath := strings.ToLower(strings.Join(parts, "."))
+
+	err := c.viper.BindEnv(variablePath, varName)
+
+	if err != nil {
+		stdlog.Println("bindEnv failed:", err.Error())
+	}
+
+	c.viper.SetDefault(variablePath, val.Interface())
+}
+
+func (c *Holder) registerDifferentValue(val reflect.Value, parts ...string) {
+	variablePath := strings.Join(parts, ".")
+	previousValue := c.viper.Get(variablePath)
+
+	if ! reflect.DeepEqual(previousValue, val.Interface()) {
+		c.viper.Set(variablePath, val.Interface())
+	}
+}
+
+func (c *Holder) recurseCallInLeaf(cb func(reflect.Value, ...string), iface interface{}, parts ...string) {
+	fldV := reflect.ValueOf(iface)
+	fldT := reflect.TypeOf(iface)
+
+	for fldPos := 0; fldPos < fldV.NumField(); fldPos++ {
+		fldName, fldValue := fldT.Field(fldPos).Name, fldV.Field(fldPos)
+
+		path := append(parts, fldName)
+
+		switch fldValue.Kind() {
+		case reflect.Struct:
+			c.recurseCallInLeaf(cb, fldValue.Interface(), path...)
+		default:
+			cb(fldValue, path...)
+		}
+	}
 }
 
 // NewHolder creates new Holder with default configuration
@@ -106,10 +142,8 @@ func NewHolder() *Holder {
 	holder.viper.AddConfigPath(".")
 	holder.viper.SetConfigType("yml")
 
-	holder.viper.SetDefault("insolar", cfg)
+	holder.recurseCallInLeaf(holder.registerDefaultValue, cfg)
 
-	holder.viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	holder.viper.SetEnvPrefix("insolar")
 	return holder
 }
 
@@ -120,13 +154,6 @@ func (c *Holder) Load() error {
 		return err
 	}
 
-	return c.viper.UnmarshalKey("insolar", &c.Configuration)
-}
-
-// LoadEnv overrides configuration with env variables
-func (c *Holder) LoadEnv() error {
-	// workaround for AutomaticEnv issue https://github.com/spf13/viper/issues/188
-	bindEnvs(c.viper, c.Configuration)
 	return c.viper.Unmarshal(&c.Configuration)
 }
 
@@ -138,37 +165,14 @@ func (c *Holder) LoadFromFile(path string) error {
 
 // Save method writes configuration to default file path
 func (c *Holder) Save() error {
-	c.viper.Set("insolar", c.Configuration)
+	c.recurseCallInLeaf(c.registerDifferentValue, c.Configuration)
 	return c.viper.WriteConfig()
 }
 
 // SaveAs method writes configuration to particular file path
 func (c *Holder) SaveAs(path string) error {
+	c.recurseCallInLeaf(c.registerDifferentValue, c.Configuration)
 	return c.viper.WriteConfigAs(path)
-}
-
-func bindEnvs(v *viper.Viper, iface interface{}, parts ...string) {
-	ifv := reflect.ValueOf(iface)
-	ift := reflect.TypeOf(iface)
-	for i := 0; i < ift.NumField(); i++ {
-		fieldv := ifv.Field(i)
-		t := ift.Field(i)
-		name := strings.ToLower(t.Name)
-		tag, ok := t.Tag.Lookup("mapstructure")
-		if ok {
-			name = tag
-		}
-		path := append(parts, name)
-		switch fieldv.Kind() {
-		case reflect.Struct:
-			bindEnvs(v, fieldv.Interface(), path...)
-		default:
-			err := v.BindEnv(strings.Join(path, "."))
-			if err != nil {
-				stdlog.Println("bindEnv failed:", err.Error())
-			}
-		}
-	}
 }
 
 // ToString converts any configuration struct to yaml string

--- a/configuration/testdata/changed.yml
+++ b/configuration/testdata/changed.yml
@@ -1,16 +1,15 @@
-insolar:
-  host:
-    transport:
-      protocol: TCP
-      address: 127.0.0.1:0
-      behindnat: false
-    bootstraphosts: []
-    isrelay: false
-  node:
-    nodes: []
-  log:
-    format: ""
-    level: Debug
-    output: insolar.log
-  stats:
-    listenaddress: 0.0.0.0:8080
+host:
+  transport:
+    protocol: TCP
+    address: 127.0.0.1:0
+    behindnat: false
+  bootstraphosts: []
+  isrelay: false
+node:
+  nodes: []
+log:
+  format: ""
+  level: Debug
+  output: insolar.log
+stats:
+  listenaddress: 0.0.0.0:8080

--- a/configuration/testdata/default.yml
+++ b/configuration/testdata/default.yml
@@ -23,9 +23,9 @@ ledger:
       5: 1
 log:
   level: Info
-  adapter: logrus
+  adapter: zerolog
 metrics:
-  listenaddress: 0.0.0.0:8080
+  listenaddress: 0.0.0.0:9090
 logicrunner:
   rpclisten: 127.0.0.1:7778
   rpcprotocol: tcp
@@ -55,7 +55,7 @@ pulsar:
     behindnat: false
   pulsedistributor:
     bootstraphosts:
-    - 127.0.0.1:64278
+    - localhost:53837
 bootstrap:
   rootkeys: ""
   rootbalance: 0

--- a/scripts/generate_insolar_configs.go
+++ b/scripts/generate_insolar_configs.go
@@ -220,8 +220,6 @@ func main() {
 	cfgHolder := configuration.NewHolder()
 	err = cfgHolder.LoadFromFile(pulsarTemplate)
 	check("Can't read pulsar template config", err)
-	err = cfgHolder.LoadEnv()
-	check("Can't read pulsar template config", err)
 	fmt.Println("pulsar template config: " + pulsarTemplate)
 
 	pulsarConfig := cfgHolder.Configuration


### PR DESCRIPTION
* remove prefix 'insolar' from yaml configuration (in Save/Load
  functions)
* register names of env variables at start, load them simultaniously
  with configuration file in Load/LoadFrom functions
* make Save/SaveAs to save in expected file format
* in configuration test - stash all 'INSOLAR_' before test and load them
  after again (may be a problem in parallel testing)
