### PR TITLE
INS-1196: increase go test timeout up to 40 min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ ci_test_func:
 
 .PHONY: ci_test_integrtest
 ci_test_integrtest:
-	CGO_ENABLED=1 go test $(TEST_ARGS) -tags networktest -v ./network/servicenetwork -count=1 | tee integr.file
+	CGO_ENABLED=1 go test $(TEST_ARGS) -timeout 40m -tags networktest -v ./network/servicenetwork -count=1 | tee integr.file
 
 
 .PHONY: regen-proxies


### PR DESCRIPTION

**- What I did**
Increase timeout for network tests up to 40 minutes

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
