### PR TITLE
INS-2043: pass listen error up to ServiceNetwork

### DIFF
--- a/network/hostnetwork/transport_consensus.go
+++ b/network/hostnetwork/transport_consensus.go
@@ -43,13 +43,11 @@ type transportConsensus struct {
 }
 
 func (tc *transportConsensus) Start(ctx context.Context) error {
-	tc.transportBase.Start(ctx)
-	return nil
+	return tc.transportBase.Start(ctx)
 }
 
 func (tc *transportConsensus) Stop(ctx context.Context) error {
-	tc.transportBase.Stop()
-	return nil
+	return tc.transportBase.Stop(ctx)
 }
 
 // RegisterPacketHandler register a handler function to process incoming requests of a specific type.

--- a/network/hostnetwork/transport_resolvable.go
+++ b/network/hostnetwork/transport_resolvable.go
@@ -33,13 +33,13 @@ type TransportResolvable struct {
 }
 
 // Start listening to network requests.
-func (tr *TransportResolvable) Start(ctx context.Context) {
-	tr.internalTransport.Start(ctx)
+func (tr *TransportResolvable) Start(ctx context.Context) error {
+	return tr.internalTransport.Start(ctx)
 }
 
 // Stop listening to network requests.
-func (tr *TransportResolvable) Stop() {
-	tr.internalTransport.Stop()
+func (tr *TransportResolvable) Stop(ctx context.Context) error {
+	return tr.internalTransport.Stop(ctx)
 }
 
 // PublicAddress returns public address that can be published for all nodes.

--- a/network/interfaces.go
+++ b/network/interfaces.go
@@ -60,10 +60,8 @@ type RequestHandler func(context.Context, Request) (Response, error)
 // HostNetwork simple interface to send network requests and process network responses.
 //go:generate minimock -i github.com/insolar/insolar/network.HostNetwork -o ../testutils/network -s _mock.go
 type HostNetwork interface {
-	// Start listening to network requests.
-	Start(ctx context.Context)
-	// Stop listening to network requests.
-	Stop()
+	component.Starter
+	component.Stopper
 	// PublicAddress returns public address that can be published for all nodes.
 	PublicAddress() string
 	// GetNodeID get current node ID.
@@ -247,10 +245,8 @@ type RoutingTable interface {
 
 // InternalTransport simple interface to send network requests and process network responses.
 type InternalTransport interface {
-	// Start listening to network requests, should be started in goroutine.
-	Start(ctx context.Context)
-	// Stop listening to network requests.
-	Stop()
+	component.Starter
+	component.Stopper
 	// PublicAddress returns public address that can be published for all nodes.
 	PublicAddress() string
 	// GetNodeID get current node ID.

--- a/network/pulsenetwork/distributor.go
+++ b/network/pulsenetwork/distributor.go
@@ -100,7 +100,10 @@ func (d *distributor) Distribute(ctx context.Context, pulse core.Pulse) {
 		return
 	}
 
-	d.resume(ctx)
+	if err := d.resume(ctx); err != nil {
+		logger.Error("[ Distribute ] resume distribution error: " + err.Error())
+		return
+	}
 	defer d.pause(ctx)
 
 	wg := sync.WaitGroup{}
@@ -201,9 +204,9 @@ func (d *distributor) pause(ctx context.Context) {
 	d.Transport.Close()
 }
 
-func (d *distributor) resume(ctx context.Context) {
+func (d *distributor) resume(ctx context.Context) error {
 	inslogger.FromContext(ctx).Info("[ Resume ] Resume distribution, starting transport")
 	ctx, span := instracer.StartSpan(ctx, "distributor.resume")
 	defer span.End()
-	transport.ListenAndWaitUntilReady(ctx, d.Transport)
+	return transport.ListenAndWaitUntilReady(ctx, d.Transport)
 }

--- a/network/servicenetwork/servicenetwork.go
+++ b/network/servicenetwork/servicenetwork.go
@@ -215,8 +215,7 @@ func (n *ServiceNetwork) Stop(ctx context.Context) error {
 		log.Errorf("Error while stopping network components: %s", err.Error())
 	}
 	logger.Info("Stopping host network")
-	n.hostNetwork.Stop()
-	return nil
+	return n.hostNetwork.Stop(ctx)
 }
 
 func (n *ServiceNetwork) HandlePulse(ctx context.Context, newPulse core.Pulse) {


### PR DESCRIPTION
**- What I did**
Now error from transport.Listen is passed up to ServiceNetwork so we know early when Insolar network module can't occupy a network port for its needs.
**- How to verify it**
Run unit and integration tests