### PR TITLE
NOISSUE: increase integration tests initialization timeout to 30s

### DIFF
--- a/network/servicenetwork/suite_test.go
+++ b/network/servicenetwork/suite_test.go
@@ -178,7 +178,7 @@ func (s *testSuite) SetupNodesNetwork(nodes []*networkNode) {
 				if count == expected {
 					return nil
 				}
-			case <-time.After(time.Second * 20):
+			case <-time.After(time.Second * 30):
 				return errors.New("timeout")
 			}
 		}


### PR DESCRIPTION
**- What I did**
Increased integration tests initialization timeout to 30s. This can decrease number of false failing tests.
**- How to verify it**
run integration tests
