### PR TITLE
INS-2176: do not create a new transport in each request iteration

### DIFF
--- a/cmd/pulsewatcher/pulsewatcher.go
+++ b/cmd/pulsewatcher/pulsewatcher.go
@@ -157,11 +157,6 @@ func displayResultsJSON(results [][]string, ready bool, buffer *bytes.Buffer) {
 }
 
 func collectNodesStatuses(conf *pulsewatcher.Config) ([][]string, bool) {
-	client = http.Client{
-		Transport: &http.Transport{},
-		Timeout:   conf.Timeout,
-	}
-
 	state := true
 	errored := 0
 	results := make([][]string, len(conf.Nodes))
@@ -248,6 +243,12 @@ func main() {
 
 	buffer := &bytes.Buffer{}
 	fmt.Print("\n\n")
+
+	client = http.Client{
+		Transport: &http.Transport{},
+		Timeout:   conf.Timeout,
+	}
+
 	for {
 		results, ready := collectNodesStatuses(conf)
 		if useJSONFormat {


### PR DESCRIPTION
**- What I did**
Fixed error when we get out of available TCP ports.
**- How to verify it**
Run `launchnet.sh`, run `sudo lsof -i -n -P | grep TCP | cut -f1 -d' ' | sort | uniq -c` and verify that pulsewatcher does not waste TCP ports