### PR TITLE
NOISSUE: segregate testing port ranges

### DIFF
--- a/network/servicenetwork/integr_test.go
+++ b/network/servicenetwork/integr_test.go
@@ -133,14 +133,14 @@ func (s *testSuite) TestManyNodesConnect() {
 
 	for i, node := range nodes {
 		go func(wg *sync.WaitGroup, node *networkNode, nodeNum int) {
-			s.T().Logf("[ TestManyNodesConnect ] PreIniting node %d", i)
+			s.T().Logf("[ TestManyNodesConnect ] PreIniting node %d", nodeNum)
 			s.preInitNode(node)
-			s.T().Logf("[ TestManyNodesConnect ] Initing node %d", i)
+			s.T().Logf("[ TestManyNodesConnect ] Initing node %d", nodeNum)
 			s.InitNode(node)
 			wg.Done()
-			s.T().Logf("[ TestManyNodesConnect ] Starting node %d", i)
+			s.T().Logf("[ TestManyNodesConnect ] Starting node %d", nodeNum)
 			s.StartNode(node)
-			s.T().Logf("[ TestManyNodesConnect ] Done node %d", i)
+			s.T().Logf("[ TestManyNodesConnect ] Done node %d", nodeNum)
 
 		}(&wg, node, i)
 	}

--- a/network/servicenetwork/integr_test.go
+++ b/network/servicenetwork/integr_test.go
@@ -131,23 +131,16 @@ func (s *testSuite) TestManyNodesConnect() {
 	wg := sync.WaitGroup{}
 	wg.Add(joinersCount)
 
-	for i, node := range nodes {
-		go func(wg *sync.WaitGroup, node *networkNode, nodeNum int) {
-			s.T().Logf("[ TestManyNodesConnect ] PreIniting node %d", nodeNum)
+	for _, node := range nodes {
+		go func(wg *sync.WaitGroup, node *networkNode) {
 			s.preInitNode(node)
-			s.T().Logf("[ TestManyNodesConnect ] Initing node %d", nodeNum)
 			s.InitNode(node)
-			s.T().Logf("[ TestManyNodesConnect ] Starting node %d", nodeNum)
-			s.StartNode(node)
-			s.T().Logf("[ TestManyNodesConnect ] Done node %d", nodeNum)
-
 			wg.Done()
-
-		}(&wg, node, i)
+			s.StartNode(node)
+		}(&wg, node)
 	}
 
 	wg.Wait()
-	s.T().Logf("[ TestManyNodesConnect ] All nodes waited")
 
 	defer func() {
 		for _, node := range nodes {
@@ -156,8 +149,6 @@ func (s *testSuite) TestManyNodesConnect() {
 	}()
 
 	s.waitForConsensus(5)
-
-	s.T().Logf("[ TestManyNodesConnect ] Concensus waited")
 
 	joined := claimhandler.ApprovedJoinersCount(joinersCount, s.getNodesCount())
 	activeNodes := s.fixture().bootstrapNodes[0].serviceNetwork.NodeKeeper.GetAccessor().GetActiveNodes()

--- a/network/servicenetwork/integr_test.go
+++ b/network/servicenetwork/integr_test.go
@@ -137,10 +137,11 @@ func (s *testSuite) TestManyNodesConnect() {
 			s.preInitNode(node)
 			s.T().Logf("[ TestManyNodesConnect ] Initing node %d", nodeNum)
 			s.InitNode(node)
-			wg.Done()
 			s.T().Logf("[ TestManyNodesConnect ] Starting node %d", nodeNum)
 			s.StartNode(node)
 			s.T().Logf("[ TestManyNodesConnect ] Done node %d", nodeNum)
+
+			wg.Done()
 
 		}(&wg, node, i)
 	}

--- a/network/servicenetwork/integr_test.go
+++ b/network/servicenetwork/integr_test.go
@@ -131,16 +131,22 @@ func (s *testSuite) TestManyNodesConnect() {
 	wg := sync.WaitGroup{}
 	wg.Add(joinersCount)
 
-	for _, node := range nodes {
-		go func(wg *sync.WaitGroup, node *networkNode) {
+	for i, node := range nodes {
+		go func(wg *sync.WaitGroup, node *networkNode, nodeNum int) {
+			s.T().Logf("[ TestManyNodesConnect ] PreIniting node %d", i)
 			s.preInitNode(node)
+			s.T().Logf("[ TestManyNodesConnect ] Initing node %d", i)
 			s.InitNode(node)
-			s.StartNode(node)
 			wg.Done()
-		}(&wg, node)
+			s.T().Logf("[ TestManyNodesConnect ] Starting node %d", i)
+			s.StartNode(node)
+			s.T().Logf("[ TestManyNodesConnect ] Done node %d", i)
+
+		}(&wg, node, i)
 	}
 
 	wg.Wait()
+	s.T().Logf("[ TestManyNodesConnect ] All nodes waited", i)
 
 	defer func() {
 		for _, node := range nodes {
@@ -149,6 +155,8 @@ func (s *testSuite) TestManyNodesConnect() {
 	}()
 
 	s.waitForConsensus(5)
+
+	s.T().Logf("[ TestManyNodesConnect ] Concensus waited", i)
 
 	joined := claimhandler.ApprovedJoinersCount(joinersCount, s.getNodesCount())
 	activeNodes := s.fixture().bootstrapNodes[0].serviceNetwork.NodeKeeper.GetAccessor().GetActiveNodes()

--- a/network/servicenetwork/integr_test.go
+++ b/network/servicenetwork/integr_test.go
@@ -147,7 +147,7 @@ func (s *testSuite) TestManyNodesConnect() {
 	}
 
 	wg.Wait()
-	s.T().Logf("[ TestManyNodesConnect ] All nodes waited", i)
+	s.T().Logf("[ TestManyNodesConnect ] All nodes waited")
 
 	defer func() {
 		for _, node := range nodes {
@@ -157,7 +157,7 @@ func (s *testSuite) TestManyNodesConnect() {
 
 	s.waitForConsensus(5)
 
-	s.T().Logf("[ TestManyNodesConnect ] Concensus waited", i)
+	s.T().Logf("[ TestManyNodesConnect ] Concensus waited")
 
 	joined := claimhandler.ApprovedJoinersCount(joinersCount, s.getNodesCount())
 	activeNodes := s.fixture().bootstrapNodes[0].serviceNetwork.NodeKeeper.GetAccessor().GetActiveNodes()

--- a/network/servicenetwork/suite_test.go
+++ b/network/servicenetwork/suite_test.go
@@ -55,6 +55,7 @@ import (
 	"crypto"
 	"fmt"
 	"math/rand"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -85,6 +86,21 @@ var (
 	reqTimeoutMs    int32  = 2000
 	pulseDelta      int32  = 5
 )
+
+func init() {
+	if tbn, ok := os.LookupEnv("TBN"); ok {
+		log.Infof("Found $TBN=%s\n", tbn)
+		num, err := strconv.Atoi(tbn)
+		if err != nil {
+			log.Fatalf("Test build number must be numeric: %v", err)
+		}
+		testNetworkPort = uint32((4 + num%60) * 1000)
+		log.Infof("Starting on port=%d\n", testNetworkPort)
+
+	} else {
+		log.Infof("TBN environment variable not found\n")
+	}
+}
 
 type fixture struct {
 	ctx            context.Context

--- a/network/servicenetwork/suite_test.go
+++ b/network/servicenetwork/suite_test.go
@@ -88,8 +88,8 @@ var (
 )
 
 func init() {
-	if tbn, ok := os.LookupEnv("TBN"); ok {
-		log.Infof("Found $TBN=%s\n", tbn)
+	if tbn, ok := os.LookupEnv("TEST_BUILD_NUMBER"); ok {
+		log.Infof("Found TEST_BUILD_NUMBER=%s\n", tbn)
 		num, err := strconv.Atoi(tbn)
 		if err != nil {
 			log.Fatalf("Test build number must be numeric: %v", err)
@@ -98,7 +98,7 @@ func init() {
 		log.Infof("Starting on port=%d\n", testNetworkPort)
 
 	} else {
-		log.Infof("TBN environment variable not found\n")
+		log.Infof("TEST_BUILD_NUMBER environment variable not found\n")
 	}
 }
 


### PR DESCRIPTION
According to environment variable TBN we now choose range of testing ports. This made for reduce port collisions on building platform.