### PR TITLE
INS-2219: change log level "on the flight"

### DIFF
--- a/log/zerolog.go
+++ b/log/zerolog.go
@@ -141,7 +141,7 @@ func (z zerologAdapter) Panicf(format string, args ...interface{}) {
 	z.logger.Panic().Msgf(format, args...)
 }
 
-// SetLevel sets log level
+// WithLevel sets log level
 func (z *zerologAdapter) WithLevel(level string) (insolar.Logger, error) {
 	levelNumber, err := insolar.ParseLevel(level)
 	if err != nil {

--- a/log/zerolog.go
+++ b/log/zerolog.go
@@ -19,6 +19,7 @@ package log
 import (
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 
@@ -31,6 +32,41 @@ import (
 
 type zerologAdapter struct {
 	logger zerolog.Logger
+}
+
+type loglevelChangeHandler struct {
+}
+
+func NewLoglevelChangeHandler() *loglevelChangeHandler {
+	handler := &loglevelChangeHandler{}
+	return handler
+}
+
+// ServeHTTP is an HTTP handler that changes the global minimum log level
+func (h *loglevelChangeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	values := r.URL.Query()
+	levelStr := "(nil)"
+	if values["level"] != nil {
+		levelStr = values["level"][0]
+	}
+	level, err := insolar.ParseLevel(levelStr)
+	if err != nil {
+		w.WriteHeader(500)
+		_, _ = fmt.Fprintf(w, "Invalid level '%v': %v\n", levelStr, err)
+		return
+	}
+
+	zlevel, err := InternalLevelToZerologLevel(level)
+	if err != nil {
+		w.WriteHeader(500)
+		_, _ = fmt.Fprintf(w, "Invalid level '%v': %v\n", levelStr, err)
+		return
+	}
+
+	zerolog.SetGlobalLevel(zlevel)
+
+	w.WriteHeader(200)
+	_, _ = fmt.Fprintf(w, "New log level: '%v'\n", levelStr)
 }
 
 func InternalLevelToZerologLevel(level insolar.LogLevel) (zerolog.Level, error) {

--- a/log/zerolog.go
+++ b/log/zerolog.go
@@ -37,7 +37,7 @@ type zerologAdapter struct {
 type loglevelChangeHandler struct {
 }
 
-func NewLoglevelChangeHandler() *loglevelChangeHandler {
+func NewLoglevelChangeHandler() http.Handler {
 	handler := &loglevelChangeHandler{}
 	return handler
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/insolar/insolar/log"
-
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -35,6 +33,7 @@ import (
 	"github.com/insolar/insolar/instrumentation/inslogger"
 	"github.com/insolar/insolar/instrumentation/insmetrics"
 	"github.com/insolar/insolar/instrumentation/pprof"
+	"github.com/insolar/insolar/log"
 )
 
 const insolarNamespace = "insolar"

--- a/metrics/status.go
+++ b/metrics/status.go
@@ -106,7 +106,7 @@ type procStatus struct {
 	StartTime time.Time
 }
 
-func newProcStatus() *procStatus {
+func newProcStatus() http.Handler {
 	info := &procStatus{
 		StartTime: time.Now(),
 	}

--- a/metrics/status.go
+++ b/metrics/status.go
@@ -106,7 +106,7 @@ type procStatus struct {
 	StartTime time.Time
 }
 
-func newProcStatus() http.Handler {
+func newProcStatus() *procStatus {
 	info := &procStatus{
 		StartTime: time.Now(),
 	}


### PR DESCRIPTION
**- What I did**

An API for changing loglevel without restarting a node was added. A corresponding test will be added to integration (junit+java) tests after merging.

**- How to verify it**

```
$ curl 'http://localhost:8005/debug/loglevel?level=warn' 2>&1
OK, new log level: 'warn'
$ curl 'http://localhost:8005/debug/loglevel?level=debug' 2>&1
OK, new log level: 'debug'
$ curl 'http://localhost:8005/debug/loglevel?level=info' 2>&1
OK, new log level: 'info'
$ curl 'http://localhost:8005/debug/loglevel?level=ololo' 2>&1
Invalid level 'ololo'
$ curl 'http://localhost:8005/debug/loglevel' 2>&1
Invalid level '(nil)'
$ tail -n 25 .//scripts/insolard/discoverynodes/5/output.log
```
