### PR TITLE
NOISSUE: fix building of insolar in case of clean installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ clean:
 .PHONY: install-deps
 install-deps:
 	./scripts/build/fetchdeps github.com/golang/dep/cmd/dep 22125cfaa6ddc71e145b1535d4b7ee9744fefff2
+	go clean -modcache
 	./scripts/build/fetchdeps golang.org/x/tools/cmd/stringer 63e6ed9258fa6cbc90aab9b1eef3e0866e89b874
 	./scripts/build/fetchdeps github.com/gojuno/minimock/cmd/minimock 890c67cef23dd06d694294d4f7b1026ed7bac8e6
 


### PR DESCRIPTION
versions of gopkg.com/x/net used in godep and in stringer are
two years apart from each other (July 2017 for godep and March 2019 for
stringer).

`go cache -modclean` deletes old net module (used for building godep)
and refetching of net repo works just fine.

cherry-pick of master commit