### PR TITLE
INS-2002: rename LR.Execute to HandleCalls, we agreed earlier on this

### DIFF
--- a/insolar/vm.go
+++ b/insolar/vm.go
@@ -61,7 +61,7 @@ type MachineLogicExecutor interface {
 
 // LogicRunner is an interface that should satisfy logic executor
 type LogicRunner interface {
-	Execute(context.Context, Parcel) (res Reply, err error)
+	HandleCalls(context.Context, Parcel) (res Reply, err error)
 	HandleValidateCaseBindMessage(context.Context, Parcel) (res Reply, err error)
 	HandleValidationResultsMessage(context.Context, Parcel) (res Reply, err error)
 	HandleExecutorResultsMessage(context.Context, Parcel) (res Reply, err error)

--- a/logicrunner/builtin_test.go
+++ b/logicrunner/builtin_test.go
@@ -145,7 +145,7 @@ func TestBareHelloworld(t *testing.T) {
 	assert.NoError(t, err)
 	// #1
 	ctx = inslogger.ContextWithTrace(ctx, "TestBareHelloworld1")
-	resp, err := lr.Execute(
+	resp, err := lr.HandleCalls(
 		ctx,
 		parcel,
 	)
@@ -163,7 +163,7 @@ func TestBareHelloworld(t *testing.T) {
 	assert.NoError(t, err)
 	// #2
 	ctx = inslogger.ContextWithTrace(ctx, "TestBareHelloworld2")
-	resp, err = lr.Execute(
+	resp, err = lr.HandleCalls(
 		ctx,
 		parcel,
 	)

--- a/logicrunner/logicrunner_test.go
+++ b/logicrunner/logicrunner_test.go
@@ -99,8 +99,8 @@ func (s *LogicRunnerFuncSuite) SetupSuite() {
 }
 
 func MessageBusTrivialBehavior(mb *testmessagebus.TestMessageBus, lr insolar.LogicRunner) {
-	mb.ReRegister(insolar.TypeCallMethod, lr.Execute)
-	mb.ReRegister(insolar.TypeCallConstructor, lr.Execute)
+	mb.ReRegister(insolar.TypeCallMethod, lr.HandleCalls)
+	mb.ReRegister(insolar.TypeCallConstructor, lr.HandleCalls)
 	mb.ReRegister(insolar.TypeValidateCaseBind, lr.HandleValidateCaseBindMessage)
 	mb.ReRegister(insolar.TypeValidationResults, lr.HandleValidationResultsMessage)
 	mb.ReRegister(insolar.TypeExecutorResults, lr.HandleExecutorResultsMessage)

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -795,7 +795,7 @@ func (suite *LogicRunnerTestSuite) TestConcurrency() {
 
 			ctx := inslogger.ContextWithTrace(suite.ctx, "req-"+strconv.Itoa(i))
 
-			_, err := suite.lr.Execute(ctx, parcel)
+			_, err := suite.lr.HandleCalls(ctx, parcel)
 			suite.Require().NoError(err)
 
 			wg.Done()
@@ -1030,7 +1030,7 @@ func (suite *LogicRunnerTestSuite) TestCallMethodWithOnPulse() {
 
 			ctx := inslogger.ContextWithTrace(suite.ctx, "req")
 
-			_, err := suite.lr.Execute(ctx, parcel)
+			_, err := suite.lr.HandleCalls(ctx, parcel)
 			if test.errorExpected {
 				suite.Require().Error(err)
 			} else {


### PR DESCRIPTION
all message handlers should start from Handle. This is handler for two
messages: CallMethod and CallConstructor, so we name it HandleCalls