### PR TITLE
INS-2351: jetID generator was using the same zero data all the time

### DIFF
--- a/insolar/gen/reference.go
+++ b/insolar/gen/reference.go
@@ -30,13 +30,16 @@ func ID() (id insolar.ID) {
 
 // JetID generates random jet id.
 func JetID() (jetID insolar.JetID) {
-	f := fuzz.New().Funcs(func(id *insolar.JetID, c fuzz.Continue) {
-		c.Fuzz(id)
+	f := fuzz.New().Funcs(func(jet *insolar.JetID, c fuzz.Continue) {
+		var id insolar.ID
+		c.Fuzz(&id)
+		copy(jet[:], id[:])
 		// set special pulse number
-		copy(id[:insolar.PulseNumberSize], insolar.PulseNumberJet.Bytes())
+		copy(jet[:insolar.PulseNumberSize], insolar.PulseNumberJet.Bytes())
 		// set depth
 		// adds 1 because Intn returns [0,n)
-		id[insolar.PulseNumberSize] = byte(c.Intn(insolar.JetMaximumDepth + 1))
+		jet[insolar.PulseNumberSize] = byte(c.Intn(insolar.JetMaximumDepth + 1))
+
 	})
 	f.Fuzz(&jetID)
 	return


### PR DESCRIPTION
c.Fuzz(id) was resulting in recursive call as `id` has type jetID.
fuzzer is smart and just ignores the call and jetID is filled with
zeroes. We had very good chance that fuzzer generates the same jetID
during one test multiple times.

For example the following tests was falling quite fast:
go test ./ledger/storage/drop/... -count 1000 -run TestDropStorageMemory_Delete -failfast