### PR TITLE
INS-2352: fix send to closed channel panic during reply to message

### DIFF
--- a/insolar/flow/handler/handler.go
+++ b/insolar/flow/handler/handler.go
@@ -52,9 +52,6 @@ func (h *Handler) WrapBusHandle(ctx context.Context, parcel insolar.Parcel) (ins
 		ReplyTo: make(chan bus.Reply, 1),
 		Parcel:  parcel,
 	}
-	defer func() {
-		close(msg.ReplyTo)
-	}()
 
 	ctx = pulse.ContextWith(ctx, parcel.Pulse())
 

--- a/ledger/proc/proc.go
+++ b/ledger/proc/proc.go
@@ -36,7 +36,10 @@ type ReturnReply struct {
 	Reply   insolar.Reply
 }
 
-func (p *ReturnReply) Proceed(context.Context) error {
-	p.ReplyTo <- bus.Reply{Reply: p.Reply, Err: p.Err}
+func (p *ReturnReply) Proceed(ctx context.Context) error {
+	select {
+	case p.ReplyTo <- bus.Reply{Reply: p.Reply, Err: p.Err}:
+	case <-ctx.Done():
+	}
 	return nil
 }

--- a/ledger/proc/send_object.go
+++ b/ledger/proc/send_object.go
@@ -52,7 +52,11 @@ type SendObject struct {
 func (p *SendObject) Proceed(ctx context.Context) error {
 	r := bus.Reply{}
 	r.Reply, r.Err = p.handle(ctx, p.Message.Parcel)
-	p.Message.ReplyTo <- r
+
+	select {
+	case p.Message.ReplyTo <- r:
+	case <-ctx.Done():
+	}
 	return nil
 }
 


### PR DESCRIPTION
don't close channel, just make sure no user of the channel blocks by
also accounting ctx.Done() channel as a signal. All users go away
and channel goes garbage collected.