### PR TITLE
INS-2363: it was possible to generate two JetIDs that are the same

### DIFF
--- a/insolar/gen/reference.go
+++ b/insolar/gen/reference.go
@@ -45,6 +45,21 @@ func JetID() (jetID insolar.JetID) {
 	return
 }
 
+// UniqueJetIDs generates several different jet ids
+func UniqueJetIDs(jets ...*insolar.JetID) {
+	seen := make(map[insolar.JetID]struct{})
+
+	for _, j := range jets {
+		for {
+			*j = JetID()
+			if _, ok := seen[*j]; !ok {
+				break
+			}
+		}
+		seen[*j] = struct{}{}
+	}
+}
+
 // Reference generates random reference.
 func Reference() (ref insolar.Reference) {
 	fuzz.New().NilChance(0).Fuzz(&ref)

--- a/ledger/storage/drop/memory_test.go
+++ b/ledger/storage/drop/memory_test.go
@@ -72,10 +72,11 @@ func TestDropStorageMemory_ForPulse(t *testing.T) {
 	ctx := inslogger.TestContext(t)
 	ms := NewStorageMemory()
 
-	fJet := gen.JetID()
+	var fJet, sJet insolar.JetID
+	gen.UniqueJetIDs(&fJet, &sJet)
+
 	fPn := gen.PulseNumber()
 	_ = ms.Set(ctx, Drop{JetID: fJet, Pulse: fPn})
-	sJet := gen.JetID()
 	sPn := gen.PulseNumber()
 	_ = ms.Set(ctx, Drop{JetID: sJet, Pulse: sPn})
 
@@ -132,8 +133,9 @@ func TestDropStorageMemory_Delete(t *testing.T) {
 	ctx := inslogger.TestContext(t)
 	ms := NewStorageMemory()
 
-	fJet := gen.JetID()
-	sJet := gen.JetID()
+	var fJet, sJet insolar.JetID
+	gen.UniqueJetIDs(&fJet, &sJet)
+
 	fPn := gen.PulseNumber()
 	sPn := gen.PulseNumber()
 	fSize := rand.Uint64()

--- a/testutils/core.go
+++ b/testutils/core.go
@@ -80,7 +80,7 @@ func RandomID() insolar.ID {
 }
 
 // RandomJet generates random jet with random depth.
-// DEPRECATED: use gem.JetID
+// DEPRECATED: use gen.JetID
 func RandomJet() insolar.ID {
 	// don't be too huge (i.e. 255)
 	n, err := rand.Int(rand.Reader, big.NewInt(128))


### PR DESCRIPTION
fix tests that use more than one generate jet by making sure used jets
are not the same as it expected by the tests