### PR TITLE
INS-2375: wait for expected minimock calls for a minute at least

### DIFF
--- a/ledger/replication/cleaner_test.go
+++ b/ledger/replication/cleaner_test.go
@@ -105,7 +105,7 @@ func TestCleaner_clean(t *testing.T) {
 	go cleaner.clean(ctx)
 	cleaner.pulseForClean <- inputPulse.PulseNumber
 
-	ctrl.Wait(10 * time.Millisecond)
+	ctrl.Wait(time.Minute)
 }
 
 func TestLightCleaner_NotifyAboutPulse(t *testing.T) {
@@ -145,5 +145,5 @@ func TestLightCleaner_NotifyAboutPulse(t *testing.T) {
 	cleaner := NewCleaner(jm, nm, dc, bc, rc, ic, ps, pc, limit)
 	go cleaner.NotifyAboutPulse(ctx, inputPulse.PulseNumber)
 
-	ctrl.Wait(10 * time.Millisecond)
+	ctrl.Wait(time.Minute)
 }

--- a/ledger/replication/lightreplicator_test.go
+++ b/ledger/replication/lightreplicator_test.go
@@ -123,7 +123,7 @@ func TestLightReplicatorDefault_sync(t *testing.T) {
 	go r.sync(ctx)
 	r.syncWaitingPulses <- pn
 
-	ctrl.Wait(10 * time.Millisecond)
+	ctrl.Wait(time.Minute)
 	ctrl.Finish()
 }
 
@@ -162,6 +162,6 @@ func TestLightReplicatorDefault_NotifyAboutPulse(t *testing.T) {
 
 	go r.NotifyAboutPulse(ctx, inputPN)
 
-	ctrl.Wait(10 * time.Millisecond)
+	ctrl.Wait(time.Minute)
 	ctrl.Finish()
 }

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -81,7 +81,7 @@ func (suite *LogicRunnerCommonTestSuite) SetupLogicRunner() {
 }
 
 func (suite *LogicRunnerCommonTestSuite) AfterTest(suiteName, testName string) {
-	suite.mc.Wait(10 * time.Second)
+	suite.mc.Wait(time.Minute)
 	suite.mc.Finish()
 }
 
@@ -131,7 +131,7 @@ func (suite *LogicRunnerTestSuite) TestPendingFinished() {
 	suite.Require().Equal(message.NotPending, es.pending)
 	suite.Require().Nil(es.objectbody)
 
-	suite.mc.Wait(time.Second) // message bus' send is called in a goroutine
+	suite.mc.Wait(time.Minute) // message bus' send is called in a goroutine
 
 	es.pending = message.InPending
 	es.objectbody = &ObjectBody{}

--- a/network/termination/handler_test.go
+++ b/network/termination/handler_test.go
@@ -89,7 +89,7 @@ func (s *CommonTestSuite) BeforeTest(suiteName, testName string) {
 }
 
 func (s *CommonTestSuite) AfterTest(suiteName, testName string) {
-	s.mc.Wait(10 * time.Second)
+	s.mc.Wait(time.Minute)
 	s.mc.Finish()
 }
 


### PR DESCRIPTION
you expect them to happen and if they don't then test FAILS, 10ms
is TOO SMALL duration, it randomly fails under -race flag, on slow
machines, on C.I, on virtual nodes....
