### PR TITLE
INS-2393: I believ that in some situation `wait` never finishes

### DIFF
--- a/scripts/insolard/launchnet.sh
+++ b/scripts/insolard/launchnet.sh
@@ -101,10 +101,10 @@ stop_listening()
 
     for port in $ports
     do
-        echo "kill port '$port' owner"
-        kill_port $port &
+        echo "killing process using port '$port'"
+        kill_port $port
     done
-    wait
+
     echo "stop_listening() end."
 }
 


### PR DESCRIPTION
after implementing parallel kill and final wait, we see tests hanging
from time to time on our test agents. let's rollback to previous
solution.

my idea is that we either start a child and don't kill it or order of
kills is important