### PR TITLE
INS-2397: fuzzer can not be used concurrently, causes race

### DIFF
--- a/insolar/record/record_test.go
+++ b/insolar/record/record_test.go
@@ -34,10 +34,14 @@ func FuzzRandomReference(t *insolar.Reference, _ fuzz.Continue) {
 	*t = gen.Reference()
 }
 
+func fuzzer() *fuzz.Fuzzer {
+	return fuzz.New().Funcs(FuzzRandomID, FuzzRandomReference).NumElements(50, 100).NilChance(0)
+}
+
 func TestMarshalUnmarshalRecord(t *testing.T) {
-	f := fuzz.New().Funcs(FuzzRandomID, FuzzRandomReference).NumElements(50, 100).NilChance(0)
 
 	t.Run("GenesisRecordTest", func(t *testing.T) {
+		f := fuzzer()
 		a := assert.New(t)
 		t.Parallel()
 		var record GenesisRecord
@@ -60,6 +64,7 @@ func TestMarshalUnmarshalRecord(t *testing.T) {
 	})
 
 	t.Run("ChildRecordTest", func(t *testing.T) {
+		f := fuzzer()
 		a := assert.New(t)
 		t.Parallel()
 		var record ChildRecord
@@ -82,6 +87,7 @@ func TestMarshalUnmarshalRecord(t *testing.T) {
 	})
 
 	t.Run("JetRecordTest", func(t *testing.T) {
+		f := fuzzer()
 		a := assert.New(t)
 		t.Parallel()
 		var record JetRecord
@@ -104,6 +110,7 @@ func TestMarshalUnmarshalRecord(t *testing.T) {
 	})
 
 	t.Run("RequestRecordTest", func(t *testing.T) {
+		f := fuzzer()
 		a := assert.New(t)
 		t.Parallel()
 		var record RequestRecord
@@ -126,6 +133,7 @@ func TestMarshalUnmarshalRecord(t *testing.T) {
 	})
 
 	t.Run("ResultRecordTest", func(t *testing.T) {
+		f := fuzzer()
 		a := assert.New(t)
 		t.Parallel()
 		var record ResultRecord
@@ -148,6 +156,7 @@ func TestMarshalUnmarshalRecord(t *testing.T) {
 	})
 
 	t.Run("TypeRecordTest", func(t *testing.T) {
+		f := fuzzer()
 		a := assert.New(t)
 		t.Parallel()
 		var record TypeRecord
@@ -170,6 +179,7 @@ func TestMarshalUnmarshalRecord(t *testing.T) {
 	})
 
 	t.Run("CodeRecordTest", func(t *testing.T) {
+		f := fuzzer()
 		a := assert.New(t)
 		t.Parallel()
 		var record CodeRecord
@@ -192,6 +202,7 @@ func TestMarshalUnmarshalRecord(t *testing.T) {
 	})
 
 	t.Run("ObjectActivateRecordTest", func(t *testing.T) {
+		f := fuzzer()
 		a := assert.New(t)
 		t.Parallel()
 		var record ObjectActivateRecord
@@ -214,6 +225,7 @@ func TestMarshalUnmarshalRecord(t *testing.T) {
 	})
 
 	t.Run("ObjectAmendRecordTest", func(t *testing.T) {
+		f := fuzzer()
 		a := assert.New(t)
 		t.Parallel()
 		var record ObjectAmendRecord
@@ -236,6 +248,7 @@ func TestMarshalUnmarshalRecord(t *testing.T) {
 	})
 
 	t.Run("ObjectDeactivateRecordTest", func(t *testing.T) {
+		f := fuzzer()
 		a := assert.New(t)
 		t.Parallel()
 		var record ObjectDeactivateRecord


### PR DESCRIPTION
looks like fuzzer creates an instance of math.Rand and this object can
not be accessed concurrently and fuzzer doesn't protect it with a lock

```
WARNING: DATA RACE
Read at 0x00c0001a4000 by goroutine 15:
  math/rand.(*rngSource).Int63()
      /opt/local/lib/go/src/math/rand/rng.go:239 +0x3e
  math/rand.(*Rand).Int63()
      /opt/local/lib/go/src/math/rand/rand.go:85 +0x50
  math/rand.(*Rand).Int()
      /opt/local/lib/go/src/math/rand/rand.go:103 +0x38
  github.com/insolar/insolar/vendor/github.com/google/gofuzz.randBool()
      /Users/ruz/go/src/github.com/insolar/insolar/vendor/github.com/google/gofuzz/fuzz.go:449 +0x38
  github.com/insolar/insolar/vendor/github.com/google/gofuzz.glob..func1()
      /Users/ruz/go/src/github.com/insolar/insolar/vendor/github.com/google/gofuzz/fuzz.go:414 +0x38
  github.com/insolar/insolar/vendor/github.com/google/gofuzz.(*fuzzerContext).doFuzz()
      /Users/ruz/go/src/github.com/insolar/insolar/vendor/github.com/google/gofuzz/fuzz.go:231 +0xd59
  github.com/insolar/insolar/vendor/github.com/google/gofuzz.(*fuzzerContext).doFuzz()
      /Users/ruz/go/src/github.com/insolar/insolar/vendor/github.com/google/gofuzz/fuzz.go:277 +0xa55
  github.com/insolar/insolar/vendor/github.com/google/gofuzz.(*Fuzzer).fuzzWithContext()
      /Users/ruz/go/src/github.com/insolar/insolar/vendor/github.com/google/gofuzz/fuzz.go:199 +0xc7
  github.com/insolar/insolar/vendor/github.com/google/gofuzz.(*Fuzzer).Fuzz()
      /Users/ruz/go/src/github.com/insolar/insolar/vendor/github.com/google/gofuzz/fuzz.go:173 +0x9f
  github.com/insolar/insolar/insolar/record.TestMarshalUnmarshalRecord.func8()
      /Users/ruz/go/src/github.com/insolar/insolar/insolar/record/record_test.go:200 +0x313
  testing.tRunner()
      /opt/local/lib/go/src/testing/testing.go:827 +0x162

Previous write at 0x00c0001a4000 by goroutine 12:
  math/rand.(*rngSource).Int63()
      /opt/local/lib/go/src/math/rand/rng.go:239 +0x54
  math/rand.(*Rand).Int63()
      /opt/local/lib/go/src/math/rand/rand.go:85 +0x50
  math/rand.(*Rand).Float64()
      /opt/local/lib/go/src/math/rand/rand.go:196 +0x38
  github.com/insolar/insolar/vendor/github.com/google/gofuzz.(*Fuzzer).genShouldFill()
      /Users/ruz/go/src/github.com/insolar/insolar/vendor/github.com/google/gofuzz/fuzz.go:142 +0x54
  github.com/insolar/insolar/vendor/github.com/google/gofuzz.(*fuzzerContext).doFuzz()
      /Users/ruz/go/src/github.com/insolar/insolar/vendor/github.com/google/gofuzz/fuzz.go:257 +0xad3
  github.com/insolar/insolar/vendor/github.com/google/gofuzz.(*fuzzerContext).doFuzz()
      /Users/ruz/go/src/github.com/insolar/insolar/vendor/github.com/google/gofuzz/fuzz.go:277 +0xa55
  github.com/insolar/insolar/vendor/github.com/google/gofuzz.(*Fuzzer).fuzzWithContext()
      /Users/ruz/go/src/github.com/insolar/insolar/vendor/github.com/google/gofuzz/fuzz.go:199 +0xc7
  github.com/insolar/insolar/vendor/github.com/google/gofuzz.(*Fuzzer).Fuzz()
      /Users/ruz/go/src/github.com/insolar/insolar/vendor/github.com/google/gofuzz/fuzz.go:173 +0x9f
  github.com/insolar/insolar/insolar/record.TestMarshalUnmarshalRecord.func5()
      /Users/ruz/go/src/github.com/insolar/insolar/insolar/record/record_test.go:134 +0x320
  testing.tRunner()
      /opt/local/lib/go/src/testing/testing.go:827 +0x162
```
