### PR TITLE
[INS-2400] add ability to suspend the tests if failed

### DIFF
--- a/network/servicenetwork/suite_test.go
+++ b/network/servicenetwork/suite_test.go
@@ -259,7 +259,7 @@ func waitFileToBeRemoved() {
 		return
 	}
 	for fileExists(file.Name()) {
-		time.Sleep(time.Second * 5)
+		time.Sleep(time.Second * 60)
 		log.Info("Tests are suspended. Delete file to continue. " + fileMarker)
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add the ability to suspend the test if the test failed

**- How I did it**
If the test failed then will create the file marker and wait until the file exists 

**- How to verify it**
pass env.SUSPEND_TEST=true and false and checked it
**- Description for the changelog**
Test suit has a parameter needToStop with default value false. 
if needToStop true and test failed then will wait to file deletion 

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
