### PR TITLE
INS-2461: wait for expected minimock tests to happen before leaving

### DIFF
--- a/ledger/light/artifactmanager/handler_test.go
+++ b/ledger/light/artifactmanager/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/rand"
 	"testing"
+	"time"
 
 	"github.com/gojuno/minimock"
 	"github.com/stretchr/testify/assert"
@@ -617,6 +618,7 @@ func (s *handlerSuite) TestMessageHandler_HandleHotRecords() {
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), drop.Drop{Pulse: insolar.FirstPulseNumber, Hash: []byte{88}, JetID: jetID}, savedDrop)
 
+	mc.Wait(1*time.Minute)
 	pendingMock.MinimockFinish()
 }
 


### PR DESCRIPTION
test suite can start preping next test case when callback triggers and
runs suite.T() function that may result in a race
