### PR TITLE
NOISSUE: fix for race condition in flow contoller

### DIFF
--- a/insolar/flow/internal/thread/controller.go
+++ b/insolar/flow/internal/thread/controller.go
@@ -30,6 +30,9 @@ func NewController() *Controller {
 }
 
 func (c *Controller) Cancel() <-chan struct{} {
+	c.cancelMu.Lock()
+	defer c.cancelMu.Unlock()
+
 	return c.cancel
 }
 


### PR DESCRIPTION
In case when controller.Cancel is called on pulse change - it may take
broken data. Fix it with locking cancel mutex inside `.Cancel`.
