### PR TITLE
INS-1635: CM: don't call Stop() in Start() is not called yet

### DIFF
--- a/component/manager.go
+++ b/component/manager.go
@@ -194,7 +194,7 @@ func (m *Manager) Stop(ctx context.Context) error {
 	m.startStopLock.Lock()
 	defer m.startStopLock.Unlock()
 
-	if m.started == false {
+	if m.started {
 		glog().Debug("ComponentManager: components are not started. Skip stopping")
 		return nil
 	}

--- a/component/manager.go
+++ b/component/manager.go
@@ -194,7 +194,7 @@ func (m *Manager) Stop(ctx context.Context) error {
 	m.startStopLock.Lock()
 	defer m.startStopLock.Unlock()
 
-	if m.started {
+	if !m.started {
 		glog().Debug("ComponentManager: components are not started. Skip stopping")
 		return nil
 	}

--- a/component/manager_test.go
+++ b/component/manager_test.go
@@ -77,3 +77,38 @@ func TestComponentManager_Inject(t *testing.T) {
 	require.NoError(t, cm.Start(nil))
 	require.NoError(t, cm.Stop(nil))
 }
+
+type Component3 struct {
+	started bool
+	stopped bool
+}
+
+func (c *Component3) Start(ctx context.Context) error {
+	c.started = true
+	return nil
+}
+
+func (c *Component3) Stop(ctx context.Context) error {
+	c.stopped = true
+	return nil
+}
+
+func TestComponentManager_NoCallStopIfNoCallStart(t *testing.T) {
+	c := Component3{}
+	cm := Manager{}
+	cm.Inject(&c)
+	err := cm.Stop(context.Background())
+	require.NoError(t, err)
+	require.False(t, c.stopped)
+	require.False(t, c.started)
+
+	err = cm.Start(context.Background())
+	require.NoError(t, err)
+	require.False(t, c.stopped)
+	require.True(t, c.started)
+
+	err = cm.Stop(context.Background())
+	require.NoError(t, err)
+	require.True(t, c.stopped)
+	require.True(t, c.started)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Prevent call Stop() before Start() on component manager

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
