### PR TITLE
INS-2493: fix goroutines leak and data races in LR tests

### DIFF
--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -241,6 +241,7 @@ func initHandlers(lr *LogicRunner) error {
 		pubSub,
 		lr.innerFlowDispatcher.InnerSubscriber,
 	)
+
 	go func() {
 		if err := router.Run(); err != nil {
 			ctx := context.Background()

--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -241,7 +241,6 @@ func initHandlers(lr *LogicRunner) error {
 		pubSub,
 		lr.innerFlowDispatcher.InnerSubscriber,
 	)
-
 	go func() {
 		if err := router.Run(); err != nil {
 			ctx := context.Background()

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -93,8 +93,10 @@ func (suite *LogicRunnerCommonTestSuite) SetupLogicRunner() {
 func (suite *LogicRunnerCommonTestSuite) AfterTest(suiteName, testName string) {
 	suite.mc.Wait(time.Minute)
 	suite.mc.Finish()
-	suite.lr.Executors[insolar.MachineTypeBuiltin].(*testutils.MachineLogicExecutorMock).StopMock.Expect().Return(nil)
-	suite.lr.Stop(suite.ctx) // free resources before next test
+	if suite.lr.Executors[insolar.MachineTypeBuiltin] != nil {
+		suite.lr.Executors[insolar.MachineTypeBuiltin].(*testutils.MachineLogicExecutorMock).StopMock.Expect().Return(nil)
+		suite.lr.Stop(suite.ctx) // free resources before next test
+	}
 }
 
 type LogicRunnerTestSuite struct {

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -94,10 +94,15 @@ func (suite *LogicRunnerCommonTestSuite) SetupLogicRunner() {
 func (suite *LogicRunnerCommonTestSuite) AfterTest(suiteName, testName string) {
 	suite.mc.Wait(time.Minute)
 	suite.mc.Finish()
-	if suite.lr.Executors[insolar.MachineTypeBuiltin] != nil {
-		suite.lr.Executors[insolar.MachineTypeBuiltin].(*testutils.MachineLogicExecutorMock).StopMock.Expect().Return(nil)
-		suite.lr.Stop(suite.ctx) // free resources before next test
+	for _, e := range suite.lr.Executors {
+		if e == nil {
+			continue
+		}
+		// e.Stop() is about to be called in lr.Stop() method
+		e.(*testutils.MachineLogicExecutorMock).StopMock.Expect().Return(nil)
 	}
+	// free resources before next test
+	suite.lr.Stop(suite.ctx)
 }
 
 type LogicRunnerTestSuite struct {

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -93,6 +93,8 @@ func (suite *LogicRunnerCommonTestSuite) SetupLogicRunner() {
 func (suite *LogicRunnerCommonTestSuite) AfterTest(suiteName, testName string) {
 	suite.mc.Wait(time.Minute)
 	suite.mc.Finish()
+	suite.lr.Executors[insolar.MachineTypeBuiltin].(*testutils.MachineLogicExecutorMock).StopMock.Expect().Return(nil)
+	suite.lr.Stop(suite.ctx) // free resources before next test
 }
 
 type LogicRunnerTestSuite struct {
@@ -999,7 +1001,7 @@ func (suite *LogicRunnerTestSuite) TestCallMethodWithOnPulse() {
 				}
 
 				if test.when == whenIsAuthorized {
-					changePulse()
+					<-changePulse()
 					for pn == 100 {
 						time.Sleep(time.Millisecond)
 					}


### PR DESCRIPTION
```
$ time go test -failfast -race ./logicrunner/ -run 'TestLogicRunner/TestCallMethodWithOnPulse/pulse_change_in_CallMethod' -count 10000
ok  	github.com/insolar/insolar/logicrunner	201.612s

real	3m24.203s
user	8m6.812s
sys	0m28.378s
```