### PR TITLE
request should be stored next to object it belongs to

### DIFF
--- a/logicrunner/artifacts/client.go
+++ b/logicrunner/artifacts/client.go
@@ -92,7 +92,7 @@ func (m *client) RegisterRequest(
 	switch request.CallType {
 	case record.CTMethod:
 		recRef = request.Object
-	case record.CTSaveAsChild, record.CTSaveAsDelegate:
+	case record.CTSaveAsChild, record.CTSaveAsDelegate, record.CTGenesis:
 		hash := record.HashVirtual(m.PCS.ReferenceHasher(), virtRec)
 		recID := insolar.NewID(currentPN, hash)
 		recRef = insolar.NewReference(insolar.DomainID, *recID)

--- a/logicrunner/artifacts/client.go
+++ b/logicrunner/artifacts/client.go
@@ -87,9 +87,18 @@ func (m *client) RegisterRequest(
 	}
 
 	virtRec := record.Wrap(request)
-	hash := record.HashVirtual(m.PCS.ReferenceHasher(), virtRec)
-	recID := insolar.NewID(currentPN, hash)
-	recRef := insolar.NewReference(insolar.DomainID, *recID)
+
+	var recRef *insolar.Reference
+	switch request.CallType {
+	case record.CTMethod:
+		recRef = request.Object
+	case record.CTSaveAsChild, record.CTSaveAsDelegate:
+		hash := record.HashVirtual(m.PCS.ReferenceHasher(), virtRec)
+		recID := insolar.NewID(currentPN, hash)
+		recRef = insolar.NewReference(insolar.DomainID, *recID)
+	default:
+		return nil, errors.New("not supported call type "+ request.CallType.String())
+	}
 
 	id, err := m.setRecord(
 		ctx,
@@ -679,7 +688,7 @@ func (m *client) RegisterResult(
 	recid, err := m.setRecord(
 		ctx,
 		virtRec,
-		request,
+		obj,
 	)
 	return recid, err
 }


### PR DESCRIPTION
all pending requests should be tracked by object, requests should be
executed in order and object should be able to tell which one goes first
and which is last. results also go next to requests, so next to objects.
