### PR TITLE
NOISSUE: Mitigating integr tests problems until consensus is reworked

### DIFF
--- a/network/tests/suite_test.go
+++ b/network/tests/suite_test.go
@@ -89,13 +89,13 @@ var (
 )
 
 const (
-	pulseTimeMs  int32 = 5000
+	pulseTimeMs  int32 = 8000
 	reqTimeoutMs int32 = 2000
-	pulseDelta   int32 = 5
+	pulseDelta   int32 = 8
 
-	Phase1Timeout  float64 = 0.45
-	Phase2Timeout  float64 = 0.60
-	Phase21Timeout float64 = 0.75
+	Phase1Timeout  float64 = 0.30
+	Phase2Timeout  float64 = 0.50
+	Phase21Timeout float64 = 0.70
 	Phase3Timeout  float64 = 0.90
 )
 
@@ -452,7 +452,7 @@ func (p *PublisherMock) Close() error {
 func (s *testSuite) preInitNode(node *networkNode) {
 	t := s.T()
 	cfg := configuration.NewConfiguration()
-	cfg.Pulsar.PulseTime = pulseTimeMs // pulse 5 sec for faster tests
+	cfg.Pulsar.PulseTime = pulseTimeMs
 	cfg.Host.Transport.Address = node.host
 	cfg.Service.Skip = 5
 	cfg.Service.CacheDirectory = cacheDir + node.host


### PR DESCRIPTION
**- What I did**
Increased integration tests pulse duration to decrease frequency of tests failures. This is not a complete solution for flaky integration tests, only a temporary mitigation.
**- How to verify it**
Run integration tests
