### PR TITLE
INS-2515: account for pulse in hot data waiter

### DIFF
--- a/ledger/light/artifactmanager/middleware.go
+++ b/ledger/light/artifactmanager/middleware.go
@@ -180,7 +180,7 @@ func (m *middleware) waitForHotData(handler insolar.MessageHandler) insolar.Mess
 		}
 
 		jetID := jetFromContext(ctx)
-		err := m.jetWaiter.Wait(ctx, jetID)
+		err := m.jetWaiter.Wait(ctx, jetID, parcel.Pulse())
 		if err != nil {
 			return &reply.Error{ErrType: reply.ErrHotDataTimeout}, nil
 		}

--- a/ledger/light/hot/waiter_test.go
+++ b/ledger/light/hot/waiter_test.go
@@ -73,7 +73,7 @@ func TestHotDataWaiterConcrete_Wait_UnlockHotData(t *testing.T) {
 	// Act
 	go func() {
 		waitingStarted <- struct{}{}
-		err := hdwGetter().Wait(inslogger.TestContext(t), jetID)
+		err := hdwGetter().Wait(inslogger.TestContext(t), jetID, 124567)
 		require.Nil(t, err)
 		close(waitingFinished)
 	}()
@@ -118,7 +118,7 @@ func TestHotDataWaiterConcrete_Wait_ThrowTimeout(t *testing.T) {
 	// Act
 	go func() {
 		waitingStarted <- struct{}{}
-		err := hdwGetter().Wait(inslogger.TestContext(t), jetID)
+		err := hdwGetter().Wait(inslogger.TestContext(t), jetID, 124567)
 		require.NotNil(t, err)
 		require.Equal(t, insolar.ErrHotDataTimeout, err)
 		close(waitingFinished)
@@ -127,7 +127,7 @@ func TestHotDataWaiterConcrete_Wait_ThrowTimeout(t *testing.T) {
 	<-waitingStarted
 	time.Sleep(1 * time.Second)
 
-	hdwGetter().ThrowTimeout(inslogger.TestContext(t))
+	hdwGetter().ThrowTimeout(inslogger.TestContext(t), 1245678)
 
 	<-waitingFinished
 	require.Equal(t, 0, hdwLengthGetter())
@@ -160,14 +160,14 @@ func TestHotDataWaiterConcrete_Wait_ThrowTimeout_MultipleMembers(t *testing.T) {
 	// Act
 	go func() {
 		waitingStarted <- struct{}{}
-		err := hdwGetter().Wait(inslogger.TestContext(t), jetID)
+		err := hdwGetter().Wait(inslogger.TestContext(t), jetID, 124567)
 		require.NotNil(t, err)
 		require.Equal(t, insolar.ErrHotDataTimeout, err)
 		waitingFinished <- struct{}{}
 	}()
 	go func() {
 		waitingStarted <- struct{}{}
-		err := hdwGetter().Wait(inslogger.TestContext(t), secondJetID)
+		err := hdwGetter().Wait(inslogger.TestContext(t), secondJetID, 124567)
 		require.NotNil(t, err)
 		require.Equal(t, insolar.ErrHotDataTimeout, err)
 		waitingFinished <- struct{}{}
@@ -177,10 +177,21 @@ func TestHotDataWaiterConcrete_Wait_ThrowTimeout_MultipleMembers(t *testing.T) {
 	<-waitingStarted
 	time.Sleep(1 * time.Second)
 
-	hdwGetter().ThrowTimeout(inslogger.TestContext(t))
+	hdwGetter().ThrowTimeout(inslogger.TestContext(t), 1245678)
 
 	<-waitingFinished
 	<-waitingFinished
 
 	require.Equal(t, 0, hdwLengthGetter())
+}
+
+func TestHotDataWaiterConcrete_WaitOldPulse(t *testing.T) {
+	t.Parallel()
+
+	hdw := NewChannelWaiter()
+
+	jetID := testutils.RandomID()
+	hdw.ThrowTimeout(inslogger.TestContext(t), 1245678)
+	err := hdw.Wait(inslogger.TestContext(t), jetID, 124567)
+	require.NoError(t, err)
 }

--- a/ledger/light/proc/wait_jet.go
+++ b/ledger/light/proc/wait_jet.go
@@ -99,7 +99,7 @@ func NewWaitHot(j insolar.JetID, pn insolar.PulseNumber, rep chan<- bus.Reply) *
 }
 
 func (p *WaitHot) Proceed(ctx context.Context) error {
-	err := p.Dep.Waiter.Wait(ctx, insolar.ID(p.jetID))
+	err := p.Dep.Waiter.Wait(ctx, insolar.ID(p.jetID), p.pulse)
 	if err != nil {
 		p.replyTo <- bus.Reply{Reply: &reply.Error{ErrType: reply.ErrHotDataTimeout}}
 		return err

--- a/ledger/light/pulsemanager/pulsemanager.go
+++ b/ledger/light/pulsemanager/pulsemanager.go
@@ -626,7 +626,7 @@ func (m *PulseManager) prepareArtifactManagerMessageHandlerForNextPulse(ctx cont
 	ctx, span := instracer.StartSpan(ctx, "early.close")
 	defer span.End()
 
-	m.JetReleaser.ThrowTimeout(ctx)
+	m.JetReleaser.ThrowTimeout(ctx, newPulse.PulseNumber)
 }
 
 // Start starts pulse manager

--- a/testutils/jet_releaser_mock.go
+++ b/testutils/jet_releaser_mock.go
@@ -20,7 +20,7 @@ import (
 type JetReleaserMock struct {
 	t minimock.Tester
 
-	ThrowTimeoutFunc       func(p context.Context)
+	ThrowTimeoutFunc       func(p context.Context, p1 insolar.PulseNumber)
 	ThrowTimeoutCounter    uint64
 	ThrowTimeoutPreCounter uint64
 	ThrowTimeoutMock       mJetReleaserMockThrowTimeout
@@ -56,18 +56,19 @@ type JetReleaserMockThrowTimeoutExpectation struct {
 }
 
 type JetReleaserMockThrowTimeoutInput struct {
-	p context.Context
+	p  context.Context
+	p1 insolar.PulseNumber
 }
 
 //Expect specifies that invocation of JetReleaser.ThrowTimeout is expected from 1 to Infinity times
-func (m *mJetReleaserMockThrowTimeout) Expect(p context.Context) *mJetReleaserMockThrowTimeout {
+func (m *mJetReleaserMockThrowTimeout) Expect(p context.Context, p1 insolar.PulseNumber) *mJetReleaserMockThrowTimeout {
 	m.mock.ThrowTimeoutFunc = nil
 	m.expectationSeries = nil
 
 	if m.mainExpectation == nil {
 		m.mainExpectation = &JetReleaserMockThrowTimeoutExpectation{}
 	}
-	m.mainExpectation.input = &JetReleaserMockThrowTimeoutInput{p}
+	m.mainExpectation.input = &JetReleaserMockThrowTimeoutInput{p, p1}
 	return m
 }
 
@@ -84,18 +85,18 @@ func (m *mJetReleaserMockThrowTimeout) Return() *JetReleaserMock {
 }
 
 //ExpectOnce specifies that invocation of JetReleaser.ThrowTimeout is expected once
-func (m *mJetReleaserMockThrowTimeout) ExpectOnce(p context.Context) *JetReleaserMockThrowTimeoutExpectation {
+func (m *mJetReleaserMockThrowTimeout) ExpectOnce(p context.Context, p1 insolar.PulseNumber) *JetReleaserMockThrowTimeoutExpectation {
 	m.mock.ThrowTimeoutFunc = nil
 	m.mainExpectation = nil
 
 	expectation := &JetReleaserMockThrowTimeoutExpectation{}
-	expectation.input = &JetReleaserMockThrowTimeoutInput{p}
+	expectation.input = &JetReleaserMockThrowTimeoutInput{p, p1}
 	m.expectationSeries = append(m.expectationSeries, expectation)
 	return expectation
 }
 
 //Set uses given function f as a mock of JetReleaser.ThrowTimeout method
-func (m *mJetReleaserMockThrowTimeout) Set(f func(p context.Context)) *JetReleaserMock {
+func (m *mJetReleaserMockThrowTimeout) Set(f func(p context.Context, p1 insolar.PulseNumber)) *JetReleaserMock {
 	m.mainExpectation = nil
 	m.expectationSeries = nil
 
@@ -104,18 +105,18 @@ func (m *mJetReleaserMockThrowTimeout) Set(f func(p context.Context)) *JetReleas
 }
 
 //ThrowTimeout implements github.com/insolar/insolar/ledger/light/hot.JetReleaser interface
-func (m *JetReleaserMock) ThrowTimeout(p context.Context) {
+func (m *JetReleaserMock) ThrowTimeout(p context.Context, p1 insolar.PulseNumber) {
 	counter := atomic.AddUint64(&m.ThrowTimeoutPreCounter, 1)
 	defer atomic.AddUint64(&m.ThrowTimeoutCounter, 1)
 
 	if len(m.ThrowTimeoutMock.expectationSeries) > 0 {
 		if counter > uint64(len(m.ThrowTimeoutMock.expectationSeries)) {
-			m.t.Fatalf("Unexpected call to JetReleaserMock.ThrowTimeout. %v", p)
+			m.t.Fatalf("Unexpected call to JetReleaserMock.ThrowTimeout. %v %v", p, p1)
 			return
 		}
 
 		input := m.ThrowTimeoutMock.expectationSeries[counter-1].input
-		testify_assert.Equal(m.t, *input, JetReleaserMockThrowTimeoutInput{p}, "JetReleaser.ThrowTimeout got unexpected parameters")
+		testify_assert.Equal(m.t, *input, JetReleaserMockThrowTimeoutInput{p, p1}, "JetReleaser.ThrowTimeout got unexpected parameters")
 
 		return
 	}
@@ -124,18 +125,18 @@ func (m *JetReleaserMock) ThrowTimeout(p context.Context) {
 
 		input := m.ThrowTimeoutMock.mainExpectation.input
 		if input != nil {
-			testify_assert.Equal(m.t, *input, JetReleaserMockThrowTimeoutInput{p}, "JetReleaser.ThrowTimeout got unexpected parameters")
+			testify_assert.Equal(m.t, *input, JetReleaserMockThrowTimeoutInput{p, p1}, "JetReleaser.ThrowTimeout got unexpected parameters")
 		}
 
 		return
 	}
 
 	if m.ThrowTimeoutFunc == nil {
-		m.t.Fatalf("Unexpected call to JetReleaserMock.ThrowTimeout. %v", p)
+		m.t.Fatalf("Unexpected call to JetReleaserMock.ThrowTimeout. %v %v", p, p1)
 		return
 	}
 
-	m.ThrowTimeoutFunc(p)
+	m.ThrowTimeoutFunc(p, p1)
 }
 
 //ThrowTimeoutMinimockCounter returns a count of JetReleaserMock.ThrowTimeoutFunc invocations


### PR DESCRIPTION
a message can come close to the end of the current pulse, spend some
time figuring out jet and jet tree and then hang waiting for hot data
until next pulse. this happens when waiter for hot data was refreshed
as pulse has been changed while we were figuring out jet and jet tree.

we discussed this and decided that we wouldn't be saving hot data
history for older pulses. we just make hot data waiter PULSE aware and
make it relase waiter immediately if message is from older pulse.
