### PR TITLE
NOISSUE: added /server/internal/ to slow tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ ci_test_unit:
 
 .PHONY: ci_test_slow
 ci_test_slow:
-	CGO_ENABLED=1 go test $(TEST_ARGS) -json -v -tags slowtest ./logicrunner/ -count 1 | tee -a ci_test_unit.json
+	CGO_ENABLED=1 go test $(TEST_ARGS) -json -v -tags slowtest ./logicrunner/... ./server/internal/... -count 1 | tee -a ci_test_unit.json
 
 .PHONY: ci_test_func
 ci_test_func:

--- a/Makefile
+++ b/Makefile
@@ -217,3 +217,4 @@ generate-protobuf:
 
 regen-builtin: $(BININSGOCC)
 	$(BININSGOCC) regen-builtin
+

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ test_network_integration:
 
 .PHONY: test_slow
 test_slow:
-	CGO_ENABLED=1 go test $(TEST_ARGS) -tags slowtest ./logicrunner/
+	CGO_ENABLED=1 go test $(TEST_ARGS) -tags slowtest ./logicrunner/... ./server/internal/...
 
 .PHONY: test
 test: test_unit


### PR DESCRIPTION
Tests in /server/internal/ are tagged with `+build slowtest`. I've added them to `test_slow` and `ci_tests_slow` targets in Makefile.