### PR TITLE
INS-2550: fix missed db.Stop

### DIFF
--- a/internal/ledger/store/badger_test.go
+++ b/internal/ledger/store/badger_test.go
@@ -25,6 +25,8 @@ import (
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/insolar/insolar/instrumentation/inslogger"
 )
 
 type testBadgerKey struct {
@@ -43,11 +45,14 @@ func (k testBadgerKey) ID() []byte {
 func TestBadgerDB_Get(t *testing.T) {
 	t.Parallel()
 
+	ctx := inslogger.TestContext(t)
+
 	tmpdir, err := ioutil.TempDir("", "bdb-test-")
 	defer os.RemoveAll(tmpdir)
 	assert.NoError(t, err)
 
 	db, err := NewBadgerDB(tmpdir)
+	defer db.Stop(ctx)
 	require.NoError(t, err)
 
 	var (
@@ -69,11 +74,14 @@ func TestBadgerDB_Get(t *testing.T) {
 func TestBadgerDB_Set(t *testing.T) {
 	t.Parallel()
 
+	ctx := inslogger.TestContext(t)
+
 	tmpdir, err := ioutil.TempDir("", "bdb-test-")
 	defer os.RemoveAll(tmpdir)
 	assert.NoError(t, err)
 
 	db, err := NewBadgerDB(tmpdir)
+	defer db.Stop(ctx)
 	require.NoError(t, err)
 
 	var (

--- a/internal/ledger/store/db_cmp_test.go
+++ b/internal/ledger/store/db_cmp_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/insolar/insolar/instrumentation/inslogger"
 )
 
 type testKey struct {
@@ -44,10 +46,13 @@ func (k testKey) ID() []byte {
 func TestDB_Components(t *testing.T) {
 	t.Parallel()
 
+	ctx := inslogger.TestContext(t)
+
 	tmpdir, err := ioutil.TempDir("", "bdb-test-")
 	defer os.RemoveAll(tmpdir)
 	assert.NoError(t, err)
 	badger, err := NewBadgerDB(tmpdir)
+	defer badger.Stop(ctx)
 	require.NoError(t, err)
 
 	mock := NewMemoryMockDB()

--- a/network/storage/cloudhash_test.go
+++ b/network/storage/cloudhash_test.go
@@ -51,7 +51,6 @@
 package storage
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -59,6 +58,8 @@ import (
 	"github.com/insolar/insolar/component"
 	"github.com/insolar/insolar/configuration"
 	"github.com/insolar/insolar/insolar"
+	"github.com/insolar/insolar/instrumentation/inslogger"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -68,9 +69,10 @@ func TestCloudHashtStorage(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 	assert.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := inslogger.TestContext(t)
 	cm := component.NewManager(nil)
 	badgerDB, err := NewBadgerDB(configuration.ServiceNetwork{CacheDirectory: tmpdir})
+	defer badgerDB.Stop(ctx)
 	cs := NewCloudHashStorage()
 
 	cm.Register(badgerDB, cs)

--- a/network/storage/pulse_test.go
+++ b/network/storage/pulse_test.go
@@ -51,7 +51,6 @@
 package storage
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -59,6 +58,8 @@ import (
 	"github.com/insolar/insolar/component"
 	"github.com/insolar/insolar/configuration"
 	"github.com/insolar/insolar/insolar"
+	"github.com/insolar/insolar/instrumentation/inslogger"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -67,9 +68,10 @@ func TestNewPulseStorage(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 	assert.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := inslogger.TestContext(t)
 	cm := component.NewManager(nil)
 	badgerDB, err := NewBadgerDB(configuration.ServiceNetwork{CacheDirectory: tmpdir})
+	defer badgerDB.Stop(ctx)
 	ps := NewPulseStorage()
 
 	cm.Register(badgerDB, ps)

--- a/network/storage/snapshot_test.go
+++ b/network/storage/snapshot_test.go
@@ -51,7 +51,6 @@
 package storage
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -59,6 +58,7 @@ import (
 	"github.com/insolar/insolar/component"
 	"github.com/insolar/insolar/configuration"
 	"github.com/insolar/insolar/insolar"
+	"github.com/insolar/insolar/instrumentation/inslogger"
 	"github.com/insolar/insolar/network/node"
 	"github.com/insolar/insolar/platformpolicy"
 	"github.com/insolar/insolar/testutils"
@@ -70,9 +70,10 @@ func TestNewSnapshotStorage(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 	assert.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := inslogger.TestContext(t)
 	cm := component.NewManager(nil)
 	badgerDB, err := NewBadgerDB(configuration.ServiceNetwork{CacheDirectory: tmpdir})
+	defer badgerDB.Stop(ctx)
 	ss := NewSnapshotStorage()
 
 	cm.Register(badgerDB, ss)

--- a/network/storage/storage_test.go
+++ b/network/storage/storage_test.go
@@ -58,6 +58,8 @@ import (
 	"github.com/dgraph-io/badger"
 	fuzz "github.com/google/gofuzz"
 	"github.com/insolar/insolar/configuration"
+	"github.com/insolar/insolar/instrumentation/inslogger"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -78,11 +80,14 @@ func (k testBadgerKey) ID() []byte {
 func TestBadgerDB_Get(t *testing.T) {
 	t.Parallel()
 
+	ctx := inslogger.TestContext(t)
+
 	tmpdir, err := ioutil.TempDir("", "bdb-test-")
 	defer os.RemoveAll(tmpdir)
 	assert.NoError(t, err)
 
 	db, err := NewBadgerDB(configuration.ServiceNetwork{CacheDirectory: tmpdir})
+	defer db.Stop(ctx)
 	require.NoError(t, err)
 
 	var (
@@ -104,11 +109,14 @@ func TestBadgerDB_Get(t *testing.T) {
 func TestBadgerDB_Set(t *testing.T) {
 	t.Parallel()
 
+	ctx := inslogger.TestContext(t)
+
 	tmpdir, err := ioutil.TempDir("", "bdb-test-")
 	defer os.RemoveAll(tmpdir)
 	assert.NoError(t, err)
 
 	db, err := NewBadgerDB(configuration.ServiceNetwork{CacheDirectory: tmpdir})
+	defer db.Stop(ctx)
 	require.NoError(t, err)
 
 	var (

--- a/server/internal/heavy/components.go
+++ b/server/internal/heavy/components.go
@@ -267,6 +267,7 @@ func newComponents(ctx context.Context, cfg configuration.Configuration, genesis
 	}
 
 	c.cmp.Inject(
+		DB,
 		WmBus,
 		Handler,
 		PulseManager,


### PR DESCRIPTION
**- What I did**
fix INS-2550
**- How I did it**
Added missed db.Stop call
**- How to verify it**
```shell
go test -timeout 1200s -v ./internal/ledger/store -run "TestBadgerDB_Set" -count 1000 -failfast -race
```
