### PR TITLE
GetExecutionState returns ES only if it exists or NIL

### DIFF
--- a/logicrunner/accessors.go
+++ b/logicrunner/accessors.go
@@ -73,6 +73,17 @@ func (lr *LogicRunner) MustObjectState(ref Ref) *ObjectState {
 	return res
 }
 
+func (lr *LogicRunner) GetExecutionState(ref Ref) *ExecutionState {
+	os := lr.GetObjectState(ref)
+	if os == nil {
+		return nil
+	}
+
+	os.Lock()
+	defer os.Unlock()
+	return os.ExecutionState
+}
+
 func (lr *LogicRunner) pulse(ctx context.Context) *insolar.Pulse {
 	pulse, err := lr.PulseAccessor.Latest(ctx)
 	if err != nil {

--- a/logicrunner/handle_ledgerpendingrequest.go
+++ b/logicrunner/handle_ledgerpendingrequest.go
@@ -36,7 +36,7 @@ func (p *GetLedgerPendingRequest) Present(ctx context.Context, f flow.Flow) erro
 	defer span.End()
 
 	lr := p.dep.lr
-	es := lr.getExecStateFromRef(ctx, p.Message.Payload)
+	es := lr.GetExecutionState(Ref{}.FromSlice(p.Message.Payload))
 	if es == nil {
 		return nil
 	}

--- a/logicrunner/handle_processqueue.go
+++ b/logicrunner/handle_processqueue.go
@@ -42,7 +42,7 @@ func (p *ProcessExecutionQueue) Present(ctx context.Context, f flow.Flow) error 
 	inslogger.FromContext(ctx).Debug("ProcessExecutionQueue")
 
 	lr := p.dep.lr
-	es := lr.getExecStateFromRef(ctx, p.Message.Payload)
+	es := lr.GetExecutionState(Ref{}.FromSlice(p.Message.Payload))
 	if es == nil {
 		return nil
 	}

--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -491,23 +491,6 @@ func (lr *LogicRunner) executeOrValidate(
 	}()
 }
 
-func (lr *LogicRunner) getExecStateFromRef(ctx context.Context, rawRef []byte) *ExecutionState {
-	ref := Ref{}.FromSlice(rawRef)
-
-	// TODO: we should stop processing here if 'ref' doesn't exist. Made UpsertObjectState return error if so?
-	os := lr.UpsertObjectState(ref)
-
-	os.Lock()
-	defer os.Unlock()
-	if os.ExecutionState == nil {
-		inslogger.FromContext(ctx).Info("[ ProcessExecutionQueue ] got not existing reference. It's strange. Ref: ", ref.String())
-		return nil
-	}
-	es := os.ExecutionState
-
-	return es
-}
-
 func (lr *LogicRunner) unsafeGetLedgerPendingRequest(ctx context.Context, es *ExecutionState) *insolar.Reference {
 	es.Lock()
 	if es.LedgerQueueElement != nil || !es.LedgerHasMoreRequests {


### PR DESCRIPTION
* doesn't create empty ObjectState what fixes a TODO
* placed in correct place next to other accessors
* keep deserializing concern out of accessor method, do it in caller
