### PR TITLE
INS-2526: more timeout for test

### DIFF
--- a/pulsar/pulsar_integration_test.go
+++ b/pulsar/pulsar_integration_test.go
@@ -167,7 +167,7 @@ func TestPulsar_SendPulseToNode(t *testing.T) {
 	}()
 
 	// Assert
-	pulseDistributor.MinimockWait(100 * time.Millisecond)
+	pulseDistributor.MinimockWait(1 * time.Second)
 	require.Equal(t, 1, int(pulseDistributor.DistributeCounter))
 
 	defer newPulsar.StopServer(ctx)

--- a/pulsar/pulsar_integration_test.go
+++ b/pulsar/pulsar_integration_test.go
@@ -167,7 +167,7 @@ func TestPulsar_SendPulseToNode(t *testing.T) {
 	}()
 
 	// Assert
-	pulseDistributor.MinimockWait(1 * time.Second)
+	pulseDistributor.MinimockWait(1 * time.Minute)
 	require.Equal(t, 1, int(pulseDistributor.DistributeCounter))
 
 	defer newPulsar.StopServer(ctx)


### PR DESCRIPTION

**- What I did**
`pulseDistributor.MinimockWait(1 * time.Second)` instead of `pulseDistributor.MinimockWait(100 * time.Millisecond)` 