### PR TITLE
INS-2593: move preprocessor tests under slowtest tag

### DIFF
--- a/logicrunner/preprocessor/main_test.go
+++ b/logicrunner/preprocessor/main_test.go
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+// +build slowtest
+
 package preprocessor
 
 import (

--- a/logicrunner/preprocessor/real_contracts_test.go
+++ b/logicrunner/preprocessor/real_contracts_test.go
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+// +build slowtest
+
 package preprocessor
 
 import (


### PR DESCRIPTION
Moved `logicrunner/preprocessor/main_test.go` and `logicrunner/preprocessor/real_contracts_test.go` under `+build slowtest` build tag.