### PR TITLE
NOISSUE: dont set traceid for net resp

### DIFF
--- a/network/servicenetwork/servicenetwork.go
+++ b/network/servicenetwork/servicenetwork.go
@@ -473,8 +473,10 @@ func (n *ServiceNetwork) processIncoming(ctx context.Context, args []byte) ([]by
 		logger.Error(err)
 		return nil, err
 	}
-	ctx = inslogger.ContextWithTrace(ctx, msg.Metadata.Get(bus.MetaTraceID))
 	logger = inslogger.FromContext(ctx)
+	if inslogger.TraceID(ctx) != msg.Metadata.Get(bus.MetaTraceID) {
+		logger.Errorf("traceID from context (%s) is different from traceID from message Metadata (%s)", inslogger.TraceID(ctx), msg.Metadata.Get(bus.MetaTraceID))
+	}
 	// TODO: check pulse here
 
 	msgType, err := payload.UnmarshalTypeFromMeta(msg.Payload)


### PR DESCRIPTION
**- What I did**
Stop setting traceID from response message to context, i.e. network already done it.

**- How to verify it**
Run bench and check for logs