### PR TITLE
INS-2660: send side effect and result record in one message

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -117,11 +117,6 @@ func (s *ContractService) CallConstructor(r *http.Request, args *CallConstructor
 		return errors.Wrap(err, "can't get protoRef")
 	}
 
-	domain, err := insolar.NewReferenceFromBase58("4K3NiGuqYGqKPnYp6XeGd2kdN4P9veL6rYcWkLKWXZCu.7ZQboaH24PH42sqZKUvoa7UBrpuuubRtShp6CKNuWGZa")
-	if err != nil {
-		return errors.Wrap(err, "can't get domain reference")
-	}
-
 	base := testutils.RandomRef()
 
 	contractID, err := s.runner.ArtifactManager.RegisterRequest(
@@ -144,7 +139,6 @@ func (s *ContractService) CallConstructor(r *http.Request, args *CallConstructor
 
 	_, err = s.runner.ArtifactManager.ActivateObject(
 		ctx,
-		*domain,
 		objectRef,
 		insolar.GenesisRecord.Ref(),
 		*protoRef,

--- a/insolar/message/ledger.go
+++ b/insolar/message/ledger.go
@@ -143,9 +143,10 @@ func (*GetDelegate) Type() insolar.MessageType {
 type UpdateObject struct {
 	ledgerMessage
 
-	Record []byte
-	Object insolar.Reference
-	Memory []byte
+	Record       []byte
+	ResultRecord []byte
+	Object       insolar.Reference
+	Memory       []byte
 }
 
 // AllowedSenderObjectAndRole implements interface method

--- a/ledger/light/artifactmanager/handler.go
+++ b/ledger/light/artifactmanager/handler.go
@@ -180,6 +180,7 @@ func NewMessageHandler(
 			p.Dep.LifelineStateModifier = h.LifelineStateModifier
 			p.Dep.LifelineIndex = h.LifelineIndex
 			p.Dep.WriteAccessor = h.WriteAccessor
+			p.Dep.PendingModifier = h.PendingModifier
 		},
 		GetChildren: func(p *proc.GetChildren) {
 			p.Dep.Coordinator = h.JetCoordinator

--- a/ledger/light/proc/update_object.go
+++ b/ledger/light/proc/update_object.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/flow"
 	"github.com/insolar/insolar/insolar/flow/bus"
@@ -32,7 +34,6 @@ import (
 	"github.com/insolar/insolar/ledger/light/hot"
 	"github.com/insolar/insolar/ledger/light/recentstorage"
 	"github.com/insolar/insolar/ledger/object"
-	"github.com/pkg/errors"
 )
 
 type UpdateObject struct {
@@ -52,6 +53,7 @@ type UpdateObject struct {
 		LifelineIndex         object.LifelineIndex
 		LifelineStateModifier object.LifelineStateModifier
 		WriteAccessor         hot.WriteAccessor
+		PendingModifier       object.PendingModifier
 	}
 }
 
@@ -186,6 +188,11 @@ func (p *UpdateObject) handle(ctx context.Context) bus.Reply {
 
 	logger.WithField("state", idx.LatestState.DebugString()).Debug("saved object")
 
+	_, err = p.recordResult(ctx)
+	if err != nil {
+		return bus.Reply{Err: errors.Wrap(err, "failed to record result")}
+	}
+
 	rep := reply.Object{
 		Head:         p.Message.Object,
 		State:        *idx.LatestState,
@@ -223,6 +230,52 @@ func (p *UpdateObject) saveIndexFromHeavy(
 		return object.Lifeline{}, errors.Wrap(err, "failed to save")
 	}
 	return idx, nil
+}
+
+func (p *UpdateObject) recordResult(ctx context.Context) (*insolar.ID, error) {
+	virtRec := record.Virtual{}
+	err := virtRec.Unmarshal(p.Message.ResultRecord)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't deserialize record")
+	}
+
+	hash := record.HashVirtual(p.Dep.PCS.ReferenceHasher(), virtRec)
+	id := insolar.NewID(p.PulseNumber, hash)
+	rec := record.Material{
+		Virtual: &virtRec,
+		JetID:   p.JetID,
+	}
+
+	err = p.Dep.RecordModifier.Set(ctx, *id, rec)
+
+	if err == object.ErrOverride {
+		inslogger.FromContext(ctx).WithField("type", fmt.Sprintf("%T", virtRec)).Warn("set record override")
+	} else if err != nil {
+		return nil, errors.Wrap(err, "can't save record into storage")
+	}
+	err = p.closePending(ctx, *id, &virtRec)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't close Pending")
+	}
+
+	return id, nil
+}
+
+func (p *UpdateObject) closePending(ctx context.Context, id insolar.ID, virtRec *record.Virtual) error {
+	concrete := record.Unwrap(virtRec)
+	switch r := concrete.(type) {
+	case *record.Result:
+		recentStorage := p.Dep.RecentStorageProvider.GetPendingStorage(ctx, insolar.ID(p.JetID))
+		recentStorage.RemovePendingRequest(ctx, r.Object, *r.Request.Record())
+
+		err := p.Dep.PendingModifier.SetResult(ctx, p.PulseNumber, r.Object, id, *r)
+		if err != nil {
+			return errors.Wrap(err, "can't save result into filament-index")
+		}
+	default:
+		return errors.New(fmt.Sprintf("unexpected virtual record of type %T", r))
+	}
+	return nil
 }
 
 func validateState(old record.StateID, new record.StateID) error {

--- a/ledger/light/proc/update_object_test.go
+++ b/ledger/light/proc/update_object_test.go
@@ -70,6 +70,9 @@ func TestMessageHandler_HandleUpdateObject_FetchesIndexFromHeavy(t *testing.T) {
 	provideMock := recentstorage.NewProviderMock(t)
 	provideMock.GetPendingStorageMock.Return(pendingMock)
 
+	pendingModifierMock := object.NewPendingModifierMock(t)
+	pendingModifierMock.SetResultMock.Return(nil)
+
 	mb := testutils.NewMessageBusMock(t)
 	mb.MustRegisterMock.Return()
 	jc := jet.NewCoordinatorMock(t)
@@ -92,13 +95,22 @@ func TestMessageHandler_HandleUpdateObject_FetchesIndexFromHeavy(t *testing.T) {
 	amendRecord := record.Amend{
 		PrevState: *objIndex.LatestState,
 	}
-	virtAmend := record.Wrap(amendRecord)
-	data, err := virtAmend.Marshal()
+	amendVirt := record.Wrap(amendRecord)
+	amendData, err := amendVirt.Marshal()
+	require.NoError(t, err)
+
+	objectRef := genRandomRef(0)
+	resultRecord := record.Result{
+		Object: *objectRef.Record(),
+	}
+	resultVirt := record.Wrap(resultRecord)
+	resultData, err := resultVirt.Marshal()
 	require.NoError(t, err)
 
 	msg := message.UpdateObject{
-		Record: data,
-		Object: *genRandomRef(0),
+		Record: amendData,
+		ResultRecord: resultData,
+		Object: *objectRef,
 	}
 
 	mb.SendFunc = func(c context.Context, gm insolar.Message, o *insolar.MessageSendOptions) (r insolar.Reply, r1 error) {
@@ -129,6 +141,8 @@ func TestMessageHandler_HandleUpdateObject_FetchesIndexFromHeavy(t *testing.T) {
 	updateObject.Dep.RecordModifier = recordStorage
 	updateObject.Dep.LifelineStateModifier = indexMemoryStor
 	updateObject.Dep.WriteAccessor = writeManagerMock
+	updateObject.Dep.RecentStorageProvider = provideMock
+	updateObject.Dep.PendingModifier = pendingModifierMock
 
 	rep := updateObject.handle(ctx)
 	require.NoError(t, rep.Err)
@@ -152,6 +166,9 @@ func TestMessageHandler_HandleUpdateObject_UpdateIndexState(t *testing.T) {
 	provideMock := recentstorage.NewProviderMock(t)
 	provideMock.GetPendingStorageMock.Return(pendingMock)
 
+	pendingModifierMock := object.NewPendingModifierMock(t)
+	pendingModifierMock.SetResultMock.Return(nil)
+
 	writeManagerMock := hot.NewWriteAccessorMock(t)
 	writeManagerMock.BeginFunc = func(context.Context, insolar.PulseNumber) (func(), error) {
 		return func() {}, nil
@@ -174,13 +191,22 @@ func TestMessageHandler_HandleUpdateObject_UpdateIndexState(t *testing.T) {
 	amendRecord := record.Amend{
 		PrevState: *objIndex.LatestState,
 	}
-	virtAmend := record.Wrap(amendRecord)
-	data, err := virtAmend.Marshal()
+	amendVirt := record.Wrap(amendRecord)
+	amendData, err := amendVirt.Marshal()
+	require.NoError(t, err)
+
+	objectRef := genRandomRef(0)
+	resultRecord := record.Result{
+		Object: *objectRef.Record(),
+	}
+	resultVirt := record.Wrap(resultRecord)
+	resultData, err := resultVirt.Marshal()
 	require.NoError(t, err)
 
 	msg := message.UpdateObject{
-		Record: data,
-		Object: *genRandomRef(0),
+		Record: amendData,
+		ResultRecord: resultData,
+		Object: *objectRef,
 	}
 	ctx := context.Background()
 	err = indexMemoryStor.Set(ctx, insolar.FirstPulseNumber, *msg.Object.Record(), objIndex)
@@ -199,6 +225,8 @@ func TestMessageHandler_HandleUpdateObject_UpdateIndexState(t *testing.T) {
 	updateObject.Dep.RecordModifier = recordStorage
 	updateObject.Dep.LifelineStateModifier = indexMemoryStor
 	updateObject.Dep.WriteAccessor = writeManagerMock
+	updateObject.Dep.RecentStorageProvider = provideMock
+	updateObject.Dep.PendingModifier = pendingModifierMock
 
 	rep := updateObject.handle(ctx)
 	require.NoError(t, rep.Err)

--- a/logicrunner/artifacts/artifacts.go
+++ b/logicrunner/artifacts/artifacts.go
@@ -66,11 +66,6 @@ type Client interface {
 	// During iteration children refs will be fetched from remote source (parent object).
 	GetChildren(ctx context.Context, parent insolar.Reference, pulse *insolar.PulseNumber) (RefIterator, error)
 
-	// DeclareType creates new type record in storage.
-	//
-	// Type is a contract interface. It contains one method signature.
-	DeclareType(ctx context.Context, domain, request insolar.Reference, typeDec []byte) (*insolar.ID, error)
-
 	// DeployCode creates new code record in storage.
 	//
 	// Code records are used to activate prototype.
@@ -82,7 +77,7 @@ type Client interface {
 	// Request reference will be this object's identifier and referred as "object head".
 	ActivatePrototype(
 		ctx context.Context,
-		domain, request, parent, code insolar.Reference,
+		request, parent, code insolar.Reference,
 		memory []byte,
 	) (ObjectDescriptor, error)
 
@@ -92,21 +87,9 @@ type Client interface {
 	// Request reference will be this object's identifier and referred as "object head".
 	ActivateObject(
 		ctx context.Context,
-		domain, request, parent, prototype insolar.Reference,
+		request, parent, prototype insolar.Reference,
 		asDelegate bool,
 		memory []byte,
-	) (ObjectDescriptor, error)
-
-	// UpdatePrototype creates amend object record in storage. Provided reference should be a reference to the head of
-	// the prototype. Provided memory well be the new object memory.
-	//
-	// Returned reference will be the latest object state (exact) reference.
-	UpdatePrototype(
-		ctx context.Context,
-		domain, request insolar.Reference,
-		obj ObjectDescriptor,
-		memory []byte,
-		code *insolar.Reference,
 	) (ObjectDescriptor, error)
 
 	// UpdateObject creates amend object record in storage. Provided reference should be a reference to the head of the
@@ -115,16 +98,22 @@ type Client interface {
 	// Returned reference will be the latest object state (exact) reference.
 	UpdateObject(
 		ctx context.Context,
-		domain, request insolar.Reference,
+		request insolar.Reference,
 		obj ObjectDescriptor,
 		memory []byte,
+		result []byte,
 	) (ObjectDescriptor, error)
 
 	// DeactivateObject creates deactivate object record in storage. Provided reference should be a reference to the head
 	// of the object. If object is already deactivated, an error should be returned.
 	//
 	// Deactivated object cannot be changed.
-	DeactivateObject(ctx context.Context, domain, request insolar.Reference, obj ObjectDescriptor) (*insolar.ID, error)
+	DeactivateObject(
+		ctx context.Context,
+		request insolar.Reference,
+		obj ObjectDescriptor,
+		result []byte,
+	) (*insolar.ID, error)
 
 	// State returns hash state for artifact manager.
 	State() ([]byte, error)

--- a/logicrunner/artifacts/client.go
+++ b/logicrunner/artifacts/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
+
 	"github.com/insolar/insolar/insolar/bus"
 	"github.com/insolar/insolar/insolar/payload"
 	"github.com/insolar/insolar/insolar/pulse"
@@ -550,39 +551,6 @@ func (m *client) GetChildren(
 	return iter, err
 }
 
-// DeclareType creates new type record in storage.
-//
-// Type is a contract interface. It contains one method signature.
-func (m *client) DeclareType(
-	ctx context.Context, domain, request insolar.Reference, typeDec []byte,
-) (*insolar.ID, error) {
-	var err error
-	ctx, span := instracer.StartSpan(ctx, "artifactmanager.DeclareType")
-	instrumenter := instrument(ctx, "DeclareType").err(&err)
-	defer func() {
-		if err != nil {
-			span.AddAttributes(trace.StringAttribute("error", err.Error()))
-		}
-		span.End()
-		instrumenter.end()
-	}()
-
-	typeRec := record.Type{
-		Domain:          domain,
-		Request:         request,
-		TypeDeclaration: typeDec,
-	}
-	virtRec := record.Wrap(typeRec)
-
-	recid, err := m.setRecord(
-		ctx,
-		virtRec,
-		request,
-	)
-
-	return recid, err
-}
-
 // DeployCode creates new code record in storage.
 //
 // CodeRef records are used to activate prototype or as migration code for an object.
@@ -667,7 +635,7 @@ func (m *client) DeployCode(
 // Request reference will be this object's identifier and referred as "object head".
 func (m *client) ActivatePrototype(
 	ctx context.Context,
-	domain, object, parent, code insolar.Reference,
+	object, parent, code insolar.Reference,
 	memory []byte,
 ) (ObjectDescriptor, error) {
 	var err error
@@ -680,7 +648,7 @@ func (m *client) ActivatePrototype(
 		span.End()
 		instrumenter.end()
 	}()
-	desc, err := m.activateObject(ctx, domain, object, code, true, parent, false, memory)
+	desc, err := m.activateObject(ctx, object, code, true, parent, false, memory)
 	return desc, err
 }
 
@@ -690,7 +658,7 @@ func (m *client) ActivatePrototype(
 // Request reference will be this object's identifier and referred as "object head".
 func (m *client) ActivateObject(
 	ctx context.Context,
-	domain, object, parent, prototype insolar.Reference,
+	object, parent, prototype insolar.Reference,
 	asDelegate bool,
 	memory []byte,
 ) (ObjectDescriptor, error) {
@@ -704,7 +672,7 @@ func (m *client) ActivateObject(
 		span.End()
 		instrumenter.end()
 	}()
-	desc, err := m.activateObject(ctx, domain, object, prototype, false, parent, asDelegate, memory)
+	desc, err := m.activateObject(ctx, object, prototype, false, parent, asDelegate, memory)
 	return desc, err
 }
 
@@ -713,7 +681,7 @@ func (m *client) ActivateObject(
 //
 // Deactivated object cannot be changed.
 func (m *client) DeactivateObject(
-	ctx context.Context, domain, request insolar.Reference, obj ObjectDescriptor,
+	ctx context.Context, request insolar.Reference, obj ObjectDescriptor, result []byte,
 ) (*insolar.ID, error) {
 	var err error
 	ctx, span := instracer.StartSpan(ctx, "artifactmanager.DeactivateObject")
@@ -727,15 +695,19 @@ func (m *client) DeactivateObject(
 	}()
 
 	deactivate := record.Deactivate{
-		Domain:    domain,
 		Request:   request,
 		PrevState: *obj.StateID(),
 	}
-	virtRec := record.Wrap(deactivate)
+	resultRecord := record.Result{
+		Object:  *obj.HeadRef().Record(),
+		Request: request,
+		Payload: result,
+	}
 
 	desc, err := m.sendUpdateObject(
 		ctx,
-		virtRec,
+		record.Wrap(deactivate),
+		record.Wrap(resultRecord),
 		*obj.HeadRef(),
 		nil,
 	)
@@ -745,45 +717,16 @@ func (m *client) DeactivateObject(
 	return &desc.State, nil
 }
 
-// UpdatePrototype creates amend object record in storage. Provided reference should be a reference to the head of the
-// prototype. Provided memory well be the new object memory.
-//
-// Returned reference will be the latest object state (exact) reference.
-func (m *client) UpdatePrototype(
-	ctx context.Context,
-	domain, request insolar.Reference,
-	object ObjectDescriptor,
-	memory []byte,
-	code *insolar.Reference,
-) (ObjectDescriptor, error) {
-	var err error
-	ctx, span := instracer.StartSpan(ctx, "artifactmanager.UpdatePrototype")
-	instrumenter := instrument(ctx, "UpdatePrototype").err(&err)
-	defer func() {
-		if err != nil {
-			span.AddAttributes(trace.StringAttribute("error", err.Error()))
-		}
-		span.End()
-		instrumenter.end()
-	}()
-
-	if !object.IsPrototype() {
-		err = errors.New("object is not a prototype")
-		return nil, err
-	}
-	desc, err := m.updateObject(ctx, domain, request, object, code, memory)
-	return desc, err
-}
-
 // UpdateObject creates amend object record in storage. Provided reference should be a reference to the head of the
 // object. Provided memory well be the new object memory.
 //
 // Returned reference will be the latest object state (exact) reference.
 func (m *client) UpdateObject(
 	ctx context.Context,
-	domain, request insolar.Reference,
+	request insolar.Reference,
 	object ObjectDescriptor,
 	memory []byte,
+	result []byte,
 ) (ObjectDescriptor, error) {
 	var err error
 	ctx, span := instracer.StartSpan(ctx, "artifactmanager.UpdateObject")
@@ -800,7 +743,7 @@ func (m *client) UpdateObject(
 		err = errors.New("object is not an instance")
 		return nil, err
 	}
-	desc, err := m.updateObject(ctx, domain, request, object, nil, memory)
+	desc, err := m.updateObject(ctx, request, object, memory, result)
 	return desc, err
 }
 
@@ -884,7 +827,6 @@ func (m *client) pulse(ctx context.Context) (pn insolar.PulseNumber, err error) 
 
 func (m *client) activateObject(
 	ctx context.Context,
-	domain insolar.Reference,
 	obj insolar.Reference,
 	prototype insolar.Reference,
 	isPrototype bool,
@@ -902,7 +844,6 @@ func (m *client) activateObject(
 	}
 
 	activate := record.Activate{
-		Domain:      domain,
 		Request:     obj,
 		Memory:      *object.CalculateIDForBlob(m.PCS, currentPN, memory),
 		Image:       prototype,
@@ -910,11 +851,16 @@ func (m *client) activateObject(
 		Parent:      parent,
 		IsDelegate:  asDelegate,
 	}
-	virtRec := record.Wrap(activate)
+
+	result := record.Result{
+		Object:  *obj.Record(),
+		Request: obj,
+	}
 
 	o, err := m.sendUpdateObject(
 		ctx,
-		virtRec,
+		record.Wrap(activate),
+		record.Wrap(result),
 		obj,
 		memory,
 	)
@@ -957,21 +903,17 @@ func (m *client) activateObject(
 
 func (m *client) updateObject(
 	ctx context.Context,
-	domain, request insolar.Reference,
+	request insolar.Reference,
 	obj ObjectDescriptor,
-	code *insolar.Reference,
 	memory []byte,
+	result []byte,
 ) (ObjectDescriptor, error) {
 	var (
 		image *insolar.Reference
 		err   error
 	)
 	if obj.IsPrototype() {
-		if code != nil {
-			image = code
-		} else {
-			image, err = obj.Code()
-		}
+		image, err = obj.Code()
 	} else {
 		image, err = obj.Prototype()
 	}
@@ -980,17 +922,22 @@ func (m *client) updateObject(
 	}
 
 	amend := record.Amend{
-		Domain:      domain,
 		Request:     request,
 		Image:       *image,
 		IsPrototype: obj.IsPrototype(),
 		PrevState:   *obj.StateID(),
 	}
-	virtRec := record.Wrap(amend)
+
+	resultRecord := record.Result{
+		Object:  *obj.HeadRef().Record(),
+		Request: request,
+		Payload: result,
+	}
 
 	o, err := m.sendUpdateObject(
 		ctx,
-		virtRec,
+		record.Wrap(amend),
+		record.Wrap(resultRecord),
 		*obj.HeadRef(),
 		memory,
 	)
@@ -1074,11 +1021,16 @@ func (m *client) setBlob(
 
 func (m *client) sendUpdateObject(
 	ctx context.Context,
-	rec record.Virtual,
+	objRec record.Virtual,
+	resRec record.Virtual,
 	obj insolar.Reference,
 	memory []byte,
 ) (*reply.Object, error) {
-	data, err := rec.Marshal()
+	objRecData, err := objRec.Marshal()
+	if err != nil {
+		return nil, errors.Wrap(err, "setRecord: can't serialize record")
+	}
+	resRecData, err := resRec.Marshal()
 	if err != nil {
 		return nil, errors.Wrap(err, "setRecord: can't serialize record")
 	}
@@ -1091,9 +1043,10 @@ func (m *client) sendUpdateObject(
 	genericReply, err := sender(
 		ctx,
 		&message.UpdateObject{
-			Record: data,
-			Object: obj,
-			Memory: memory,
+			Record:       objRecData,
+			ResultRecord: resRecData,
+			Object:       obj,
+			Memory:       memory,
 		}, nil)
 
 	if err != nil {

--- a/logicrunner/artifacts/client_mock.go
+++ b/logicrunner/artifacts/client_mock.go
@@ -21,25 +21,20 @@ import (
 type ClientMock struct {
 	t minimock.Tester
 
-	ActivateObjectFunc       func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 insolar.Reference, p5 bool, p6 []byte) (r ObjectDescriptor, r1 error)
+	ActivateObjectFunc       func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 bool, p5 []byte) (r ObjectDescriptor, r1 error)
 	ActivateObjectCounter    uint64
 	ActivateObjectPreCounter uint64
 	ActivateObjectMock       mClientMockActivateObject
 
-	ActivatePrototypeFunc       func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 insolar.Reference, p5 []byte) (r ObjectDescriptor, r1 error)
+	ActivatePrototypeFunc       func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 []byte) (r ObjectDescriptor, r1 error)
 	ActivatePrototypeCounter    uint64
 	ActivatePrototypePreCounter uint64
 	ActivatePrototypeMock       mClientMockActivatePrototype
 
-	DeactivateObjectFunc       func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor) (r *insolar.ID, r1 error)
+	DeactivateObjectFunc       func(p context.Context, p1 insolar.Reference, p2 ObjectDescriptor, p3 []byte) (r *insolar.ID, r1 error)
 	DeactivateObjectCounter    uint64
 	DeactivateObjectPreCounter uint64
 	DeactivateObjectMock       mClientMockDeactivateObject
-
-	DeclareTypeFunc       func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 []byte) (r *insolar.ID, r1 error)
-	DeclareTypeCounter    uint64
-	DeclareTypePreCounter uint64
-	DeclareTypeMock       mClientMockDeclareType
 
 	DeployCodeFunc       func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 []byte, p4 insolar.MachineType) (r *insolar.ID, r1 error)
 	DeployCodeCounter    uint64
@@ -111,15 +106,10 @@ type ClientMock struct {
 	StatePreCounter uint64
 	StateMock       mClientMockState
 
-	UpdateObjectFunc       func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor, p4 []byte) (r ObjectDescriptor, r1 error)
+	UpdateObjectFunc       func(p context.Context, p1 insolar.Reference, p2 ObjectDescriptor, p3 []byte, p4 []byte) (r ObjectDescriptor, r1 error)
 	UpdateObjectCounter    uint64
 	UpdateObjectPreCounter uint64
 	UpdateObjectMock       mClientMockUpdateObject
-
-	UpdatePrototypeFunc       func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor, p4 []byte, p5 *insolar.Reference) (r ObjectDescriptor, r1 error)
-	UpdatePrototypeCounter    uint64
-	UpdatePrototypePreCounter uint64
-	UpdatePrototypeMock       mClientMockUpdatePrototype
 }
 
 //NewClientMock returns a mock for github.com/insolar/insolar/logicrunner/artifacts.Client
@@ -133,7 +123,6 @@ func NewClientMock(t minimock.Tester) *ClientMock {
 	m.ActivateObjectMock = mClientMockActivateObject{mock: m}
 	m.ActivatePrototypeMock = mClientMockActivatePrototype{mock: m}
 	m.DeactivateObjectMock = mClientMockDeactivateObject{mock: m}
-	m.DeclareTypeMock = mClientMockDeclareType{mock: m}
 	m.DeployCodeMock = mClientMockDeployCode{mock: m}
 	m.GetChildrenMock = mClientMockGetChildren{mock: m}
 	m.GetCodeMock = mClientMockGetCode{mock: m}
@@ -149,7 +138,6 @@ func NewClientMock(t minimock.Tester) *ClientMock {
 	m.RegisterValidationMock = mClientMockRegisterValidation{mock: m}
 	m.StateMock = mClientMockState{mock: m}
 	m.UpdateObjectMock = mClientMockUpdateObject{mock: m}
-	m.UpdatePrototypeMock = mClientMockUpdatePrototype{mock: m}
 
 	return m
 }
@@ -170,9 +158,8 @@ type ClientMockActivateObjectInput struct {
 	p1 insolar.Reference
 	p2 insolar.Reference
 	p3 insolar.Reference
-	p4 insolar.Reference
-	p5 bool
-	p6 []byte
+	p4 bool
+	p5 []byte
 }
 
 type ClientMockActivateObjectResult struct {
@@ -181,14 +168,14 @@ type ClientMockActivateObjectResult struct {
 }
 
 //Expect specifies that invocation of Client.ActivateObject is expected from 1 to Infinity times
-func (m *mClientMockActivateObject) Expect(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 insolar.Reference, p5 bool, p6 []byte) *mClientMockActivateObject {
+func (m *mClientMockActivateObject) Expect(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 bool, p5 []byte) *mClientMockActivateObject {
 	m.mock.ActivateObjectFunc = nil
 	m.expectationSeries = nil
 
 	if m.mainExpectation == nil {
 		m.mainExpectation = &ClientMockActivateObjectExpectation{}
 	}
-	m.mainExpectation.input = &ClientMockActivateObjectInput{p, p1, p2, p3, p4, p5, p6}
+	m.mainExpectation.input = &ClientMockActivateObjectInput{p, p1, p2, p3, p4, p5}
 	return m
 }
 
@@ -205,12 +192,12 @@ func (m *mClientMockActivateObject) Return(r ObjectDescriptor, r1 error) *Client
 }
 
 //ExpectOnce specifies that invocation of Client.ActivateObject is expected once
-func (m *mClientMockActivateObject) ExpectOnce(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 insolar.Reference, p5 bool, p6 []byte) *ClientMockActivateObjectExpectation {
+func (m *mClientMockActivateObject) ExpectOnce(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 bool, p5 []byte) *ClientMockActivateObjectExpectation {
 	m.mock.ActivateObjectFunc = nil
 	m.mainExpectation = nil
 
 	expectation := &ClientMockActivateObjectExpectation{}
-	expectation.input = &ClientMockActivateObjectInput{p, p1, p2, p3, p4, p5, p6}
+	expectation.input = &ClientMockActivateObjectInput{p, p1, p2, p3, p4, p5}
 	m.expectationSeries = append(m.expectationSeries, expectation)
 	return expectation
 }
@@ -220,7 +207,7 @@ func (e *ClientMockActivateObjectExpectation) Return(r ObjectDescriptor, r1 erro
 }
 
 //Set uses given function f as a mock of Client.ActivateObject method
-func (m *mClientMockActivateObject) Set(f func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 insolar.Reference, p5 bool, p6 []byte) (r ObjectDescriptor, r1 error)) *ClientMock {
+func (m *mClientMockActivateObject) Set(f func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 bool, p5 []byte) (r ObjectDescriptor, r1 error)) *ClientMock {
 	m.mainExpectation = nil
 	m.expectationSeries = nil
 
@@ -229,18 +216,18 @@ func (m *mClientMockActivateObject) Set(f func(p context.Context, p1 insolar.Ref
 }
 
 //ActivateObject implements github.com/insolar/insolar/logicrunner/artifacts.Client interface
-func (m *ClientMock) ActivateObject(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 insolar.Reference, p5 bool, p6 []byte) (r ObjectDescriptor, r1 error) {
+func (m *ClientMock) ActivateObject(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 bool, p5 []byte) (r ObjectDescriptor, r1 error) {
 	counter := atomic.AddUint64(&m.ActivateObjectPreCounter, 1)
 	defer atomic.AddUint64(&m.ActivateObjectCounter, 1)
 
 	if len(m.ActivateObjectMock.expectationSeries) > 0 {
 		if counter > uint64(len(m.ActivateObjectMock.expectationSeries)) {
-			m.t.Fatalf("Unexpected call to ClientMock.ActivateObject. %v %v %v %v %v %v %v", p, p1, p2, p3, p4, p5, p6)
+			m.t.Fatalf("Unexpected call to ClientMock.ActivateObject. %v %v %v %v %v %v", p, p1, p2, p3, p4, p5)
 			return
 		}
 
 		input := m.ActivateObjectMock.expectationSeries[counter-1].input
-		testify_assert.Equal(m.t, *input, ClientMockActivateObjectInput{p, p1, p2, p3, p4, p5, p6}, "Client.ActivateObject got unexpected parameters")
+		testify_assert.Equal(m.t, *input, ClientMockActivateObjectInput{p, p1, p2, p3, p4, p5}, "Client.ActivateObject got unexpected parameters")
 
 		result := m.ActivateObjectMock.expectationSeries[counter-1].result
 		if result == nil {
@@ -258,7 +245,7 @@ func (m *ClientMock) ActivateObject(p context.Context, p1 insolar.Reference, p2 
 
 		input := m.ActivateObjectMock.mainExpectation.input
 		if input != nil {
-			testify_assert.Equal(m.t, *input, ClientMockActivateObjectInput{p, p1, p2, p3, p4, p5, p6}, "Client.ActivateObject got unexpected parameters")
+			testify_assert.Equal(m.t, *input, ClientMockActivateObjectInput{p, p1, p2, p3, p4, p5}, "Client.ActivateObject got unexpected parameters")
 		}
 
 		result := m.ActivateObjectMock.mainExpectation.result
@@ -273,11 +260,11 @@ func (m *ClientMock) ActivateObject(p context.Context, p1 insolar.Reference, p2 
 	}
 
 	if m.ActivateObjectFunc == nil {
-		m.t.Fatalf("Unexpected call to ClientMock.ActivateObject. %v %v %v %v %v %v %v", p, p1, p2, p3, p4, p5, p6)
+		m.t.Fatalf("Unexpected call to ClientMock.ActivateObject. %v %v %v %v %v %v", p, p1, p2, p3, p4, p5)
 		return
 	}
 
-	return m.ActivateObjectFunc(p, p1, p2, p3, p4, p5, p6)
+	return m.ActivateObjectFunc(p, p1, p2, p3, p4, p5)
 }
 
 //ActivateObjectMinimockCounter returns a count of ClientMock.ActivateObjectFunc invocations
@@ -326,8 +313,7 @@ type ClientMockActivatePrototypeInput struct {
 	p1 insolar.Reference
 	p2 insolar.Reference
 	p3 insolar.Reference
-	p4 insolar.Reference
-	p5 []byte
+	p4 []byte
 }
 
 type ClientMockActivatePrototypeResult struct {
@@ -336,14 +322,14 @@ type ClientMockActivatePrototypeResult struct {
 }
 
 //Expect specifies that invocation of Client.ActivatePrototype is expected from 1 to Infinity times
-func (m *mClientMockActivatePrototype) Expect(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 insolar.Reference, p5 []byte) *mClientMockActivatePrototype {
+func (m *mClientMockActivatePrototype) Expect(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 []byte) *mClientMockActivatePrototype {
 	m.mock.ActivatePrototypeFunc = nil
 	m.expectationSeries = nil
 
 	if m.mainExpectation == nil {
 		m.mainExpectation = &ClientMockActivatePrototypeExpectation{}
 	}
-	m.mainExpectation.input = &ClientMockActivatePrototypeInput{p, p1, p2, p3, p4, p5}
+	m.mainExpectation.input = &ClientMockActivatePrototypeInput{p, p1, p2, p3, p4}
 	return m
 }
 
@@ -360,12 +346,12 @@ func (m *mClientMockActivatePrototype) Return(r ObjectDescriptor, r1 error) *Cli
 }
 
 //ExpectOnce specifies that invocation of Client.ActivatePrototype is expected once
-func (m *mClientMockActivatePrototype) ExpectOnce(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 insolar.Reference, p5 []byte) *ClientMockActivatePrototypeExpectation {
+func (m *mClientMockActivatePrototype) ExpectOnce(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 []byte) *ClientMockActivatePrototypeExpectation {
 	m.mock.ActivatePrototypeFunc = nil
 	m.mainExpectation = nil
 
 	expectation := &ClientMockActivatePrototypeExpectation{}
-	expectation.input = &ClientMockActivatePrototypeInput{p, p1, p2, p3, p4, p5}
+	expectation.input = &ClientMockActivatePrototypeInput{p, p1, p2, p3, p4}
 	m.expectationSeries = append(m.expectationSeries, expectation)
 	return expectation
 }
@@ -375,7 +361,7 @@ func (e *ClientMockActivatePrototypeExpectation) Return(r ObjectDescriptor, r1 e
 }
 
 //Set uses given function f as a mock of Client.ActivatePrototype method
-func (m *mClientMockActivatePrototype) Set(f func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 insolar.Reference, p5 []byte) (r ObjectDescriptor, r1 error)) *ClientMock {
+func (m *mClientMockActivatePrototype) Set(f func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 []byte) (r ObjectDescriptor, r1 error)) *ClientMock {
 	m.mainExpectation = nil
 	m.expectationSeries = nil
 
@@ -384,18 +370,18 @@ func (m *mClientMockActivatePrototype) Set(f func(p context.Context, p1 insolar.
 }
 
 //ActivatePrototype implements github.com/insolar/insolar/logicrunner/artifacts.Client interface
-func (m *ClientMock) ActivatePrototype(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 insolar.Reference, p5 []byte) (r ObjectDescriptor, r1 error) {
+func (m *ClientMock) ActivatePrototype(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 insolar.Reference, p4 []byte) (r ObjectDescriptor, r1 error) {
 	counter := atomic.AddUint64(&m.ActivatePrototypePreCounter, 1)
 	defer atomic.AddUint64(&m.ActivatePrototypeCounter, 1)
 
 	if len(m.ActivatePrototypeMock.expectationSeries) > 0 {
 		if counter > uint64(len(m.ActivatePrototypeMock.expectationSeries)) {
-			m.t.Fatalf("Unexpected call to ClientMock.ActivatePrototype. %v %v %v %v %v %v", p, p1, p2, p3, p4, p5)
+			m.t.Fatalf("Unexpected call to ClientMock.ActivatePrototype. %v %v %v %v %v", p, p1, p2, p3, p4)
 			return
 		}
 
 		input := m.ActivatePrototypeMock.expectationSeries[counter-1].input
-		testify_assert.Equal(m.t, *input, ClientMockActivatePrototypeInput{p, p1, p2, p3, p4, p5}, "Client.ActivatePrototype got unexpected parameters")
+		testify_assert.Equal(m.t, *input, ClientMockActivatePrototypeInput{p, p1, p2, p3, p4}, "Client.ActivatePrototype got unexpected parameters")
 
 		result := m.ActivatePrototypeMock.expectationSeries[counter-1].result
 		if result == nil {
@@ -413,7 +399,7 @@ func (m *ClientMock) ActivatePrototype(p context.Context, p1 insolar.Reference, 
 
 		input := m.ActivatePrototypeMock.mainExpectation.input
 		if input != nil {
-			testify_assert.Equal(m.t, *input, ClientMockActivatePrototypeInput{p, p1, p2, p3, p4, p5}, "Client.ActivatePrototype got unexpected parameters")
+			testify_assert.Equal(m.t, *input, ClientMockActivatePrototypeInput{p, p1, p2, p3, p4}, "Client.ActivatePrototype got unexpected parameters")
 		}
 
 		result := m.ActivatePrototypeMock.mainExpectation.result
@@ -428,11 +414,11 @@ func (m *ClientMock) ActivatePrototype(p context.Context, p1 insolar.Reference, 
 	}
 
 	if m.ActivatePrototypeFunc == nil {
-		m.t.Fatalf("Unexpected call to ClientMock.ActivatePrototype. %v %v %v %v %v %v", p, p1, p2, p3, p4, p5)
+		m.t.Fatalf("Unexpected call to ClientMock.ActivatePrototype. %v %v %v %v %v", p, p1, p2, p3, p4)
 		return
 	}
 
-	return m.ActivatePrototypeFunc(p, p1, p2, p3, p4, p5)
+	return m.ActivatePrototypeFunc(p, p1, p2, p3, p4)
 }
 
 //ActivatePrototypeMinimockCounter returns a count of ClientMock.ActivatePrototypeFunc invocations
@@ -479,8 +465,8 @@ type ClientMockDeactivateObjectExpectation struct {
 type ClientMockDeactivateObjectInput struct {
 	p  context.Context
 	p1 insolar.Reference
-	p2 insolar.Reference
-	p3 ObjectDescriptor
+	p2 ObjectDescriptor
+	p3 []byte
 }
 
 type ClientMockDeactivateObjectResult struct {
@@ -489,7 +475,7 @@ type ClientMockDeactivateObjectResult struct {
 }
 
 //Expect specifies that invocation of Client.DeactivateObject is expected from 1 to Infinity times
-func (m *mClientMockDeactivateObject) Expect(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor) *mClientMockDeactivateObject {
+func (m *mClientMockDeactivateObject) Expect(p context.Context, p1 insolar.Reference, p2 ObjectDescriptor, p3 []byte) *mClientMockDeactivateObject {
 	m.mock.DeactivateObjectFunc = nil
 	m.expectationSeries = nil
 
@@ -513,7 +499,7 @@ func (m *mClientMockDeactivateObject) Return(r *insolar.ID, r1 error) *ClientMoc
 }
 
 //ExpectOnce specifies that invocation of Client.DeactivateObject is expected once
-func (m *mClientMockDeactivateObject) ExpectOnce(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor) *ClientMockDeactivateObjectExpectation {
+func (m *mClientMockDeactivateObject) ExpectOnce(p context.Context, p1 insolar.Reference, p2 ObjectDescriptor, p3 []byte) *ClientMockDeactivateObjectExpectation {
 	m.mock.DeactivateObjectFunc = nil
 	m.mainExpectation = nil
 
@@ -528,7 +514,7 @@ func (e *ClientMockDeactivateObjectExpectation) Return(r *insolar.ID, r1 error) 
 }
 
 //Set uses given function f as a mock of Client.DeactivateObject method
-func (m *mClientMockDeactivateObject) Set(f func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor) (r *insolar.ID, r1 error)) *ClientMock {
+func (m *mClientMockDeactivateObject) Set(f func(p context.Context, p1 insolar.Reference, p2 ObjectDescriptor, p3 []byte) (r *insolar.ID, r1 error)) *ClientMock {
 	m.mainExpectation = nil
 	m.expectationSeries = nil
 
@@ -537,7 +523,7 @@ func (m *mClientMockDeactivateObject) Set(f func(p context.Context, p1 insolar.R
 }
 
 //DeactivateObject implements github.com/insolar/insolar/logicrunner/artifacts.Client interface
-func (m *ClientMock) DeactivateObject(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor) (r *insolar.ID, r1 error) {
+func (m *ClientMock) DeactivateObject(p context.Context, p1 insolar.Reference, p2 ObjectDescriptor, p3 []byte) (r *insolar.ID, r1 error) {
 	counter := atomic.AddUint64(&m.DeactivateObjectPreCounter, 1)
 	defer atomic.AddUint64(&m.DeactivateObjectCounter, 1)
 
@@ -613,159 +599,6 @@ func (m *ClientMock) DeactivateObjectFinished() bool {
 	// if func was set then invocations count should be greater than zero
 	if m.DeactivateObjectFunc != nil {
 		return atomic.LoadUint64(&m.DeactivateObjectCounter) > 0
-	}
-
-	return true
-}
-
-type mClientMockDeclareType struct {
-	mock              *ClientMock
-	mainExpectation   *ClientMockDeclareTypeExpectation
-	expectationSeries []*ClientMockDeclareTypeExpectation
-}
-
-type ClientMockDeclareTypeExpectation struct {
-	input  *ClientMockDeclareTypeInput
-	result *ClientMockDeclareTypeResult
-}
-
-type ClientMockDeclareTypeInput struct {
-	p  context.Context
-	p1 insolar.Reference
-	p2 insolar.Reference
-	p3 []byte
-}
-
-type ClientMockDeclareTypeResult struct {
-	r  *insolar.ID
-	r1 error
-}
-
-//Expect specifies that invocation of Client.DeclareType is expected from 1 to Infinity times
-func (m *mClientMockDeclareType) Expect(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 []byte) *mClientMockDeclareType {
-	m.mock.DeclareTypeFunc = nil
-	m.expectationSeries = nil
-
-	if m.mainExpectation == nil {
-		m.mainExpectation = &ClientMockDeclareTypeExpectation{}
-	}
-	m.mainExpectation.input = &ClientMockDeclareTypeInput{p, p1, p2, p3}
-	return m
-}
-
-//Return specifies results of invocation of Client.DeclareType
-func (m *mClientMockDeclareType) Return(r *insolar.ID, r1 error) *ClientMock {
-	m.mock.DeclareTypeFunc = nil
-	m.expectationSeries = nil
-
-	if m.mainExpectation == nil {
-		m.mainExpectation = &ClientMockDeclareTypeExpectation{}
-	}
-	m.mainExpectation.result = &ClientMockDeclareTypeResult{r, r1}
-	return m.mock
-}
-
-//ExpectOnce specifies that invocation of Client.DeclareType is expected once
-func (m *mClientMockDeclareType) ExpectOnce(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 []byte) *ClientMockDeclareTypeExpectation {
-	m.mock.DeclareTypeFunc = nil
-	m.mainExpectation = nil
-
-	expectation := &ClientMockDeclareTypeExpectation{}
-	expectation.input = &ClientMockDeclareTypeInput{p, p1, p2, p3}
-	m.expectationSeries = append(m.expectationSeries, expectation)
-	return expectation
-}
-
-func (e *ClientMockDeclareTypeExpectation) Return(r *insolar.ID, r1 error) {
-	e.result = &ClientMockDeclareTypeResult{r, r1}
-}
-
-//Set uses given function f as a mock of Client.DeclareType method
-func (m *mClientMockDeclareType) Set(f func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 []byte) (r *insolar.ID, r1 error)) *ClientMock {
-	m.mainExpectation = nil
-	m.expectationSeries = nil
-
-	m.mock.DeclareTypeFunc = f
-	return m.mock
-}
-
-//DeclareType implements github.com/insolar/insolar/logicrunner/artifacts.Client interface
-func (m *ClientMock) DeclareType(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 []byte) (r *insolar.ID, r1 error) {
-	counter := atomic.AddUint64(&m.DeclareTypePreCounter, 1)
-	defer atomic.AddUint64(&m.DeclareTypeCounter, 1)
-
-	if len(m.DeclareTypeMock.expectationSeries) > 0 {
-		if counter > uint64(len(m.DeclareTypeMock.expectationSeries)) {
-			m.t.Fatalf("Unexpected call to ClientMock.DeclareType. %v %v %v %v", p, p1, p2, p3)
-			return
-		}
-
-		input := m.DeclareTypeMock.expectationSeries[counter-1].input
-		testify_assert.Equal(m.t, *input, ClientMockDeclareTypeInput{p, p1, p2, p3}, "Client.DeclareType got unexpected parameters")
-
-		result := m.DeclareTypeMock.expectationSeries[counter-1].result
-		if result == nil {
-			m.t.Fatal("No results are set for the ClientMock.DeclareType")
-			return
-		}
-
-		r = result.r
-		r1 = result.r1
-
-		return
-	}
-
-	if m.DeclareTypeMock.mainExpectation != nil {
-
-		input := m.DeclareTypeMock.mainExpectation.input
-		if input != nil {
-			testify_assert.Equal(m.t, *input, ClientMockDeclareTypeInput{p, p1, p2, p3}, "Client.DeclareType got unexpected parameters")
-		}
-
-		result := m.DeclareTypeMock.mainExpectation.result
-		if result == nil {
-			m.t.Fatal("No results are set for the ClientMock.DeclareType")
-		}
-
-		r = result.r
-		r1 = result.r1
-
-		return
-	}
-
-	if m.DeclareTypeFunc == nil {
-		m.t.Fatalf("Unexpected call to ClientMock.DeclareType. %v %v %v %v", p, p1, p2, p3)
-		return
-	}
-
-	return m.DeclareTypeFunc(p, p1, p2, p3)
-}
-
-//DeclareTypeMinimockCounter returns a count of ClientMock.DeclareTypeFunc invocations
-func (m *ClientMock) DeclareTypeMinimockCounter() uint64 {
-	return atomic.LoadUint64(&m.DeclareTypeCounter)
-}
-
-//DeclareTypeMinimockPreCounter returns the value of ClientMock.DeclareType invocations
-func (m *ClientMock) DeclareTypeMinimockPreCounter() uint64 {
-	return atomic.LoadUint64(&m.DeclareTypePreCounter)
-}
-
-//DeclareTypeFinished returns true if mock invocations count is ok
-func (m *ClientMock) DeclareTypeFinished() bool {
-	// if expectation series were set then invocations count should be equal to expectations count
-	if len(m.DeclareTypeMock.expectationSeries) > 0 {
-		return atomic.LoadUint64(&m.DeclareTypeCounter) == uint64(len(m.DeclareTypeMock.expectationSeries))
-	}
-
-	// if main expectation was set then invocations count should be greater than zero
-	if m.DeclareTypeMock.mainExpectation != nil {
-		return atomic.LoadUint64(&m.DeclareTypeCounter) > 0
-	}
-
-	// if func was set then invocations count should be greater than zero
-	if m.DeclareTypeFunc != nil {
-		return atomic.LoadUint64(&m.DeclareTypeCounter) > 0
 	}
 
 	return true
@@ -2800,8 +2633,8 @@ type ClientMockUpdateObjectExpectation struct {
 type ClientMockUpdateObjectInput struct {
 	p  context.Context
 	p1 insolar.Reference
-	p2 insolar.Reference
-	p3 ObjectDescriptor
+	p2 ObjectDescriptor
+	p3 []byte
 	p4 []byte
 }
 
@@ -2811,7 +2644,7 @@ type ClientMockUpdateObjectResult struct {
 }
 
 //Expect specifies that invocation of Client.UpdateObject is expected from 1 to Infinity times
-func (m *mClientMockUpdateObject) Expect(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor, p4 []byte) *mClientMockUpdateObject {
+func (m *mClientMockUpdateObject) Expect(p context.Context, p1 insolar.Reference, p2 ObjectDescriptor, p3 []byte, p4 []byte) *mClientMockUpdateObject {
 	m.mock.UpdateObjectFunc = nil
 	m.expectationSeries = nil
 
@@ -2835,7 +2668,7 @@ func (m *mClientMockUpdateObject) Return(r ObjectDescriptor, r1 error) *ClientMo
 }
 
 //ExpectOnce specifies that invocation of Client.UpdateObject is expected once
-func (m *mClientMockUpdateObject) ExpectOnce(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor, p4 []byte) *ClientMockUpdateObjectExpectation {
+func (m *mClientMockUpdateObject) ExpectOnce(p context.Context, p1 insolar.Reference, p2 ObjectDescriptor, p3 []byte, p4 []byte) *ClientMockUpdateObjectExpectation {
 	m.mock.UpdateObjectFunc = nil
 	m.mainExpectation = nil
 
@@ -2850,7 +2683,7 @@ func (e *ClientMockUpdateObjectExpectation) Return(r ObjectDescriptor, r1 error)
 }
 
 //Set uses given function f as a mock of Client.UpdateObject method
-func (m *mClientMockUpdateObject) Set(f func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor, p4 []byte) (r ObjectDescriptor, r1 error)) *ClientMock {
+func (m *mClientMockUpdateObject) Set(f func(p context.Context, p1 insolar.Reference, p2 ObjectDescriptor, p3 []byte, p4 []byte) (r ObjectDescriptor, r1 error)) *ClientMock {
 	m.mainExpectation = nil
 	m.expectationSeries = nil
 
@@ -2859,7 +2692,7 @@ func (m *mClientMockUpdateObject) Set(f func(p context.Context, p1 insolar.Refer
 }
 
 //UpdateObject implements github.com/insolar/insolar/logicrunner/artifacts.Client interface
-func (m *ClientMock) UpdateObject(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor, p4 []byte) (r ObjectDescriptor, r1 error) {
+func (m *ClientMock) UpdateObject(p context.Context, p1 insolar.Reference, p2 ObjectDescriptor, p3 []byte, p4 []byte) (r ObjectDescriptor, r1 error) {
 	counter := atomic.AddUint64(&m.UpdateObjectPreCounter, 1)
 	defer atomic.AddUint64(&m.UpdateObjectCounter, 1)
 
@@ -2940,161 +2773,6 @@ func (m *ClientMock) UpdateObjectFinished() bool {
 	return true
 }
 
-type mClientMockUpdatePrototype struct {
-	mock              *ClientMock
-	mainExpectation   *ClientMockUpdatePrototypeExpectation
-	expectationSeries []*ClientMockUpdatePrototypeExpectation
-}
-
-type ClientMockUpdatePrototypeExpectation struct {
-	input  *ClientMockUpdatePrototypeInput
-	result *ClientMockUpdatePrototypeResult
-}
-
-type ClientMockUpdatePrototypeInput struct {
-	p  context.Context
-	p1 insolar.Reference
-	p2 insolar.Reference
-	p3 ObjectDescriptor
-	p4 []byte
-	p5 *insolar.Reference
-}
-
-type ClientMockUpdatePrototypeResult struct {
-	r  ObjectDescriptor
-	r1 error
-}
-
-//Expect specifies that invocation of Client.UpdatePrototype is expected from 1 to Infinity times
-func (m *mClientMockUpdatePrototype) Expect(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor, p4 []byte, p5 *insolar.Reference) *mClientMockUpdatePrototype {
-	m.mock.UpdatePrototypeFunc = nil
-	m.expectationSeries = nil
-
-	if m.mainExpectation == nil {
-		m.mainExpectation = &ClientMockUpdatePrototypeExpectation{}
-	}
-	m.mainExpectation.input = &ClientMockUpdatePrototypeInput{p, p1, p2, p3, p4, p5}
-	return m
-}
-
-//Return specifies results of invocation of Client.UpdatePrototype
-func (m *mClientMockUpdatePrototype) Return(r ObjectDescriptor, r1 error) *ClientMock {
-	m.mock.UpdatePrototypeFunc = nil
-	m.expectationSeries = nil
-
-	if m.mainExpectation == nil {
-		m.mainExpectation = &ClientMockUpdatePrototypeExpectation{}
-	}
-	m.mainExpectation.result = &ClientMockUpdatePrototypeResult{r, r1}
-	return m.mock
-}
-
-//ExpectOnce specifies that invocation of Client.UpdatePrototype is expected once
-func (m *mClientMockUpdatePrototype) ExpectOnce(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor, p4 []byte, p5 *insolar.Reference) *ClientMockUpdatePrototypeExpectation {
-	m.mock.UpdatePrototypeFunc = nil
-	m.mainExpectation = nil
-
-	expectation := &ClientMockUpdatePrototypeExpectation{}
-	expectation.input = &ClientMockUpdatePrototypeInput{p, p1, p2, p3, p4, p5}
-	m.expectationSeries = append(m.expectationSeries, expectation)
-	return expectation
-}
-
-func (e *ClientMockUpdatePrototypeExpectation) Return(r ObjectDescriptor, r1 error) {
-	e.result = &ClientMockUpdatePrototypeResult{r, r1}
-}
-
-//Set uses given function f as a mock of Client.UpdatePrototype method
-func (m *mClientMockUpdatePrototype) Set(f func(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor, p4 []byte, p5 *insolar.Reference) (r ObjectDescriptor, r1 error)) *ClientMock {
-	m.mainExpectation = nil
-	m.expectationSeries = nil
-
-	m.mock.UpdatePrototypeFunc = f
-	return m.mock
-}
-
-//UpdatePrototype implements github.com/insolar/insolar/logicrunner/artifacts.Client interface
-func (m *ClientMock) UpdatePrototype(p context.Context, p1 insolar.Reference, p2 insolar.Reference, p3 ObjectDescriptor, p4 []byte, p5 *insolar.Reference) (r ObjectDescriptor, r1 error) {
-	counter := atomic.AddUint64(&m.UpdatePrototypePreCounter, 1)
-	defer atomic.AddUint64(&m.UpdatePrototypeCounter, 1)
-
-	if len(m.UpdatePrototypeMock.expectationSeries) > 0 {
-		if counter > uint64(len(m.UpdatePrototypeMock.expectationSeries)) {
-			m.t.Fatalf("Unexpected call to ClientMock.UpdatePrototype. %v %v %v %v %v %v", p, p1, p2, p3, p4, p5)
-			return
-		}
-
-		input := m.UpdatePrototypeMock.expectationSeries[counter-1].input
-		testify_assert.Equal(m.t, *input, ClientMockUpdatePrototypeInput{p, p1, p2, p3, p4, p5}, "Client.UpdatePrototype got unexpected parameters")
-
-		result := m.UpdatePrototypeMock.expectationSeries[counter-1].result
-		if result == nil {
-			m.t.Fatal("No results are set for the ClientMock.UpdatePrototype")
-			return
-		}
-
-		r = result.r
-		r1 = result.r1
-
-		return
-	}
-
-	if m.UpdatePrototypeMock.mainExpectation != nil {
-
-		input := m.UpdatePrototypeMock.mainExpectation.input
-		if input != nil {
-			testify_assert.Equal(m.t, *input, ClientMockUpdatePrototypeInput{p, p1, p2, p3, p4, p5}, "Client.UpdatePrototype got unexpected parameters")
-		}
-
-		result := m.UpdatePrototypeMock.mainExpectation.result
-		if result == nil {
-			m.t.Fatal("No results are set for the ClientMock.UpdatePrototype")
-		}
-
-		r = result.r
-		r1 = result.r1
-
-		return
-	}
-
-	if m.UpdatePrototypeFunc == nil {
-		m.t.Fatalf("Unexpected call to ClientMock.UpdatePrototype. %v %v %v %v %v %v", p, p1, p2, p3, p4, p5)
-		return
-	}
-
-	return m.UpdatePrototypeFunc(p, p1, p2, p3, p4, p5)
-}
-
-//UpdatePrototypeMinimockCounter returns a count of ClientMock.UpdatePrototypeFunc invocations
-func (m *ClientMock) UpdatePrototypeMinimockCounter() uint64 {
-	return atomic.LoadUint64(&m.UpdatePrototypeCounter)
-}
-
-//UpdatePrototypeMinimockPreCounter returns the value of ClientMock.UpdatePrototype invocations
-func (m *ClientMock) UpdatePrototypeMinimockPreCounter() uint64 {
-	return atomic.LoadUint64(&m.UpdatePrototypePreCounter)
-}
-
-//UpdatePrototypeFinished returns true if mock invocations count is ok
-func (m *ClientMock) UpdatePrototypeFinished() bool {
-	// if expectation series were set then invocations count should be equal to expectations count
-	if len(m.UpdatePrototypeMock.expectationSeries) > 0 {
-		return atomic.LoadUint64(&m.UpdatePrototypeCounter) == uint64(len(m.UpdatePrototypeMock.expectationSeries))
-	}
-
-	// if main expectation was set then invocations count should be greater than zero
-	if m.UpdatePrototypeMock.mainExpectation != nil {
-		return atomic.LoadUint64(&m.UpdatePrototypeCounter) > 0
-	}
-
-	// if func was set then invocations count should be greater than zero
-	if m.UpdatePrototypeFunc != nil {
-		return atomic.LoadUint64(&m.UpdatePrototypeCounter) > 0
-	}
-
-	return true
-}
-
 //ValidateCallCounters checks that all mocked methods of the interface have been called at least once
 //Deprecated: please use MinimockFinish method or use Finish method of minimock.Controller
 func (m *ClientMock) ValidateCallCounters() {
@@ -3109,10 +2787,6 @@ func (m *ClientMock) ValidateCallCounters() {
 
 	if !m.DeactivateObjectFinished() {
 		m.t.Fatal("Expected call to ClientMock.DeactivateObject")
-	}
-
-	if !m.DeclareTypeFinished() {
-		m.t.Fatal("Expected call to ClientMock.DeclareType")
 	}
 
 	if !m.DeployCodeFinished() {
@@ -3173,10 +2847,6 @@ func (m *ClientMock) ValidateCallCounters() {
 
 	if !m.UpdateObjectFinished() {
 		m.t.Fatal("Expected call to ClientMock.UpdateObject")
-	}
-
-	if !m.UpdatePrototypeFinished() {
-		m.t.Fatal("Expected call to ClientMock.UpdatePrototype")
 	}
 
 }
@@ -3208,10 +2878,6 @@ func (m *ClientMock) MinimockFinish() {
 		m.t.Fatal("Expected call to ClientMock.DeactivateObject")
 	}
 
-	if !m.DeclareTypeFinished() {
-		m.t.Fatal("Expected call to ClientMock.DeclareType")
-	}
-
 	if !m.DeployCodeFinished() {
 		m.t.Fatal("Expected call to ClientMock.DeployCode")
 	}
@@ -3272,10 +2938,6 @@ func (m *ClientMock) MinimockFinish() {
 		m.t.Fatal("Expected call to ClientMock.UpdateObject")
 	}
 
-	if !m.UpdatePrototypeFinished() {
-		m.t.Fatal("Expected call to ClientMock.UpdatePrototype")
-	}
-
 }
 
 //Wait waits for all mocked methods to be called at least once
@@ -3293,7 +2955,6 @@ func (m *ClientMock) MinimockWait(timeout time.Duration) {
 		ok = ok && m.ActivateObjectFinished()
 		ok = ok && m.ActivatePrototypeFinished()
 		ok = ok && m.DeactivateObjectFinished()
-		ok = ok && m.DeclareTypeFinished()
 		ok = ok && m.DeployCodeFinished()
 		ok = ok && m.GetChildrenFinished()
 		ok = ok && m.GetCodeFinished()
@@ -3309,7 +2970,6 @@ func (m *ClientMock) MinimockWait(timeout time.Duration) {
 		ok = ok && m.RegisterValidationFinished()
 		ok = ok && m.StateFinished()
 		ok = ok && m.UpdateObjectFinished()
-		ok = ok && m.UpdatePrototypeFinished()
 
 		if ok {
 			return
@@ -3328,10 +2988,6 @@ func (m *ClientMock) MinimockWait(timeout time.Duration) {
 
 			if !m.DeactivateObjectFinished() {
 				m.t.Error("Expected call to ClientMock.DeactivateObject")
-			}
-
-			if !m.DeclareTypeFinished() {
-				m.t.Error("Expected call to ClientMock.DeclareType")
 			}
 
 			if !m.DeployCodeFinished() {
@@ -3394,10 +3050,6 @@ func (m *ClientMock) MinimockWait(timeout time.Duration) {
 				m.t.Error("Expected call to ClientMock.UpdateObject")
 			}
 
-			if !m.UpdatePrototypeFinished() {
-				m.t.Error("Expected call to ClientMock.UpdatePrototype")
-			}
-
 			m.t.Fatalf("Some mocks were not called on time: %s", timeout)
 			return
 		default:
@@ -3419,10 +3071,6 @@ func (m *ClientMock) AllMocksCalled() bool {
 	}
 
 	if !m.DeactivateObjectFinished() {
-		return false
-	}
-
-	if !m.DeclareTypeFinished() {
 		return false
 	}
 
@@ -3483,10 +3131,6 @@ func (m *ClientMock) AllMocksCalled() bool {
 	}
 
 	if !m.UpdateObjectFinished() {
-		return false
-	}
-
-	if !m.UpdatePrototypeFinished() {
 		return false
 	}
 

--- a/logicrunner/builtin_test.go
+++ b/logicrunner/builtin_test.go
@@ -138,7 +138,7 @@ func TestBareHelloworld(t *testing.T) {
 	reqref.SetRecord(*contract)
 
 	_, err = am.ActivateObject(
-		ctx, *domain, reqref, insolar.GenesisRecord.Ref(), *protoRef, false,
+		ctx, reqref, insolar.GenesisRecord.Ref(), *protoRef, false,
 		goplugintestutils.CBORMarshal(t, hw),
 	)
 	assert.NoError(t, err)

--- a/logicrunner/goplugin/goplugintestutils/utils.go
+++ b/logicrunner/goplugin/goplugintestutils/utils.go
@@ -223,11 +223,6 @@ func (t *TestArtifactManager) GetDelegate(ctx context.Context, head, asClass ins
 	return &res, nil
 }
 
-// DeclareType implementation for tests
-func (t *TestArtifactManager) DeclareType(ctx context.Context, domain insolar.Reference, request insolar.Reference, typeDec []byte) (*insolar.ID, error) {
-	panic("not implemented")
-}
-
 // DeployCode implementation for tests
 func (t *TestArtifactManager) DeployCode(ctx context.Context, domain insolar.Reference, request insolar.Reference, code []byte, mt insolar.MachineType) (*insolar.ID, error) {
 	ref := testutils.RandomRef()
@@ -253,7 +248,7 @@ func (t *TestArtifactManager) GetCode(ctx context.Context, code insolar.Referenc
 // ActivatePrototype implementation for tests
 func (t *TestArtifactManager) ActivatePrototype(
 	ctx context.Context,
-	domain, request, parent, code insolar.Reference,
+	request, parent, code insolar.Reference,
 	memory []byte,
 ) (artifacts.ObjectDescriptor, error) {
 	id := testutils.RandomID()
@@ -273,7 +268,7 @@ func (t *TestArtifactManager) ActivatePrototype(
 // ActivateObject implementation for tests
 func (t *TestArtifactManager) ActivateObject(
 	ctx context.Context,
-	domain, request, parent, prototype insolar.Reference,
+	request, parent, prototype insolar.Reference,
 	asDelegate bool,
 	memory []byte,
 ) (artifacts.ObjectDescriptor, error) {
@@ -302,38 +297,19 @@ func (t *TestArtifactManager) ActivateObject(
 // DeactivateObject implementation for tests
 func (t *TestArtifactManager) DeactivateObject(
 	ctx context.Context,
-	domain insolar.Reference, request insolar.Reference, obj artifacts.ObjectDescriptor,
+	request insolar.Reference, obj artifacts.ObjectDescriptor,
+	result []byte,
 ) (*insolar.ID, error) {
 	panic("not implemented")
-}
-
-// UpdatePrototype implementation for tests
-func (t *TestArtifactManager) UpdatePrototype(
-	ctx context.Context,
-	domain insolar.Reference,
-	request insolar.Reference,
-	object artifacts.ObjectDescriptor,
-	memory []byte,
-	code *insolar.Reference,
-) (artifacts.ObjectDescriptor, error) {
-	objDesc, ok := t.Prototypes[*object.HeadRef()]
-	if !ok {
-		return nil, errors.New("No object to update")
-	}
-
-	objDesc.Data = memory
-
-	// TODO: return real exact "ref"
-	return objDesc, nil
 }
 
 // UpdateObject implementation for tests
 func (t *TestArtifactManager) UpdateObject(
 	ctx context.Context,
-	domain insolar.Reference,
 	request insolar.Reference,
 	object artifacts.ObjectDescriptor,
 	memory []byte,
+	result []byte,
 ) (artifacts.ObjectDescriptor, error) {
 	objDesc, ok := t.Objects[*object.HeadRef()]
 	if !ok {
@@ -409,7 +385,7 @@ func AMPublishCode(
 	assert.NoError(t, err)
 	protoRef = &insolar.Reference{}
 	protoRef.SetRecord(*protoID)
-	_, err = am.ActivatePrototype(ctx, domain, *protoRef, insolar.GenesisRecord.Ref(), *codeRef, nil)
+	_, err = am.ActivatePrototype(ctx, *protoRef, insolar.GenesisRecord.Ref(), *codeRef, nil)
 	assert.NoError(t, err, "create template for contract data")
 
 	return typeRef, codeRef, protoRef, err
@@ -534,7 +510,6 @@ func (cb *ContractsBuilder) Build(contracts map[string]string) error {
 		// FIXME: It's a temporary fix and should not be here. Ii will NOT work properly on production. Remove it ASAP!
 		_, err = cb.ArtifactManager.ActivatePrototype(
 			ctx,
-			insolar.Reference{},
 			*cb.Prototypes[name],
 			insolar.GenesisRecord.Ref(), // FIXME: Only bootstrap can do this!
 			*codeRef,

--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -553,20 +553,23 @@ func (lr *LogicRunner) executeMethodCall(ctx context.Context, es *ExecutionState
 	am := lr.ArtifactManager
 	if current.Deactivate {
 		_, err := am.DeactivateObject(
-			ctx, Ref{}, *current.RequestRef, es.ObjectDescriptor,
+			ctx, *current.RequestRef, es.ObjectDescriptor, result,
 		)
 		if err != nil {
 			return nil, es.WrapError(current, err, "couldn't deactivate object")
 		}
 	} else if !bytes.Equal(es.ObjectDescriptor.Memory(), newData) {
-		_, err := am.UpdateObject(ctx, Ref{}, *current.RequestRef, es.ObjectDescriptor, newData)
+		_, err := am.UpdateObject(
+			ctx, *current.RequestRef, es.ObjectDescriptor, newData, result,
+		)
 		if err != nil {
 			return nil, es.WrapError(current, err, "couldn't update object")
 		}
-	}
-	_, err = am.RegisterResult(ctx, *request.Object, *current.RequestRef, result)
-	if err != nil {
-		return nil, es.WrapError(current, err, "couldn't save results")
+	} else {
+		_, err = am.RegisterResult(ctx, *request.Object, *current.RequestRef, result)
+		if err != nil {
+			return nil, es.WrapError(current, err, "couldn't save results")
+		}
 	}
 
 	return &reply.CallMethod{Result: result}, nil
@@ -635,14 +638,10 @@ func (lr *LogicRunner) executeConstructorCall(
 	case record.CTSaveAsChild, record.CTSaveAsDelegate:
 		_, err = lr.ArtifactManager.ActivateObject(
 			ctx,
-			Ref{}, *current.RequestRef, *request.Base, *request.Prototype, request.CallType == record.CTSaveAsDelegate, newData,
+			*current.RequestRef, *request.Base, *request.Prototype, request.CallType == record.CTSaveAsDelegate, newData,
 		)
 		if err != nil {
 			return nil, es.WrapError(current, err, "couldn't activate object")
-		}
-		_, err = lr.ArtifactManager.RegisterResult(ctx, *current.RequestRef, *current.RequestRef, nil)
-		if err != nil {
-			return nil, es.WrapError(current, err, "couldn't save results")
 		}
 		return &reply.CallConstructor{Object: current.RequestRef}, err
 

--- a/logicrunner/logicrunner_test.go
+++ b/logicrunner/logicrunner_test.go
@@ -1147,7 +1147,6 @@ func (s *LogicRunnerFuncSuite) TestRootDomainContractError() {
 	rootDomainRef := getRefFromID(rootDomainID)
 	rootDomainDesc, err := am.ActivateObject(
 		ctx,
-		insolar.Reference{},
 		*rootDomainRef,
 		insolar.GenesisRecord.Ref(),
 		*cb.Prototypes["rootdomain"],
@@ -1180,7 +1179,6 @@ func (s *LogicRunnerFuncSuite) TestRootDomainContractError() {
 
 	_, err = am.ActivateObject(
 		ctx,
-		insolar.Reference{},
 		*rootMemberRef,
 		*rootDomainRef,
 		*cb.Prototypes["member"],
@@ -1190,7 +1188,11 @@ func (s *LogicRunnerFuncSuite) TestRootDomainContractError() {
 	s.NoError(err)
 
 	// Updating root domain with root member
-	_, err = am.UpdateObject(ctx, insolar.Reference{}, insolar.Reference{}, rootDomainDesc, goplugintestutils.CBORMarshal(s.T(), rootdomain.RootDomain{RootMember: *rootMemberRef}))
+	_, err = am.UpdateObject(
+		ctx, insolar.Reference{}, rootDomainDesc,
+		goplugintestutils.CBORMarshal(s.T(), rootdomain.RootDomain{RootMember: *rootMemberRef}),
+		[]byte{},
+	)
 	s.NoError(err)
 
 	csRoot := cryptography.NewKeyBoundCryptographyService(rootKey)
@@ -1545,7 +1547,6 @@ func (r *One) CreateAllowance(member string) (error) {
 	rootDomainRef := getRefFromID(rootDomainID)
 	rootDomainDesc, err := am.ActivateObject(
 		ctx,
-		insolar.Reference{},
 		*rootDomainRef,
 		insolar.GenesisRecord.Ref(),
 		*cb.Prototypes["rootdomain"],
@@ -1576,7 +1577,6 @@ func (r *One) CreateAllowance(member string) (error) {
 
 	_, err = am.ActivateObject(
 		ctx,
-		insolar.Reference{},
 		*rootMemberRef,
 		*rootDomainRef,
 		*cb.Prototypes["member"],
@@ -1586,7 +1586,11 @@ func (r *One) CreateAllowance(member string) (error) {
 	s.NoError(err)
 
 	// Updating root domain with root member
-	_, err = am.UpdateObject(ctx, insolar.Reference{}, insolar.Reference{}, rootDomainDesc, goplugintestutils.CBORMarshal(s.T(), rootdomain.RootDomain{RootMember: *rootMemberRef}))
+	_, err = am.UpdateObject(
+		ctx, insolar.Reference{}, rootDomainDesc,
+		goplugintestutils.CBORMarshal(s.T(), rootdomain.RootDomain{RootMember: *rootMemberRef}),
+		[]byte{},
+	)
 	s.NoError(err)
 
 	cs := cryptography.NewKeyBoundCryptographyService(rootKey)
@@ -1603,8 +1607,6 @@ func (r *One) CreateAllowance(member string) (error) {
 	s.NotEqual("", memberRef)
 
 	// Call CreateAllowance method in custom contract
-	domain, err := insolar.NewReferenceFromBase58("7ZQboaH24PH42sqZKUvoa7UBrpuuubRtShp6CKNuWGZa.7ZQboaH24PH42sqZKUvoa7UBrpuuubRtShp6CKNuWGZa")
-	s.Require().NoError(err)
 	contractID, err := am.RegisterRequest(
 		ctx,
 		record.Request{CallType: record.CTSaveAsChild},
@@ -1613,7 +1615,6 @@ func (r *One) CreateAllowance(member string) (error) {
 	contract := getRefFromID(contractID)
 	_, err = am.ActivateObject(
 		ctx,
-		*domain,
 		*contract,
 		insolar.GenesisRecord.Ref(),
 		*cb.Prototypes["one"],
@@ -2080,9 +2081,6 @@ func (c *First) GetName() (string, error) {
 }
 
 func (s *LogicRunnerFuncSuite) getObjectInstance(ctx context.Context, am artifacts.Client, cb *goplugintestutils.ContractsBuilder, contractName string) (*insolar.Reference, *insolar.Reference) {
-	domain, err := insolar.NewReferenceFromBase58("4K3NiGuqYGqKPnYp6XeGd2kdN4P9veL6rYcWkLKWXZCu.7ZQboaH24PH42sqZKUvoa7UBrpuuubRtShp6CKNuWGZa")
-	s.Require().NoError(err)
-
 	proto := testutils.RandomRef()
 
 	contractID, err := am.RegisterRequest(
@@ -2094,7 +2092,6 @@ func (s *LogicRunnerFuncSuite) getObjectInstance(ctx context.Context, am artifac
 
 	_, err = am.ActivateObject(
 		ctx,
-		*domain,
 		*objectRef,
 		insolar.GenesisRecord.Ref(),
 		*cb.Prototypes[contractName],

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -1213,12 +1213,8 @@ func (suite *LogicRunnerTestSuite) TestCallMethodWithOnPulse() {
 
 				suite.am.GetCodeMock.Return(cd, nil)
 
-				suite.am.RegisterResultFunc = func(
-					ctx context.Context, r1 insolar.Reference, r2 insolar.Reference, mem []byte,
-				) (*insolar.ID, error) {
-					resId := testutils.RandomID()
-					return &resId, nil
-				}
+				resId := testutils.RandomID()
+				suite.am.RegisterResultMock.Return(&resId, nil)
 			}
 
 			wg := sync.WaitGroup{}


### PR DESCRIPTION
ActivateObject, UpdateObject and DeactivateObject now send result record
along with update record

a few things that were in the way:
* delete DOMAIN argument from a few methods in artifact manager client,
  this field is not used
* AM client loses not used methods: DeclareType, UpdatePrototype,
  RegisterResult
