### PR TITLE
INS-2612: fix race in TestTimeoutSuite

### DIFF
--- a/api/call_test.go
+++ b/api/call_test.go
@@ -23,6 +23,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gojuno/minimock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/insolar/insolar/api/requester"
 	"github.com/insolar/insolar/configuration"
 	"github.com/insolar/insolar/insolar"
@@ -31,18 +35,18 @@ import (
 	"github.com/insolar/insolar/logicrunner/goplugin/foundation"
 	"github.com/insolar/insolar/platformpolicy"
 	"github.com/insolar/insolar/testutils"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 const CallUrl = "http://localhost:19192/api/call"
 
 type TimeoutSuite struct {
 	suite.Suite
+
+	mc    *minimock.Controller
 	ctx   context.Context
 	api   *Runner
 	user  *requester.UserConfigJSON
-	delay bool
+	delay chan struct{}
 }
 
 type APIresp struct {
@@ -50,10 +54,13 @@ type APIresp struct {
 	Error  string
 }
 
-func (suite *TimeoutSuite) TestRunner_callHandler() {
+func (suite *TimeoutSuite) TestRunner_callHandler_NoTimeout() {
 	seed, err := suite.api.SeedGenerator.Next()
 	suite.NoError(err)
 	suite.api.SeedManager.Add(*seed)
+
+	close(suite.delay)
+	suite.api.cfg.Timeout = 60
 
 	resp, err := requester.SendWithSeed(
 		suite.ctx,
@@ -71,12 +78,13 @@ func (suite *TimeoutSuite) TestRunner_callHandler() {
 	suite.Equal("OK", result.Result)
 }
 
-func (suite *TimeoutSuite) TestRunner_callHandlerTimeout() {
+func (suite *TimeoutSuite) TestRunner_callHandler_Timeout() {
 	seed, err := suite.api.SeedGenerator.Next()
 	suite.NoError(err)
 	suite.api.SeedManager.Add(*seed)
 
-	suite.delay = true
+	suite.api.cfg.Timeout = 1
+
 	resp, err := requester.SendWithSeed(
 		suite.ctx,
 		CallUrl,
@@ -85,6 +93,8 @@ func (suite *TimeoutSuite) TestRunner_callHandlerTimeout() {
 		seed[:],
 	)
 	suite.NoError(err)
+
+	close(suite.delay)
 
 	var result APIresp
 	err = json.Unmarshal(resp, &result)
@@ -96,6 +106,7 @@ func (suite *TimeoutSuite) TestRunner_callHandlerTimeout() {
 func TestTimeoutSuite(t *testing.T) {
 	timeoutSuite := new(TimeoutSuite)
 	timeoutSuite.ctx, _ = inslogger.WithTraceField(context.Background(), "APItests")
+	timeoutSuite.mc = minimock.NewController(t)
 
 	ks := platformpolicy.NewKeyProcessor()
 	sKey, err := ks.GeneratePrivateKey()
@@ -116,18 +127,18 @@ func TestTimeoutSuite(t *testing.T) {
 	timeoutSuite.api, err = NewRunner(&cfg)
 	require.NoError(t, err)
 
-	cert := testutils.NewCertificateMock(t)
+	cert := testutils.NewCertificateMock(timeoutSuite.mc)
 	cert.GetRootDomainReferenceFunc = func() (r *insolar.Reference) {
 		ref := testutils.RandomRef()
 		return &ref
 	}
 
-	cm := testutils.NewCertificateManagerMock(t)
+	cm := testutils.NewCertificateManagerMock(timeoutSuite.mc)
 	cm.GetCertificateFunc = func() (r insolar.Certificate) {
 		return cert
 	}
 
-	cr := testutils.NewContractRequesterMock(t)
+	cr := testutils.NewContractRequesterMock(timeoutSuite.mc)
 	cr.SendRequestFunc = func(p context.Context, p1 *insolar.Reference, method string, p3 []interface{}) (insolar.Reply, error) {
 		switch method {
 		case "GetPublicKey":
@@ -138,9 +149,7 @@ func TestTimeoutSuite(t *testing.T) {
 				Result: data,
 			}, nil
 		default:
-			if timeoutSuite.delay {
-				time.Sleep(time.Second * 21)
-			}
+			<-timeoutSuite.delay
 			var result = "OK"
 			var contractErr *foundation.Error
 			data, _ := insolar.MarshalArgs(result, contractErr)
@@ -158,4 +167,13 @@ func TestTimeoutSuite(t *testing.T) {
 	suite.Run(t, timeoutSuite)
 
 	timeoutSuite.api.Stop(timeoutSuite.ctx)
+}
+
+func (suite *TimeoutSuite) BeforeTest(suiteName, testName string) {
+	suite.delay = make(chan struct{}, 0)
+}
+
+func (suite *TimeoutSuite) AfterTest(suiteName, testName string) {
+	suite.mc.Wait(1*time.Minute)
+	suite.mc.Finish()
 }


### PR DESCRIPTION
the fix is in mc.Wait() that makes sure we don't change mocked function
while running code of the function

got rid of suite as one test was testing "no timeout" and other "with
timeout" and these required different configuration