### PR TITLE
INS-2704: fix the same port bind in server initialization tests

### DIFF
--- a/server/internal/heavy/components_test.go
+++ b/server/internal/heavy/components_test.go
@@ -31,6 +31,8 @@ func TestComponents(t *testing.T) {
 	cfg := configuration.NewConfiguration()
 	cfg.KeysPath = "testdata/bootstrap_keys.json"
 	cfg.CertificatePath = "testdata/certificate.json"
+	cfg.Metrics.ListenAddress = "0.0.0.0:0"
+	cfg.APIRunner.Address = "0.0.0.0:0"
 
 	c, err := newComponents(ctx, cfg, insolar.GenesisHeavyConfig{Skip: true})
 	require.NoError(t, err)

--- a/server/internal/light/components_test.go
+++ b/server/internal/light/components_test.go
@@ -30,6 +30,8 @@ func TestComponents(t *testing.T) {
 	cfg := configuration.NewConfiguration()
 	cfg.KeysPath = "testdata/bootstrap_keys.json"
 	cfg.CertificatePath = "testdata/certificate.json"
+	cfg.Metrics.ListenAddress = "0.0.0.0:0"
+	cfg.APIRunner.Address = "0.0.0.0:0"
 
 	c, err := newComponents(ctx, cfg)
 	require.NoError(t, err)

--- a/server/internal/virtual/components_test.go
+++ b/server/internal/virtual/components_test.go
@@ -30,6 +30,8 @@ func TestInitComponents(t *testing.T) {
 	cfg := configuration.NewConfiguration()
 	cfg.KeysPath = "testdata/bootstrap_keys.json"
 	cfg.CertificatePath = "testdata/certificate.json"
+	cfg.Metrics.ListenAddress = "0.0.0.0:0"
+	cfg.APIRunner.Address = "0.0.0.0:0"
 
 	bootstrapComponents := initBootstrapComponents(ctx, cfg)
 	cert := initCertificateManager(


### PR DESCRIPTION
it doesn't matter which port to use in initialization tests
