### PR TITLE
INS-2558: set new trace id to backgound processes on light

### DIFF
--- a/ledger/light/replication/cleaner.go
+++ b/ledger/light/replication/cleaner.go
@@ -89,7 +89,7 @@ func NewCleaner(
 // all the data for it will be cleaned
 func (c *LightCleaner) NotifyAboutPulse(ctx context.Context, pn insolar.PulseNumber) {
 	c.once.Do(func() {
-		go c.clean(ctx)
+		go c.clean(context.Background())
 	})
 	inslogger.FromContext(ctx).Debugf("[Cleaner][NotifyAboutPulse] received pulse - %v", pn)
 	c.pulseForClean <- pn

--- a/ledger/light/replication/cleaner.go
+++ b/ledger/light/replication/cleaner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/insolar/insolar/insolar/jet"
 	"github.com/insolar/insolar/insolar/node"
 	"github.com/insolar/insolar/insolar/pulse"
+	"github.com/insolar/insolar/insolar/utils"
 	"github.com/insolar/insolar/instrumentation/inslogger"
 	"github.com/insolar/insolar/ledger/blob"
 	"github.com/insolar/insolar/ledger/drop"
@@ -95,8 +96,8 @@ func (c *LightCleaner) NotifyAboutPulse(ctx context.Context, pn insolar.PulseNum
 }
 
 func (c *LightCleaner) clean(ctx context.Context) {
-	logger := inslogger.FromContext(ctx)
 	for pn := range c.pulseForClean {
+		ctx, logger := inslogger.WithTraceField(ctx, utils.RandTraceID())
 		logger.Debugf("[Cleaner][NotifyAboutPulse] start cleaning pulse - %v", pn)
 
 		expiredPn, err := c.pulseCalculator.Backwards(ctx, pn, c.lightChainLimit)

--- a/ledger/light/replication/cleaner_test.go
+++ b/ledger/light/replication/cleaner_test.go
@@ -17,6 +17,7 @@
 package replication
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/insolar/insolar/ledger/blob"
 	"github.com/insolar/insolar/ledger/drop"
 	"github.com/insolar/insolar/ledger/object"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCleaner_cleanPulse(t *testing.T) {
@@ -66,6 +68,12 @@ func TestCleaner_cleanPulse(t *testing.T) {
 	ctrl.Finish()
 }
 
+func DeleteForPNMock(t *testing.T, expected insolar.PulseNumber) func(p context.Context, p1 insolar.PulseNumber) {
+	return func(ctx context.Context, actual insolar.PulseNumber) {
+		require.Equal(t, expected, actual)
+	}
+}
+
 func TestCleaner_clean(t *testing.T) {
 	ctx := inslogger.TestContext(t)
 
@@ -76,28 +84,37 @@ func TestCleaner_clean(t *testing.T) {
 	ctrl := minimock.NewController(t)
 
 	jm := jet.NewStorageMock(ctrl)
-	jm.DeleteForPNMock.Expect(ctx, calculatedPulse.PulseNumber)
+	jm.DeleteForPNFunc = DeleteForPNMock(t, calculatedPulse.PulseNumber)
 
 	nm := node.NewModifierMock(ctrl)
 	nm.DeleteForPNMock.Expect(calculatedPulse.PulseNumber)
 
 	dc := drop.NewCleanerMock(ctrl)
-	dc.DeleteForPNMock.Expect(ctx, calculatedPulse.PulseNumber)
+	dc.DeleteForPNFunc = DeleteForPNMock(t, calculatedPulse.PulseNumber)
 
 	bc := blob.NewCleanerMock(ctrl)
-	bc.DeleteForPNMock.Expect(ctx, calculatedPulse.PulseNumber)
+	bc.DeleteForPNFunc = func(p context.Context, pn insolar.PulseNumber) {
+		require.Equal(t, calculatedPulse.PulseNumber, pn)
+	}
 
 	rc := object.NewRecordCleanerMock(ctrl)
-	rc.DeleteForPNMock.Expect(ctx, calculatedPulse.PulseNumber)
+	rc.DeleteForPNFunc = DeleteForPNMock(t, calculatedPulse.PulseNumber)
 
 	ic := object.NewIndexCleanerMock(ctrl)
-	ic.DeleteForPNMock.Expect(ctx, calculatedPulse.PulseNumber)
+	ic.DeleteForPNFunc = DeleteForPNMock(t, calculatedPulse.PulseNumber)
 
 	ps := pulse.NewShifterMock(ctrl)
-	ps.ShiftMock.Expect(ctx, calculatedPulse.PulseNumber).Return(nil)
+	ps.ShiftFunc = func(p context.Context, pn insolar.PulseNumber) error {
+		require.Equal(t, calculatedPulse.PulseNumber, pn)
+		return nil
+	}
 
 	pc := pulse.NewCalculatorMock(ctrl)
-	pc.BackwardsMock.Expect(ctx, inputPulse.PulseNumber, limit).Return(calculatedPulse, nil)
+	pc.BackwardsFunc = func(p context.Context, pn insolar.PulseNumber, l int) (r insolar.Pulse, r1 error) {
+		require.Equal(t, inputPulse.PulseNumber, pn)
+		require.Equal(t, limit, l)
+		return calculatedPulse, nil
+	}
 
 	cleaner := NewCleaner(jm, nm, dc, bc, rc, ic, ps, pc, limit)
 	defer close(cleaner.pulseForClean)
@@ -118,28 +135,35 @@ func TestLightCleaner_NotifyAboutPulse(t *testing.T) {
 	ctrl := minimock.NewController(t)
 
 	jm := jet.NewStorageMock(ctrl)
-	jm.DeleteForPNMock.Expect(ctx, calculatedPulse.PulseNumber)
+	jm.DeleteForPNFunc = DeleteForPNMock(t, calculatedPulse.PulseNumber)
 
 	nm := node.NewModifierMock(ctrl)
 	nm.DeleteForPNMock.Expect(calculatedPulse.PulseNumber)
 
 	dc := drop.NewCleanerMock(ctrl)
-	dc.DeleteForPNMock.Expect(ctx, calculatedPulse.PulseNumber)
+	dc.DeleteForPNFunc = DeleteForPNMock(t, calculatedPulse.PulseNumber)
 
 	bc := blob.NewCleanerMock(ctrl)
-	bc.DeleteForPNMock.Expect(ctx, calculatedPulse.PulseNumber)
+	bc.DeleteForPNFunc = DeleteForPNMock(t, calculatedPulse.PulseNumber)
 
 	rc := object.NewRecordCleanerMock(ctrl)
-	rc.DeleteForPNMock.Expect(ctx, calculatedPulse.PulseNumber)
+	rc.DeleteForPNFunc = DeleteForPNMock(t, calculatedPulse.PulseNumber)
 
 	ic := object.NewIndexCleanerMock(ctrl)
-	ic.DeleteForPNMock.Expect(ctx, calculatedPulse.PulseNumber)
+	ic.DeleteForPNFunc = DeleteForPNMock(t, calculatedPulse.PulseNumber)
 
 	ps := pulse.NewShifterMock(ctrl)
-	ps.ShiftMock.Expect(ctx, calculatedPulse.PulseNumber).Return(nil)
+	ps.ShiftFunc = func(p context.Context, pn insolar.PulseNumber) error {
+		require.Equal(t, calculatedPulse.PulseNumber, pn)
+		return nil
+	}
 
 	pc := pulse.NewCalculatorMock(ctrl)
-	pc.BackwardsMock.Expect(ctx, inputPulse.PulseNumber, limit).Return(calculatedPulse, nil)
+	pc.BackwardsFunc = func(p context.Context, pn insolar.PulseNumber, l int) (r insolar.Pulse, r1 error) {
+		require.Equal(t, inputPulse.PulseNumber, pn)
+		require.Equal(t, limit, l)
+		return calculatedPulse, nil
+	}
 
 	cleaner := NewCleaner(jm, nm, dc, bc, rc, ic, ps, pc, limit)
 	defer close(cleaner.pulseForClean)

--- a/ledger/light/replication/lightreplicator.go
+++ b/ledger/light/replication/lightreplicator.go
@@ -75,7 +75,7 @@ func NewReplicatorDefault(
 // with help of Cleaner
 func (t *LightReplicatorDefault) NotifyAboutPulse(ctx context.Context, pn insolar.PulseNumber) {
 	t.once.Do(func() {
-		go t.sync(ctx)
+		go t.sync(context.Background())
 	})
 
 	logger := inslogger.FromContext(ctx)

--- a/ledger/light/replication/lightreplicator.go
+++ b/ledger/light/replication/lightreplicator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/pulse"
 	"github.com/insolar/insolar/insolar/reply"
+	"github.com/insolar/insolar/insolar/utils"
 	"github.com/insolar/insolar/instrumentation/inslogger"
 	"github.com/insolar/insolar/ledger/light/executor"
 	"go.opencensus.io/stats"
@@ -91,8 +92,8 @@ func (t *LightReplicatorDefault) NotifyAboutPulse(ctx context.Context, pn insola
 }
 
 func (t *LightReplicatorDefault) sync(ctx context.Context) {
-	logger := inslogger.FromContext(ctx)
 	for pn := range t.syncWaitingPulses {
+		ctx, logger := inslogger.WithTraceField(ctx, utils.RandTraceID())
 		logger.Debugf("[Replicator][sync] pn received - %v", pn)
 
 		jets := t.jetCalculator.MineForPulse(ctx, pn)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Set new traceId to LightCleaner's and LightReplicatorDefault's background processes

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
