### PR TITLE
NOISSUE: send error via network rpc if generated

### DIFF
--- a/network/controller/pinger/pinger_test.go
+++ b/network/controller/pinger/pinger_test.go
@@ -128,12 +128,12 @@ func TestPing_HappyPath(t *testing.T) {
 
 	pinger := NewPinger(n)
 
-	_, err = pinger.Ping(ctx, n2.PublicAddress(), time.Second*10)
+	_, err = pinger.Ping(ctx, n2.PublicAddress(), time.Second*1)
 	assert.NoError(t, err)
-	_, err = pinger.Ping(ctx, n2.PublicAddress(), time.Millisecond*500)
+	_, err = pinger.Ping(ctx, n2.PublicAddress(), time.Nanosecond*1)
 	assert.Error(t, err)
-	_, err = pinger.Ping(ctx, n2.PublicAddress(), time.Second*10)
+	_, err = pinger.Ping(ctx, n2.PublicAddress(), time.Second*1)
 	assert.NoError(t, err)
-	_, err = pinger.Ping(ctx, n2.PublicAddress(), time.Millisecond*500)
+	_, err = pinger.Ping(ctx, n2.PublicAddress(), time.Nanosecond*1)
 	assert.Error(t, err)
 }

--- a/network/hostnetwork/hostnetwork.go
+++ b/network/hostnetwork/hostnetwork.go
@@ -192,6 +192,9 @@ func (hn *hostNetwork) handleRequest(ctx context.Context, p *packet.Packet) {
 	response, err := handler(ctx, p)
 	if err != nil {
 		logger.Errorf("Error handling request %s from node %s: %s", p.GetType(), p.Sender.NodeID, err)
+		ep := hn.BuildResponse(ctx, p, &packet.ErrorResponse{Error: err.Error()}).(*packet.Packet)
+		ep.RequestID = p.RequestID
+		SendPacket(ctx, hn.pool, ep)
 		return
 	}
 

--- a/network/hostnetwork/hostnetwork.go
+++ b/network/hostnetwork/hostnetwork.go
@@ -194,7 +194,9 @@ func (hn *hostNetwork) handleRequest(ctx context.Context, p *packet.Packet) {
 		logger.Errorf("Error handling request %s from node %s: %s", p.GetType(), p.Sender.NodeID, err)
 		ep := hn.BuildResponse(ctx, p, &packet.ErrorResponse{Error: err.Error()}).(*packet.Packet)
 		ep.RequestID = p.RequestID
-		SendPacket(ctx, hn.pool, ep)
+		if err = SendPacket(ctx, hn.pool, ep); err != nil {
+			logger.Errorf("Error while returning error response for request %s from node %s: %s", p.GetType(), p.Sender.NodeID, err)
+		}
 		return
 	}
 

--- a/network/hostnetwork/hostnetwork.go
+++ b/network/hostnetwork/hostnetwork.go
@@ -180,6 +180,11 @@ func (hn *hostNetwork) handleRequest(ctx context.Context, p *packet.Packet) {
 	handler, exist := hn.handlers[p.GetType()]
 	if !exist {
 		logger.Errorf("No handler set for packet type %s from node %s", p.GetType(), p.Sender.NodeID)
+		ep := hn.BuildResponse(ctx, p, &packet.ErrorResponse{Error: "UNKNOWN RPC ENDPOINT"}).(*packet.Packet)
+		ep.RequestID = p.RequestID
+		if err := SendPacket(ctx, hn.pool, ep); err != nil {
+			logger.Errorf("Error while returning error response for request %s from node %s: %s", p.GetType(), p.Sender.NodeID, err)
+		}
 		return
 	}
 	ctx, span := instracer.StartSpan(ctx, "hostTransport.processMessage")


### PR DESCRIPTION
Here is special protobuf message ResponseError
And we will send it if error was returned from handler.