### PR TITLE
INS-2008: delete custom WrapError methods and as result ES argument

### DIFF
--- a/logicrunner/executionstate.go
+++ b/logicrunner/executionstate.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/pkg/errors"
-
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/message"
 	"github.com/insolar/insolar/instrumentation/inslogger"
@@ -63,20 +61,6 @@ func (es *ExecutionState) RegisterLogicRunner(lr *LogicRunner) {
 		ledgerChecked: sync.Once{},
 		lr:            lr,
 	}
-}
-
-func (es *ExecutionState) WrapError(current *Transcript, err error, message string) error {
-	if err == nil {
-		err = errors.New(message)
-	} else {
-		err = errors.Wrap(err, message)
-	}
-	res := Error{Err: err}
-	res.Contract = &es.Ref
-	if current != nil {
-		res.Request = current.RequestRef
-	}
-	return res
 }
 
 func (es *ExecutionState) OnPulse(ctx context.Context, meNext bool) []insolar.Message {

--- a/logicrunner/handle_calls.go
+++ b/logicrunner/handle_calls.go
@@ -119,7 +119,7 @@ func (h *HandleCall) handleActual(
 
 	if lr.CheckExecutionLoop(ctx, es, parcel) {
 		es.Unlock()
-		return nil, os.WrapError(nil, "loop detected")
+		return nil, errors.New("loop detected")
 	}
 	es.Unlock()
 
@@ -133,7 +133,7 @@ func (h *HandleCall) handleActual(
 			// Requests need to be deduplicated. For now in case of ErrCancelled we may have 2 registered requests
 			return nil, err // message bus will retry on the calling side in ContractRequester
 		}
-		return nil, os.WrapError(err, "[ HandleCall.handleActual ] can't create request")
+		return nil, errors.Wrap(err, "[ HandleCall.handleActual ] can't create request")
 	}
 	request := procRegisterRequest.getResult()
 

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -747,7 +747,7 @@ func (suite *LogicRunnerTestSuite) TestNoExcessiveAmends() {
 	// In this case Update isn't send to ledger (objects data/newData are the same)
 	suite.am.RegisterResultMock.Return(nil, nil)
 
-	_, err := suite.lr.executeMethodCall(suite.ctx, es, current)
+	_, err := suite.lr.executeMethodCall(suite.ctx, current)
 	suite.Require().NoError(err)
 	suite.Require().Equal(uint64(0), suite.am.UpdateObjectCounter)
 
@@ -755,7 +755,7 @@ func (suite *LogicRunnerTestSuite) TestNoExcessiveAmends() {
 	newData := make([]byte, 5, 5)
 	mle.CallMethodMock.Return(newData, nil, nil)
 
-	_, err = suite.lr.executeMethodCall(suite.ctx, es, current)
+	_, err = suite.lr.executeMethodCall(suite.ctx, current)
 	suite.Require().NoError(err)
 	suite.Require().Equal(uint64(1), suite.am.UpdateObjectCounter)
 }


### PR DESCRIPTION
once WrapError methods are gone then ExecutionState is not required in
execute{Method,Constructor}Call methods