### PR TITLE
disabling notifications from ledger regarding abandoned requests

### DIFF
--- a/logicrunner/handle_abandonedrequestsnotification.go
+++ b/logicrunner/handle_abandonedrequestsnotification.go
@@ -67,6 +67,9 @@ type HandleAbandonedRequestsNotification struct {
 }
 
 func (h *HandleAbandonedRequestsNotification) Present(ctx context.Context, f flow.Flow) error {
+	h.Message.ReplyTo <- bus.Reply{Reply: &reply.OK{}, Err: nil}
+	return nil
+
 	parcel := h.Message.Parcel
 	ctx = loggerWithTargetID(ctx, parcel)
 	logger := inslogger.FromContext(ctx)

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -761,6 +761,8 @@ func (suite *LogicRunnerTestSuite) TestNoExcessiveAmends() {
 }
 
 func (suite *LogicRunnerTestSuite) TestHandleAbandonedRequestsNotificationMessage() {
+	suite.T().Skip("we disabled handling of this notification for now")
+
 	objectId := testutils.RandomID()
 	objectRef := *insolar.NewReference(objectId)
 	msg := &message.AbandonedRequestsNotification{Object: objectId}


### PR DESCRIPTION
they don't work at the moment, we wait for a branch to be merged that
should change drastically how pending requests work.

the current problem is that we get notification, handle it, record
result, ask for next request from ledger, get the same, repeat this loop
forever.

our tests at this moment shouldn't suffer