### PR TITLE
INS-2008: SentResult was a workaround, get rid of it

### DIFF
--- a/logicrunner/currentexecution.go
+++ b/logicrunner/currentexecution.go
@@ -132,7 +132,6 @@ type Transcript struct {
 	Request          *record.Request
 	RequestRef       *insolar.Reference
 	RequesterNode    *insolar.Reference
-	SentResult       bool
 	Nonce            uint64
 	Deactivate       bool
 	OutgoingRequests []OutgoingRequest
@@ -165,7 +164,6 @@ func NewTranscript(ctx context.Context, parcel insolar.Parcel, requestRef *insol
 		Request:       &msg.Request,
 		RequestRef:    requestRef,
 		RequesterNode: &sender,
-		SentResult:    false,
 		Nonce:         0,
 		Deactivate:    false,
 

--- a/logicrunner/executionstate.go
+++ b/logicrunner/executionstate.go
@@ -192,11 +192,18 @@ func (es *ExecutionState) executeTranscript(ctx context.Context, t *Transcript, 
 	es.CurrentList.Set(*t.RequestRef, t)
 	es.Unlock()
 
-	args.lr.executeAndReply(t.Context, es, t)
+	re, err := args.lr.executeLogic(ctx, t)
+	errstr := ""
+	if err != nil {
+		inslogger.FromContext(ctx).Warn("contract execution error: ", err)
+		errstr = err.Error()
+	}
 
 	es.Lock()
 	es.CurrentList.Delete(*t.RequestRef)
 	es.Unlock()
+
+	args.lr.sendRequestReply(t.Context, t, re, errstr)
 
 	if t.FromLedger {
 		// we've already told ledger that we've processed it's task;

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -626,7 +626,6 @@ func (suite *LogicRunnerTestSuite) TestCheckExecutionLoop() {
 
 	es.CurrentList.Set(msg.GetReference(), &Transcript{
 		Request:    &record.Request{ReturnMode: record.ReturnNoWait},
-		SentResult: true,
 	})
 	loop = suite.lr.CheckExecutionLoop(suite.ctx, es, parcel)
 	suite.Require().False(loop)


### PR DESCRIPTION
we were not deleting executed transcript from list of current
executions before sending result. this could lead to new incoming
request to the same object with the same APIRequestID and false loop
detection.

new code deletes request from list of currently executed queries right
after saving everything to ledger and before sending a reply