### PR TITLE
we were not restarting local execution when we think previous died

### DIFF
--- a/logicrunner/executionstate.go
+++ b/logicrunner/executionstate.go
@@ -89,7 +89,7 @@ func (es *ExecutionState) OnPulse(ctx context.Context, meNext bool) []insolar.Me
 			)
 		} else if es.pending == message.InPending && !es.PendingConfirmed {
 			inslogger.FromContext(ctx).Warn(
-				"looks like pending executor died, continuing execution",
+				"looks like pending executor died, continuing execution on next executor",
 			)
 			es.pending = message.NotPending
 			sendExecResults = true
@@ -131,7 +131,7 @@ func (es *ExecutionState) OnPulse(ctx context.Context, meNext bool) []insolar.Me
 			}
 		} else if es.pending == message.InPending && !es.PendingConfirmed {
 			inslogger.FromContext(ctx).Warn(
-				"looks like pending executor died, continuing execution",
+				"looks like pending executor died, re-starting execution",
 			)
 			es.pending = message.NotPending
 			es.LedgerHasMoreRequests = true

--- a/logicrunner/handle_executorresults.go
+++ b/logicrunner/handle_executorresults.go
@@ -71,6 +71,7 @@ func (p *initializeExecutionState) Proceed(ctx context.Context) error {
 		}
 	} else if es.pending == message.PendingUnknown {
 		es.pending = p.msg.Pending
+		logger.Debug("pending state was unknown, setting from previous executor to ", es.pending)
 
 		if es.pending == message.PendingUnknown {
 			p.Result.clarifyPending = true

--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -501,8 +501,13 @@ func (lr *LogicRunner) OnPulse(ctx context.Context, pulse insolar.Pulse) error {
 				if es.CurrentList.Empty() {
 					state.ExecutionState = nil
 				}
-			} else if es.pending == message.NotPending && es.LedgerHasMoreRequests {
-				lr.startGetLedgerPendingRequest(ctx, es)
+			} else {
+				if es.pending == message.NotPending && es.LedgerHasMoreRequests {
+					lr.startGetLedgerPendingRequest(ctx, es)
+				}
+				if es.pending == message.NotPending {
+					es.Broker.StartProcessorIfNeeded(ctx)
+				}
 			}
 
 			es.Unlock()


### PR DESCRIPTION
if we next executor on pulse change and decided that execution died
then we should start queue processor. otherwise we could wait more than
one pulse if execution stayed on the same virtual for several pulses
