### PR TITLE
NOISSUE: remove 'slowtest' build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,15 +150,11 @@ functest_race:
 .PHONY: test_func
 test_func: functest
 
-.PHONY: test_slow
-test_slow:
-	CGO_ENABLED=1 go test $(TEST_ARGS) -tags slowtest ./logicrunner/... ./server/internal/...
-
 .PHONY: test
 test: test_unit
 
 .PHONY: test_all
-test_all: test_unit test_func test_slow
+test_all: test_unit test_func
 
 .PHONY: test_with_coverage
 test_with_coverage: $(ARTIFACTS_DIR)
@@ -175,17 +171,12 @@ $(ARTIFACTS_DIR):
 .PHONY: ci_test_with_coverage
 ci_test_with_coverage:
 	GOMAXPROCS=$(CI_GOMAXPROCS) CGO_ENABLED=1 \
-		go test $(CI_TEST_ARGS) $(TEST_ARGS) -json -v -count 1 --coverprofile=$(COVERPROFILE) --covermode=atomic -tags slowtest $(ALL_PACKAGES)
+		go test $(CI_TEST_ARGS) $(TEST_ARGS) -json -v -count 1 --coverprofile=$(COVERPROFILE) --covermode=atomic $(ALL_PACKAGES)
 
 .PHONY: ci_test_unit
 ci_test_unit:
 	GOMAXPROCS=$(CI_GOMAXPROCS) CGO_ENABLED=1 \
 		go test $(CI_TEST_ARGS) $(TEST_ARGS) -json -v $(ALL_PACKAGES) -race -count 10 | tee ci_test_unit.json
-
-.PHONY: ci_test_slow
-ci_test_slow:
-	GOMAXPROCS=$(CI_GOMAXPROCS) CGO_ENABLED=1 \
-		go test $(CI_TEST_ARGS) $(TEST_ARGS) -json -v -tags slowtest ./logicrunner/... ./server/internal/... -count 1 | tee -a ci_test_unit.json
 
 .PHONY: ci_test_func
 ci_test_func:

--- a/logicrunner/goplugin/ginsider/ginsider_test.go
+++ b/logicrunner/goplugin/ginsider/ginsider_test.go
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// +build slowtest
 // +build !race
 
 // TODO test failed in race test call. added build tag to ignore this test
@@ -29,6 +28,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -115,8 +115,13 @@ func (s *HealthCheckSuite) prepareGoInsider(gi *GoInsider, protocol, socket stri
 	go rpc.Accept(listener)
 }
 
+// protection from count > 1 in go test invocation
+var onceHealthCheck sync.Once
+
 func TestHealthCheck(t *testing.T) {
-	suite.Run(t, new(HealthCheckSuite))
+	onceHealthCheck.Do(func() {
+		suite.Run(t, new(HealthCheckSuite))
+	})
 }
 
 func init() {

--- a/logicrunner/preprocessor/main_test.go
+++ b/logicrunner/preprocessor/main_test.go
@@ -14,8 +14,6 @@
 // limitations under the License.
 //
 
-// +build slowtest
-
 package preprocessor
 
 import (

--- a/logicrunner/preprocessor/real_contracts_test.go
+++ b/logicrunner/preprocessor/real_contracts_test.go
@@ -14,8 +14,6 @@
 // limitations under the License.
 //
 
-// +build slowtest
-
 package preprocessor
 
 import (

--- a/server/internal/heavy/components_test.go
+++ b/server/internal/heavy/components_test.go
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// +build slowtest
 
 package heavy
 

--- a/server/internal/light/components_test.go
+++ b/server/internal/light/components_test.go
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// +build slowtest
 
 package light
 

--- a/server/internal/virtual/components_test.go
+++ b/server/internal/virtual/components_test.go
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// +build slowtest
 
 package virtual
 


### PR DESCRIPTION
all slow tests migrate to func tests