### PR TITLE
INS-2868: remove faulty checks in tests

### DIFF
--- a/logicrunner/currentexecution_test.go
+++ b/logicrunner/currentexecution_test.go
@@ -169,26 +169,20 @@ func (s *ExecutionBrokerSuite) TestPut() {
 	reqRef1 := gen.Reference()
 	tr := &Transcript{
 		LogicContext: &insolar.LogicCallContext{Immutable: false},
-		RequestRef: &reqRef1,
+		RequestRef:   &reqRef1,
 	}
 
 	b.Put(ctx, false, tr)
-	b.processLock.Lock()
-	s.False(b.processActive) // this flag should be disbaled
-	b.processLock.Unlock()
 
 	s.Len(b.mutable.queue, 1)
 
 	reqRef2 := gen.Reference()
 	tr = &Transcript{
 		LogicContext: &insolar.LogicCallContext{Immutable: false},
-		RequestRef: &reqRef2,
+		RequestRef:   &reqRef2,
 	}
 
 	b.Put(ctx, true, tr)
-	b.processLock.Lock()
-	s.True(b.processActive) // this flag should be enabled
-	b.processLock.Unlock()
 
 	finishProcessing := func() bool { return b.finished.Len() == 2 }
 	s.Require().True(wait(finishProcessing), "failed to wait while processing is finished")
@@ -219,24 +213,18 @@ func (s *ExecutionBrokerSuite) TestPrepend() {
 	reqRef1 := gen.Reference()
 	tr := &Transcript{
 		LogicContext: &insolar.LogicCallContext{Immutable: false},
-		RequestRef: &reqRef1,
+		RequestRef:   &reqRef1,
 	}
 	b.Prepend(ctx, false, tr)
-	b.processLock.Lock()
-	s.False(b.processActive) // this flag should be disbaled
-	b.processLock.Unlock()
 
 	s.Len(b.mutable.queue, 1)
 
 	reqRef2 := gen.Reference()
 	tr = &Transcript{
 		LogicContext: &insolar.LogicCallContext{Immutable: false},
-		RequestRef: &reqRef2,
+		RequestRef:   &reqRef2,
 	}
 	b.Prepend(ctx, true, tr)
-	b.processLock.Lock()
-	s.True(b.processActive) // this flag should be enabled
-	b.processLock.Unlock()
 
 	finishProcessing := func() bool { return b.finished.Len() == 2 }
 	s.Require().True(wait(finishProcessing), "failed to wait while processing is finished")
@@ -268,13 +256,10 @@ func (s *ExecutionBrokerSuite) TestImmutable() {
 	reqRef1 := gen.Reference()
 	tr := &Transcript{
 		LogicContext: &insolar.LogicCallContext{Immutable: true},
-		RequestRef: &reqRef1,
+		RequestRef:   &reqRef1,
 	}
 
 	b.Prepend(ctx, false, tr)
-	b.processLock.Lock()
-	s.False(b.processActive) // we're not starting processor, but job is started
-	b.processLock.Unlock()
 
 	finishProcessing := func() bool { return b.finished.Len() == 1 }
 	s.Require().True(wait(finishProcessing), "failed to wait while processing is finished")
@@ -283,13 +268,10 @@ func (s *ExecutionBrokerSuite) TestImmutable() {
 	reqRef2 := gen.Reference()
 	tr = &Transcript{
 		LogicContext: &insolar.LogicCallContext{Immutable: true},
-		RequestRef: &reqRef2,
+		RequestRef:   &reqRef2,
 	}
 
 	b.Prepend(ctx, true, tr)
-	b.processLock.Lock()
-	s.True(b.processActive) // we're not starting processor, but job is started
-	b.processLock.Unlock()
 	finishProcessing = func() bool { return b.finished.Len() == 2 }
 	s.Require().True(wait(finishProcessing), "failed to wait while processing is finished")
 	s.Require().True(wait(processGoroutineExits))
@@ -297,15 +279,12 @@ func (s *ExecutionBrokerSuite) TestImmutable() {
 	reqRef3 := gen.Reference()
 	tr = &Transcript{
 		LogicContext: &insolar.LogicCallContext{Immutable: true},
-		RequestRef: &reqRef3,
+		RequestRef:   &reqRef3,
 	}
 
 	// we can't process messages, do not do it
 	b.checkFunc = forbidProcessingFunc
 	b.Prepend(ctx, false, tr)
-	b.processLock.Lock()
-	s.False(b.processActive) // we're not starting processor, but job is started
-	b.processLock.Unlock()
 
 	finishProcessing = func() bool { return b.immutable.Len() == 1 }
 	s.Require().True(wait(finishProcessing), "failed to wait while processing is finished")
@@ -314,21 +293,15 @@ func (s *ExecutionBrokerSuite) TestImmutable() {
 	reqRef4 := gen.Reference()
 	tr = &Transcript{
 		LogicContext: &insolar.LogicCallContext{Immutable: true},
-		RequestRef: &reqRef4,
+		RequestRef:   &reqRef4,
 	}
 
 	b.Prepend(ctx, true, tr)
-	b.processLock.Lock()
-	s.True(b.processActive) // we're not starting processor, but job is started
-	b.processLock.Unlock()
 	finishProcessing = func() bool { return b.immutable.Len() == 2 }
 	s.Require().True(wait(finishProcessing), "failed to wait while processing is finished")
 	s.Require().True(wait(processGoroutineExits))
 
 	b.StartProcessorIfNeeded(ctx)
-	b.processLock.Lock()
-	s.True(b.processActive) // we're not starting processor, but job is started
-	b.processLock.Unlock()
 	finishProcessing = func() bool {
 		b.processLock.Lock()
 		defer b.processLock.Unlock()


### PR DESCRIPTION
Sometimes QueueProcessor (for example, if we have nothing to process)
finishes before we're checking "processActive" value.
Will be fixed in the future using mocks and channels
