### PR TITLE
INS-2870 fix insgorund cleaner call

### DIFF
--- a/logicrunner/goplugin/goplugintestutils/insgorund.go
+++ b/logicrunner/goplugin/goplugintestutils/insgorund.go
@@ -101,7 +101,7 @@ func StartInsgorund(cmdPath, lProto, listen, upstreamProto, upstreamAddr string,
 		close(cancelWarning)
 
 		p := runner.Process
-		err := p.Kill()
+		err := p.Signal(syscall.SIGTERM)
 		if err != nil {
 			log.Error("couldn't kill process: ", err)
 		}


### PR DESCRIPTION
**- What I did**
fix insgorund cleaner call in tests with count
**- How I did it**
change sigkill to sigterm, sigkill doesn't handle as expected https://github.com/golang/go/issues/9463
**- How to verify it**
run tests, now contractcache-* directories remove after each test iteration