### PR TITLE
INS-2714: Add regen-builtin to pre-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ install-build-tools:
 install-deps: install-godep install-build-tools
 
 .PHONY: pre-build
-pre-build: ensure generate
+pre-build: ensure generate regen-builtin
 
 .PHONY: generate
 generate:


### PR DESCRIPTION
That's needed to check in CI that we've commited new versions of
proxy/wrapper/initializer for builtin contracts