### PR TITLE
INS-2877: fix overtake jetkeeper logic

### DIFF
--- a/insolar/jet/dbstore.go
+++ b/insolar/jet/dbstore.go
@@ -87,7 +87,7 @@ func (s *DBStore) Clone(ctx context.Context, from, to insolar.PulseNumber) error
 	defer s.Unlock()
 
 	tree := s.get(from)
-	newTree := tree.Clone(false)
+	newTree := tree.Clone(true)
 	err := s.set(to, newTree)
 	if err != nil {
 		return errors.Wrapf(err, "failed to clone jet.Tree")

--- a/insolar/jet/dbstore.go
+++ b/insolar/jet/dbstore.go
@@ -82,12 +82,12 @@ func (s *DBStore) Split(ctx context.Context, pulse insolar.PulseNumber, id insol
 	}
 	return left, right, nil
 }
-func (s *DBStore) Clone(ctx context.Context, from, to insolar.PulseNumber) error {
+func (s *DBStore) Clone(ctx context.Context, from, to insolar.PulseNumber, keep bool) error {
 	s.Lock()
 	defer s.Unlock()
 
 	tree := s.get(from)
-	newTree := tree.Clone(true)
+	newTree := tree.Clone(keep)
 	err := s.set(to, newTree)
 	if err != nil {
 		return errors.Wrapf(err, "failed to clone jet.Tree")

--- a/insolar/jet/dbstore_test.go
+++ b/insolar/jet/dbstore_test.go
@@ -107,7 +107,6 @@ func TestDBStorage_CloneJetTree(t *testing.T) {
 
 	var (
 		expectedZero = []insolar.JetID{insolar.ZeroJetID}
-		expectedNil  []insolar.JetID
 	)
 
 	err := s.Update(ctx, 100, true, *insolar.NewJetID(0, nil))
@@ -120,7 +119,7 @@ func TestDBStorage_CloneJetTree(t *testing.T) {
 	require.NoError(t, err)
 
 	tree = dbTreeForPulse(s, 101)
-	assert.Equal(t, expectedNil, tree.LeafIDs(), "actual tree in string form: %v", tree.String())
+	assert.Equal(t, expectedZero, tree.LeafIDs(), "actual tree in string form: %v", tree.String())
 
 	tree = dbTreeForPulse(s, 100)
 	assert.Equal(t, expectedZero, tree.LeafIDs(), "actual tree in string form: %v", tree.String())

--- a/insolar/jet/dbstore_test.go
+++ b/insolar/jet/dbstore_test.go
@@ -115,7 +115,7 @@ func TestDBStorage_CloneJetTree(t *testing.T) {
 	tree := dbTreeForPulse(s, 100)
 	assert.Equal(t, expectedZero, tree.LeafIDs(), "actual tree in string form: %v", tree.String())
 
-	err = s.Clone(ctx, 100, 101)
+	err = s.Clone(ctx, 100, 101, true)
 	require.NoError(t, err)
 
 	tree = dbTreeForPulse(s, 101)

--- a/insolar/jet/jet.go
+++ b/insolar/jet/jet.go
@@ -44,7 +44,7 @@ type Modifier interface {
 	// Split performs jet split and returns resulting jet ids. Always set Active flag to true for leafs.
 	Split(ctx context.Context, pulse insolar.PulseNumber, id insolar.JetID) (insolar.JetID, insolar.JetID, error)
 	// Clone copies tree from one pulse to another. Use it to copy the past tree into new pulse.
-	Clone(ctx context.Context, from, to insolar.PulseNumber) error
+	Clone(ctx context.Context, from, to insolar.PulseNumber, keep bool) error
 }
 
 // Cleaner provides an interface for removing jet.Tree from a storage.

--- a/insolar/jet/modifier_mock.go
+++ b/insolar/jet/modifier_mock.go
@@ -20,7 +20,7 @@ import (
 type ModifierMock struct {
 	t minimock.Tester
 
-	CloneFunc       func(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber) (r error)
+	CloneFunc       func(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber, p3 bool) (r error)
 	CloneCounter    uint64
 	ClonePreCounter uint64
 	CloneMock       mModifierMockClone
@@ -66,6 +66,7 @@ type ModifierMockCloneInput struct {
 	p  context.Context
 	p1 insolar.PulseNumber
 	p2 insolar.PulseNumber
+	p3 bool
 }
 
 type ModifierMockCloneResult struct {
@@ -73,14 +74,14 @@ type ModifierMockCloneResult struct {
 }
 
 //Expect specifies that invocation of Modifier.Clone is expected from 1 to Infinity times
-func (m *mModifierMockClone) Expect(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber) *mModifierMockClone {
+func (m *mModifierMockClone) Expect(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber, p3 bool) *mModifierMockClone {
 	m.mock.CloneFunc = nil
 	m.expectationSeries = nil
 
 	if m.mainExpectation == nil {
 		m.mainExpectation = &ModifierMockCloneExpectation{}
 	}
-	m.mainExpectation.input = &ModifierMockCloneInput{p, p1, p2}
+	m.mainExpectation.input = &ModifierMockCloneInput{p, p1, p2, p3}
 	return m
 }
 
@@ -97,12 +98,12 @@ func (m *mModifierMockClone) Return(r error) *ModifierMock {
 }
 
 //ExpectOnce specifies that invocation of Modifier.Clone is expected once
-func (m *mModifierMockClone) ExpectOnce(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber) *ModifierMockCloneExpectation {
+func (m *mModifierMockClone) ExpectOnce(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber, p3 bool) *ModifierMockCloneExpectation {
 	m.mock.CloneFunc = nil
 	m.mainExpectation = nil
 
 	expectation := &ModifierMockCloneExpectation{}
-	expectation.input = &ModifierMockCloneInput{p, p1, p2}
+	expectation.input = &ModifierMockCloneInput{p, p1, p2, p3}
 	m.expectationSeries = append(m.expectationSeries, expectation)
 	return expectation
 }
@@ -112,7 +113,7 @@ func (e *ModifierMockCloneExpectation) Return(r error) {
 }
 
 //Set uses given function f as a mock of Modifier.Clone method
-func (m *mModifierMockClone) Set(f func(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber) (r error)) *ModifierMock {
+func (m *mModifierMockClone) Set(f func(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber, p3 bool) (r error)) *ModifierMock {
 	m.mainExpectation = nil
 	m.expectationSeries = nil
 
@@ -121,18 +122,18 @@ func (m *mModifierMockClone) Set(f func(p context.Context, p1 insolar.PulseNumbe
 }
 
 //Clone implements github.com/insolar/insolar/insolar/jet.Modifier interface
-func (m *ModifierMock) Clone(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber) (r error) {
+func (m *ModifierMock) Clone(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber, p3 bool) (r error) {
 	counter := atomic.AddUint64(&m.ClonePreCounter, 1)
 	defer atomic.AddUint64(&m.CloneCounter, 1)
 
 	if len(m.CloneMock.expectationSeries) > 0 {
 		if counter > uint64(len(m.CloneMock.expectationSeries)) {
-			m.t.Fatalf("Unexpected call to ModifierMock.Clone. %v %v %v", p, p1, p2)
+			m.t.Fatalf("Unexpected call to ModifierMock.Clone. %v %v %v %v", p, p1, p2, p3)
 			return
 		}
 
 		input := m.CloneMock.expectationSeries[counter-1].input
-		testify_assert.Equal(m.t, *input, ModifierMockCloneInput{p, p1, p2}, "Modifier.Clone got unexpected parameters")
+		testify_assert.Equal(m.t, *input, ModifierMockCloneInput{p, p1, p2, p3}, "Modifier.Clone got unexpected parameters")
 
 		result := m.CloneMock.expectationSeries[counter-1].result
 		if result == nil {
@@ -149,7 +150,7 @@ func (m *ModifierMock) Clone(p context.Context, p1 insolar.PulseNumber, p2 insol
 
 		input := m.CloneMock.mainExpectation.input
 		if input != nil {
-			testify_assert.Equal(m.t, *input, ModifierMockCloneInput{p, p1, p2}, "Modifier.Clone got unexpected parameters")
+			testify_assert.Equal(m.t, *input, ModifierMockCloneInput{p, p1, p2, p3}, "Modifier.Clone got unexpected parameters")
 		}
 
 		result := m.CloneMock.mainExpectation.result
@@ -163,11 +164,11 @@ func (m *ModifierMock) Clone(p context.Context, p1 insolar.PulseNumber, p2 insol
 	}
 
 	if m.CloneFunc == nil {
-		m.t.Fatalf("Unexpected call to ModifierMock.Clone. %v %v %v", p, p1, p2)
+		m.t.Fatalf("Unexpected call to ModifierMock.Clone. %v %v %v %v", p, p1, p2, p3)
 		return
 	}
 
-	return m.CloneFunc(p, p1, p2)
+	return m.CloneFunc(p, p1, p2, p3)
 }
 
 //CloneMinimockCounter returns a count of ModifierMock.CloneFunc invocations

--- a/insolar/jet/storage_mock.go
+++ b/insolar/jet/storage_mock.go
@@ -25,7 +25,7 @@ type StorageMock struct {
 	AllPreCounter uint64
 	AllMock       mStorageMockAll
 
-	CloneFunc       func(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber) (r error)
+	CloneFunc       func(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber, p3 bool) (r error)
 	CloneCounter    uint64
 	ClonePreCounter uint64
 	CloneMock       mStorageMockClone
@@ -226,6 +226,7 @@ type StorageMockCloneInput struct {
 	p  context.Context
 	p1 insolar.PulseNumber
 	p2 insolar.PulseNumber
+	p3 bool
 }
 
 type StorageMockCloneResult struct {
@@ -233,14 +234,14 @@ type StorageMockCloneResult struct {
 }
 
 //Expect specifies that invocation of Storage.Clone is expected from 1 to Infinity times
-func (m *mStorageMockClone) Expect(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber) *mStorageMockClone {
+func (m *mStorageMockClone) Expect(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber, p3 bool) *mStorageMockClone {
 	m.mock.CloneFunc = nil
 	m.expectationSeries = nil
 
 	if m.mainExpectation == nil {
 		m.mainExpectation = &StorageMockCloneExpectation{}
 	}
-	m.mainExpectation.input = &StorageMockCloneInput{p, p1, p2}
+	m.mainExpectation.input = &StorageMockCloneInput{p, p1, p2, p3}
 	return m
 }
 
@@ -257,12 +258,12 @@ func (m *mStorageMockClone) Return(r error) *StorageMock {
 }
 
 //ExpectOnce specifies that invocation of Storage.Clone is expected once
-func (m *mStorageMockClone) ExpectOnce(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber) *StorageMockCloneExpectation {
+func (m *mStorageMockClone) ExpectOnce(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber, p3 bool) *StorageMockCloneExpectation {
 	m.mock.CloneFunc = nil
 	m.mainExpectation = nil
 
 	expectation := &StorageMockCloneExpectation{}
-	expectation.input = &StorageMockCloneInput{p, p1, p2}
+	expectation.input = &StorageMockCloneInput{p, p1, p2, p3}
 	m.expectationSeries = append(m.expectationSeries, expectation)
 	return expectation
 }
@@ -272,7 +273,7 @@ func (e *StorageMockCloneExpectation) Return(r error) {
 }
 
 //Set uses given function f as a mock of Storage.Clone method
-func (m *mStorageMockClone) Set(f func(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber) (r error)) *StorageMock {
+func (m *mStorageMockClone) Set(f func(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber, p3 bool) (r error)) *StorageMock {
 	m.mainExpectation = nil
 	m.expectationSeries = nil
 
@@ -281,18 +282,18 @@ func (m *mStorageMockClone) Set(f func(p context.Context, p1 insolar.PulseNumber
 }
 
 //Clone implements github.com/insolar/insolar/insolar/jet.Storage interface
-func (m *StorageMock) Clone(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber) (r error) {
+func (m *StorageMock) Clone(p context.Context, p1 insolar.PulseNumber, p2 insolar.PulseNumber, p3 bool) (r error) {
 	counter := atomic.AddUint64(&m.ClonePreCounter, 1)
 	defer atomic.AddUint64(&m.CloneCounter, 1)
 
 	if len(m.CloneMock.expectationSeries) > 0 {
 		if counter > uint64(len(m.CloneMock.expectationSeries)) {
-			m.t.Fatalf("Unexpected call to StorageMock.Clone. %v %v %v", p, p1, p2)
+			m.t.Fatalf("Unexpected call to StorageMock.Clone. %v %v %v %v", p, p1, p2, p3)
 			return
 		}
 
 		input := m.CloneMock.expectationSeries[counter-1].input
-		testify_assert.Equal(m.t, *input, StorageMockCloneInput{p, p1, p2}, "Storage.Clone got unexpected parameters")
+		testify_assert.Equal(m.t, *input, StorageMockCloneInput{p, p1, p2, p3}, "Storage.Clone got unexpected parameters")
 
 		result := m.CloneMock.expectationSeries[counter-1].result
 		if result == nil {
@@ -309,7 +310,7 @@ func (m *StorageMock) Clone(p context.Context, p1 insolar.PulseNumber, p2 insola
 
 		input := m.CloneMock.mainExpectation.input
 		if input != nil {
-			testify_assert.Equal(m.t, *input, StorageMockCloneInput{p, p1, p2}, "Storage.Clone got unexpected parameters")
+			testify_assert.Equal(m.t, *input, StorageMockCloneInput{p, p1, p2, p3}, "Storage.Clone got unexpected parameters")
 		}
 
 		result := m.CloneMock.mainExpectation.result
@@ -323,11 +324,11 @@ func (m *StorageMock) Clone(p context.Context, p1 insolar.PulseNumber, p2 insola
 	}
 
 	if m.CloneFunc == nil {
-		m.t.Fatalf("Unexpected call to StorageMock.Clone. %v %v %v", p, p1, p2)
+		m.t.Fatalf("Unexpected call to StorageMock.Clone. %v %v %v %v", p, p1, p2, p3)
 		return
 	}
 
-	return m.CloneFunc(p, p1, p2)
+	return m.CloneFunc(p, p1, p2, p3)
 }
 
 //CloneMinimockCounter returns a count of StorageMock.CloneFunc invocations

--- a/insolar/jet/store.go
+++ b/insolar/jet/store.go
@@ -114,10 +114,8 @@ func (s *Store) Split(
 }
 
 // Clone copies tree from one pulse to another. Use it to copy the past tree into new pulse.
-func (s *Store) Clone(
-	ctx context.Context, from, to insolar.PulseNumber,
-) error {
-	newTree := s.ltreeForPulse(from).clone(false)
+func (s *Store) Clone(ctx context.Context, from, to insolar.PulseNumber, keep bool) error {
+	newTree := s.ltreeForPulse(from).clone(keep)
 
 	s.Lock()
 	s.trees[to] = &lockedTree{

--- a/insolar/jet/store_test.go
+++ b/insolar/jet/store_test.go
@@ -78,7 +78,7 @@ func TestJetStorage_CloneJetTree(t *testing.T) {
 	tree, _ := treeForPulse(s, 100)
 	require.Equal(t, "root (level=0 actual=true)\n", tree.String())
 
-	s.Clone(ctx, 100, 101)
+	s.Clone(ctx, 100, 101, false)
 
 	tree, _ = treeForPulse(s, 101)
 	require.Equal(t, "root (level=0 actual=false)\n", tree.String())

--- a/ledger/heavy/handler/handler.go
+++ b/ledger/heavy/handler/handler.go
@@ -426,7 +426,7 @@ func (h *Handler) cloneUpToLatest(ctx context.Context, from insolar.PulseNumber)
 		return
 	}
 	for to := next.PulseNumber; to <= latest.PulseNumber; {
-		err := h.JetModifier.Clone(ctx, from, to)
+		err := h.JetModifier.Clone(ctx, from, to, true)
 		if err != nil {
 			logger.Error(errors.Wrapf(err, "failed to clone jet tree from %v to %v", from, to))
 			return

--- a/ledger/heavy/handler/handler.go
+++ b/ledger/heavy/handler/handler.go
@@ -62,6 +62,8 @@ type Handler struct {
 	JetKeeper       replica.JetKeeper
 	Sender          bus.Sender
 
+	PulseDelta insolar.PulseNumber
+
 	jetID insolar.JetID
 	dep   *proc.Dependencies
 }
@@ -373,7 +375,7 @@ func (h *Handler) handleHeavyPayload(ctx context.Context, genericMsg insolar.Par
 	pulse := drop.Pulse
 
 	// We can't to use PulseCalculator here because split pulse may exceed latest pulse.
-	whenSplit := pulse + 20
+	whenSplit := pulse + 2*h.PulseDelta
 
 	if drop.Split {
 		err = h.JetModifier.Update(ctx, whenSplit, true, drop.JetID)

--- a/ledger/heavy/pulsemanager/pulsemanager.go
+++ b/ledger/heavy/pulsemanager/pulsemanager.go
@@ -165,7 +165,7 @@ func (m *PulseManager) setUnderGilSection(ctx context.Context, newPulse insolar.
 		}
 
 		futurePulse := newPulse.NextPulseNumber
-		err = m.JetModifier.Clone(ctx, newPulse.PulseNumber, futurePulse)
+		err = m.JetModifier.Clone(ctx, newPulse.PulseNumber, futurePulse, true)
 		if err != nil {
 			return errors.Wrapf(err, "failed to clone jet.Tree fromPulse=%v toPulse=%v", newPulse.PulseNumber, futurePulse)
 		}

--- a/ledger/heavy/pulsemanager/pulsemanager.go
+++ b/ledger/heavy/pulsemanager/pulsemanager.go
@@ -165,7 +165,6 @@ func (m *PulseManager) setUnderGilSection(ctx context.Context, newPulse insolar.
 		}
 
 		futurePulse := newPulse.NextPulseNumber
-		logger.Warnf("CLONE %v -> %v", newPulse.PulseNumber, futurePulse)
 		err = m.JetModifier.Clone(ctx, newPulse.PulseNumber, futurePulse)
 		if err != nil {
 			return errors.Wrapf(err, "failed to clone jet.Tree fromPulse=%v toPulse=%v", newPulse.PulseNumber, futurePulse)

--- a/ledger/heavy/replica/jetkeeper.go
+++ b/ledger/heavy/replica/jetkeeper.go
@@ -17,7 +17,6 @@
 package replica
 
 import (
-	"bytes"
 	"context"
 	"reflect"
 	"sync"
@@ -186,15 +185,14 @@ func (jk *dbJetKeeper) set(pn insolar.PulseNumber, jets []insolar.JetID) error {
 }
 
 func (jk *dbJetKeeper) updateSyncPulse(pn insolar.PulseNumber) error {
-	err := jk.db.Set(syncPulseKey(pn), []byte{})
+	err := jk.db.Set(syncPulseKey(insolar.GenesisPulse.PulseNumber), pn.Bytes())
 	return errors.Wrapf(err, "failed to set up new sync pulse")
 }
 
 func (jk *dbJetKeeper) topSyncPulse() insolar.PulseNumber {
-	it := jk.db.NewIterator(syncPulseKey(0xFFFFFFFF), true)
-	defer it.Close()
-	if it.Next() && bytes.HasPrefix(it.Key(), []byte{0x02}) {
-		return insolar.NewPulseNumber(it.Key()[1:])
+	val, err := jk.db.Get(syncPulseKey(insolar.GenesisPulse.PulseNumber))
+	if err != nil {
+		return insolar.GenesisPulse.PulseNumber
 	}
-	return insolar.GenesisPulse.PulseNumber
+	return insolar.NewPulseNumber(val)
 }

--- a/ledger/heavy/replica/jetkeeper_test.go
+++ b/ledger/heavy/replica/jetkeeper_test.go
@@ -98,7 +98,7 @@ func TestDbJetKeeper_TopSyncPulse(t *testing.T) {
 
 	require.Equal(t, pulse, jetKeeper.TopSyncPulse())
 
-	err = jets.Clone(ctx, pulse, futurePulse)
+	err = jets.Clone(ctx, pulse, futurePulse, true)
 	require.NoError(t, err)
 	left, right, err := jets.Split(ctx, futurePulse, jet)
 	require.NoError(t, err)
@@ -151,9 +151,9 @@ func TestDbJetKeeper_OvertakePulse(t *testing.T) {
 	require.Equal(t, P1, jetKeeper.TopSyncPulse())
 
 	// P1 try to overtake P2
-	err = jets.Clone(ctx, P1, P2)
+	err = jets.Clone(ctx, P1, P2, true)
 	require.NoError(t, err)
-	err = jets.Clone(ctx, P2, P3)
+	err = jets.Clone(ctx, P2, P3, true)
 	require.NoError(t, err)
 	err = jetKeeper.Add(ctx, P3, jet)
 	require.NoError(t, err)

--- a/ledger/light/executor/jet_splitter.go
+++ b/ledger/light/executor/jet_splitter.go
@@ -87,7 +87,7 @@ func (js *JetSplitterDefault) Do(
 	inslog := inslogger.FromContext(ctx).WithField("split_for_pulse", newPulse.String())
 
 	// copy current jets for new pulse, for further jets modification in new pulse.
-	err := js.jetModifier.Clone(ctx, currentPulse, newPulse)
+	err := js.jetModifier.Clone(ctx, currentPulse, newPulse, false)
 	if err != nil {
 		panic("Failed to clone jets")
 	}

--- a/logicrunner/pulsemanager/pulsemanager.go
+++ b/logicrunner/pulsemanager/pulsemanager.go
@@ -145,7 +145,7 @@ func (m *PulseManager) setUnderGilSection(ctx context.Context, newPulse insolar.
 		}
 	}
 
-	err = m.JetModifier.Clone(ctx, storagePulse.PulseNumber, newPulse.PulseNumber)
+	err = m.JetModifier.Clone(ctx, storagePulse.PulseNumber, newPulse.PulseNumber, false)
 	if err != nil {
 		return errors.Wrapf(err, "failed to clone jet.Tree fromPulse=%v toPulse=%v", storagePulse.PulseNumber, newPulse.PulseNumber)
 	}

--- a/server/internal/heavy/components.go
+++ b/server/internal/heavy/components.go
@@ -233,7 +233,7 @@ func newComponents(ctx context.Context, cfg configuration.Configuration, genesis
 		blobs := blob.NewDB(DB)
 		drops := drop.NewDB(DB)
 		jets := jet.NewDBStore(DB)
-		jetKeeper := replica.NewJetKeeper(jets, DB)
+		jetKeeper := replica.NewJetKeeper(jets, DB, Pulses)
 
 		pm := pulsemanager.NewPulseManager()
 		pm.Bus = Bus
@@ -256,6 +256,7 @@ func newComponents(ctx context.Context, cfg configuration.Configuration, genesis
 		h.DropModifier = drops
 		h.PCS = CryptoScheme
 		h.PulseAccessor = Pulses
+		h.PulseCalculator = Pulses
 		h.JetModifier = jets
 		h.JetKeeper = jetKeeper
 		h.Sender = WmBus

--- a/server/internal/heavy/components.go
+++ b/server/internal/heavy/components.go
@@ -260,6 +260,7 @@ func newComponents(ctx context.Context, cfg configuration.Configuration, genesis
 		h.JetModifier = jets
 		h.JetKeeper = jetKeeper
 		h.Sender = WmBus
+		h.PulseDelta = insolar.PulseNumber(cfg.Pulsar.NumberDelta)
 
 		PulseManager = pm
 		Handler = h


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I made a patch that fixes INS-2877.
**- How I did it**
I made a condition that we update only the subsequent pulse or the second pulse after the start of the network. And I fix jet tree actualizing when we handle hot data on heavy node.
**- How to verify it**
Run launchnet + run unit tests.
