### PR TITLE
INS-2944: restore ServiceData when we pass requests between virtuals

### DIFF
--- a/insolar/message/logicrunner.go
+++ b/insolar/message/logicrunner.go
@@ -118,8 +118,9 @@ type ExecutorResults struct {
 }
 
 type ExecutionQueueElement struct {
-	RequestRef insolar.Reference
-	Request    record.IncomingRequest
+	RequestRef  insolar.Reference
+	Request     record.IncomingRequest
+	ServiceData ServiceData
 }
 
 // AllowedSenderObjectAndRole implements interface method
@@ -279,6 +280,7 @@ type AdditionalCallFromPreviousExecutor struct {
 	Pending         PendingState
 	RequestRef      insolar.Reference
 	Request         record.IncomingRequest
+	ServiceData     ServiceData
 }
 
 func (m *AdditionalCallFromPreviousExecutor) GetCaller() *insolar.Reference {

--- a/logicrunner/handle_calls.go
+++ b/logicrunner/handle_calls.go
@@ -73,6 +73,7 @@ func (h *HandleCall) sendToNextExecutor(
 			ObjectReference: es.Ref,
 			RequestRef:      *requestRef,
 			Request:         *transcript.Request,
+			ServiceData:     serviceDataFromContext(transcript.Context),
 		}
 		if es.pending == message.PendingUnknown {
 			additionalCallMsg.Pending = message.NotPending
@@ -235,13 +236,12 @@ func (h *HandleAdditionalCallFromPreviousExecutor) handleActual(
 
 func (h *HandleAdditionalCallFromPreviousExecutor) Present(ctx context.Context, f flow.Flow) error {
 	parcel := h.Message.Parcel
-	ctx = loggerWithTargetID(ctx, parcel)
-	inslogger.FromContext(ctx).Debug("HandleAdditionalCallFromPreviousExecutor.Present starts ...")
-
 	msg, ok := parcel.Message().(*message.AdditionalCallFromPreviousExecutor)
 	if !ok {
 		return errors.New("is not AdditionalCallFromPreviousExecutor message")
 	}
+
+	ctx = contextFromServiceData(msg.ServiceData)
 
 	ctx, span := instracer.StartSpan(ctx, "HandleAdditionalCallFromPreviousExecutor.Present")
 	span.AddAttributes(

--- a/logicrunner/handle_executorresults.go
+++ b/logicrunner/handle_executorresults.go
@@ -80,8 +80,8 @@ func (p *initializeExecutionState) Proceed(ctx context.Context) error {
 	// prepare Queue
 	if p.msg.Queue != nil {
 		for _, qe := range p.msg.Queue {
-			ctxToSent := context.TODO() //FIXME: !!!!
-			transcript := NewTranscript(ctxToSent, qe.RequestRef, qe.Request)
+			requestCtx := contextFromServiceData(qe.ServiceData)
+			transcript := NewTranscript(requestCtx, qe.RequestRef, qe.Request)
 
 			broker.Prepend(ctx, false, transcript)
 		}

--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -462,8 +462,9 @@ func convertQueueToMessageQueue(ctx context.Context, queue []*Transcript) []mess
 	var traces string
 	for _, elem := range queue {
 		mq = append(mq, message.ExecutionQueueElement{
-			RequestRef: elem.RequestRef,
-			Request:    *elem.Request,
+			RequestRef:  elem.RequestRef,
+			Request:     *elem.Request,
+			ServiceData: serviceDataFromContext(elem.Context),
 		})
 
 		traces += inslogger.TraceID(elem.Context) + ", "
@@ -480,4 +481,26 @@ func (lr *LogicRunner) pulse(ctx context.Context) *insolar.Pulse {
 		panic(err)
 	}
 	return &p
+}
+
+func contextFromServiceData(data message.ServiceData) context.Context {
+	ctx := inslogger.ContextWithTrace(context.Background(), data.LogTraceID)
+	ctx = inslogger.WithLoggerLevel(ctx, data.LogLevel)
+	if data.TraceSpanData != nil {
+		parentSpan := instracer.MustDeserialize(data.TraceSpanData)
+		return instracer.WithParentSpan(ctx, parentSpan)
+	}
+	return ctx
+}
+
+func serviceDataFromContext(ctx context.Context) message.ServiceData {
+	if ctx == nil {
+		log.Error("nil context, can't create correct ServiceData")
+		return message.ServiceData{}
+	}
+	return message.ServiceData{
+		LogTraceID:    inslogger.TraceID(ctx),
+		LogLevel:      inslogger.GetLoggerLevel(ctx),
+		TraceSpanData: instracer.MustSerialize(ctx),
+	}
 }


### PR DESCRIPTION
* cover ExecutorResults containing requests for execution

* cover AdditionalCallFromPreviousExecutor

* correctly switch to transcript.Context in the broker when executing