### PR TITLE
request reference in transcript is not pointer

### DIFF
--- a/logicrunner/currentexecution.go
+++ b/logicrunner/currentexecution.go
@@ -31,7 +31,7 @@ type Transcript struct {
 	Context          context.Context
 	LogicContext     *insolar.LogicCallContext
 	Request          *record.IncomingRequest
-	RequestRef       *insolar.Reference
+	RequestRef       insolar.Reference
 	RequesterNode    *insolar.Reference
 	Nonce            uint64
 	Deactivate       bool
@@ -41,7 +41,7 @@ type Transcript struct {
 
 func NewTranscript(
 	ctx context.Context,
-	requestRef *insolar.Reference,
+	requestRef insolar.Reference,
 	request record.IncomingRequest,
 ) *Transcript {
 
@@ -106,7 +106,7 @@ func (ces *CurrentExecutionList) Set(requestRef insolar.Reference, ce *Transcrip
 
 func (ces *CurrentExecutionList) SetTranscript(t *Transcript) {
 	ces.lock.Lock()
-	ces.executions[*t.RequestRef] = t
+	ces.executions[t.RequestRef] = t
 	ces.lock.Unlock()
 }
 

--- a/logicrunner/executionbroker.go
+++ b/logicrunner/executionbroker.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 
 	watermillMsg "github.com/ThreeDotsLabs/watermill/message"
+
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/jet"
 	"github.com/insolar/insolar/insolar/message"
@@ -269,7 +270,7 @@ type ExecutionBrokerRotationResult struct {
 }
 
 func (q *ExecutionBroker) checkCurrent(_ context.Context, transcript *Transcript) {
-	if q.currentList.Has(*transcript.RequestRef) {
+	if q.currentList.Has(transcript.RequestRef) {
 		panic(fmt.Sprintf("requestRef %s is already in currentList", transcript.RequestRef.String()))
 	}
 }
@@ -314,10 +315,10 @@ func (q *ExecutionBroker) releaseTask(_ context.Context, transcript *Transcript)
 	q.stateLock.Lock()
 	defer q.stateLock.Unlock()
 
-	if !q.currentList.Has(*transcript.RequestRef) {
+	if !q.currentList.Has(transcript.RequestRef) {
 		return
 	}
-	q.currentList.Delete(*transcript.RequestRef)
+	q.currentList.Delete(transcript.RequestRef)
 
 	queue := q.mutable
 	if transcript.Request.Immutable {
@@ -335,10 +336,10 @@ func (q *ExecutionBroker) finishTask(ctx context.Context, transcript *Transcript
 
 	q.finished.Push(transcript)
 
-	if !q.currentList.Has(*transcript.RequestRef) {
+	if !q.currentList.Has(transcript.RequestRef) {
 		logger.Error("[ ExecutionBroker.FinishTask ] task '%s' is not in current", transcript.RequestRef.String())
 	} else {
-		q.currentList.Delete(*transcript.RequestRef)
+		q.currentList.Delete(transcript.RequestRef)
 	}
 }
 
@@ -358,10 +359,10 @@ func (q *ExecutionBroker) storeWithoutDuplication(_ context.Context, transcript 
 	q.deduplicationLock.Lock()
 	defer q.deduplicationLock.Unlock()
 
-	if _, ok := q.deduplicationTable[*transcript.RequestRef]; ok {
+	if _, ok := q.deduplicationTable[transcript.RequestRef]; ok {
 		return true
 	}
-	q.deduplicationTable[*transcript.RequestRef] = true
+	q.deduplicationTable[transcript.RequestRef] = true
 	return false
 }
 

--- a/logicrunner/executionbroker_test.go
+++ b/logicrunner/executionbroker_test.go
@@ -137,9 +137,9 @@ func (s *TranscriptDequeueSuite) TestPopByReference() {
 	ref1, ref2, ref3 := gen.Reference(), gen.Reference(), gen.Reference()
 
 	d.Prepend(
-		&Transcript{Nonce: 3, RequestRef: &ref1},
-		&Transcript{Nonce: 4, RequestRef: &ref2},
-		&Transcript{Nonce: 5, RequestRef: &ref3},
+		&Transcript{Nonce: 3, RequestRef: ref1},
+		&Transcript{Nonce: 4, RequestRef: ref2},
+		&Transcript{Nonce: 5, RequestRef: ref3},
 	)
 
 	tr := d.PopByReference(ref2)
@@ -164,9 +164,9 @@ func (s *TranscriptDequeueSuite) TestPopByReferenceHead() {
 	s.Require().NotNil(d)
 
 	ref1, ref2, ref3 := gen.Reference(), gen.Reference(), gen.Reference()
-	el1 := &Transcript{Nonce: 3, RequestRef: &ref1}
-	el2 := &Transcript{Nonce: 4, RequestRef: &ref2}
-	el3 := &Transcript{Nonce: 5, RequestRef: &ref3}
+	el1 := &Transcript{Nonce: 3, RequestRef: ref1}
+	el2 := &Transcript{Nonce: 4, RequestRef: ref2}
+	el3 := &Transcript{Nonce: 5, RequestRef: ref3}
 	d.Prepend(el1, el2, el3)
 
 	tr := d.PopByReference(ref1)
@@ -188,9 +188,9 @@ func (s *TranscriptDequeueSuite) TestPopByReferenceTail() {
 	s.Require().NotNil(d)
 
 	ref1, ref2, ref3 := gen.Reference(), gen.Reference(), gen.Reference()
-	el1 := &Transcript{Nonce: 3, RequestRef: &ref1}
-	el2 := &Transcript{Nonce: 4, RequestRef: &ref2}
-	el3 := &Transcript{Nonce: 5, RequestRef: &ref3}
+	el1 := &Transcript{Nonce: 3, RequestRef: ref1}
+	el2 := &Transcript{Nonce: 4, RequestRef: ref2}
+	el3 := &Transcript{Nonce: 5, RequestRef: ref3}
 	d.Prepend(el1, el2, el3)
 
 	tr := d.PopByReference(ref3)
@@ -214,7 +214,7 @@ func (s *TranscriptDequeueSuite) TestPopByReferenceOneElement() {
 	ref1 := gen.Reference()
 
 	d.Prepend(
-		&Transcript{Nonce: 3, RequestRef: &ref1},
+		&Transcript{Nonce: 3, RequestRef: ref1},
 	)
 
 	tr := d.PopByReference(ref1)
@@ -353,7 +353,7 @@ func (s *ExecutionBrokerSuite) TestPut() {
 	reqRef1 := gen.Reference()
 	tr := &Transcript{
 		LogicContext: &insolar.LogicCallContext{},
-		RequestRef:   &reqRef1,
+		RequestRef:   reqRef1,
 		Request:      &record.IncomingRequest{},
 	}
 
@@ -363,7 +363,7 @@ func (s *ExecutionBrokerSuite) TestPut() {
 	reqRef2 := gen.Reference()
 	tr = &Transcript{
 		LogicContext: &insolar.LogicCallContext{},
-		RequestRef:   &reqRef2,
+		RequestRef:   reqRef2,
 		Request:      &record.IncomingRequest{},
 	}
 
@@ -405,7 +405,7 @@ func (s *ExecutionBrokerSuite) TestPrepend() {
 	reqRef1 := gen.Reference()
 	tr := &Transcript{
 		LogicContext: &insolar.LogicCallContext{},
-		RequestRef:   &reqRef1,
+		RequestRef:   reqRef1,
 		Request:      &record.IncomingRequest{},
 	}
 	b.Prepend(s.Context, false, tr)
@@ -414,7 +414,7 @@ func (s *ExecutionBrokerSuite) TestPrepend() {
 	reqRef2 := gen.Reference()
 	tr = &Transcript{
 		LogicContext: &insolar.LogicCallContext{},
-		RequestRef:   &reqRef2,
+		RequestRef:   reqRef2,
 		Request:      &record.IncomingRequest{},
 	}
 	b.Prepend(s.Context, true, tr)
@@ -459,7 +459,7 @@ func (s *ExecutionBrokerSuite) TestImmutable_NotPending() {
 	reqRef1 := gen.Reference()
 	tr := &Transcript{
 		LogicContext: &insolar.LogicCallContext{},
-		RequestRef:   &reqRef1,
+		RequestRef:   reqRef1,
 		Request:      &record.IncomingRequest{Immutable: true},
 	}
 
@@ -471,7 +471,7 @@ func (s *ExecutionBrokerSuite) TestImmutable_NotPending() {
 	reqRef2 := gen.Reference()
 	tr = &Transcript{
 		LogicContext: &insolar.LogicCallContext{},
-		RequestRef:   &reqRef2,
+		RequestRef:   reqRef2,
 		Request:      &record.IncomingRequest{Immutable: true},
 	}
 
@@ -507,7 +507,7 @@ func (s *ExecutionBrokerSuite) TestImmutable_InPending() {
 	reqRef3 := gen.Reference()
 	tr := &Transcript{
 		LogicContext: &insolar.LogicCallContext{},
-		RequestRef:   &reqRef3,
+		RequestRef:   reqRef3,
 		Request:      &record.IncomingRequest{Immutable: true},
 	}
 
@@ -518,7 +518,7 @@ func (s *ExecutionBrokerSuite) TestImmutable_InPending() {
 	reqRef4 := gen.Reference()
 	tr = &Transcript{
 		LogicContext: &insolar.LogicCallContext{},
-		RequestRef:   &reqRef4,
+		RequestRef:   reqRef4,
 		Request:      &record.IncomingRequest{Immutable: true},
 	}
 
@@ -624,14 +624,14 @@ func (s *ExecutionBrokerSuite) TestDeduplication() {
 	reqRef1 := gen.Reference()
 	b.Put(s.Context, false, &Transcript{
 		LogicContext: &insolar.LogicCallContext{},
-		RequestRef:   &reqRef1,
+		RequestRef:   reqRef1,
 		Request:      &record.IncomingRequest{},
 	}) // no duplication
 	s.Equal(b.mutable.Length(), 1)
 
 	b.Put(s.Context, false, &Transcript{
 		LogicContext: &insolar.LogicCallContext{},
-		RequestRef:   &reqRef1,
+		RequestRef:   reqRef1,
 		Request:      &record.IncomingRequest{},
 	}) // duplication
 	s.Equal(b.mutable.Length(), 1)

--- a/logicrunner/executionstate_test.go
+++ b/logicrunner/executionstate_test.go
@@ -44,7 +44,7 @@ func InitBroker(_ *testing.T, ctx context.Context, count int, broker *ExecutionB
 		broker.Put(ctx, false, &Transcript{
 			LogicContext: &insolar.LogicCallContext{},
 			Context:      ctx,
-			RequestRef:   &reqRef,
+			RequestRef:   reqRef,
 			Request:      &record.IncomingRequest{},
 		})
 	}
@@ -87,7 +87,7 @@ func TestExecutionState_OnPulse(t *testing.T) {
 
 	list := NewCurrentExecutionList()
 	requestRef := gen.Reference()
-	list.SetTranscript(&Transcript{RequestRef: &requestRef})
+	list.SetTranscript(&Transcript{RequestRef: requestRef})
 
 	inPending := message.InPending
 

--- a/logicrunner/handle_calls.go
+++ b/logicrunner/handle_calls.go
@@ -138,7 +138,7 @@ func (h *HandleCall) handleActual(
 	es, broker := lr.StateStorage.UpsertExecutionState(*objRef)
 
 	es.Lock()
-	broker.Put(ctx, false, NewTranscript(ctx, requestRef, request))
+	broker.Put(ctx, false, NewTranscript(ctx, *requestRef, request))
 	es.Unlock()
 
 	procClarifyPendingState := ClarifyPendingState{
@@ -213,7 +213,7 @@ func (h *HandleAdditionalCallFromPreviousExecutor) handleActual(
 		es.pending = message.NotPending
 	}
 
-	broker.Put(ctx, false, NewTranscript(ctx, &msg.RequestRef, msg.Request))
+	broker.Put(ctx, false, NewTranscript(ctx, msg.RequestRef, msg.Request))
 	es.Unlock()
 
 	procClarifyPendingState := ClarifyPendingState{

--- a/logicrunner/handle_executorresults.go
+++ b/logicrunner/handle_executorresults.go
@@ -81,7 +81,7 @@ func (p *initializeExecutionState) Proceed(ctx context.Context) error {
 	if p.msg.Queue != nil {
 		for _, qe := range p.msg.Queue {
 			ctxToSent := context.TODO() //FIXME: !!!!
-			transcript := NewTranscript(ctxToSent, &qe.RequestRef, qe.Request)
+			transcript := NewTranscript(ctxToSent, qe.RequestRef, qe.Request)
 
 			broker.Prepend(ctx, false, transcript)
 		}

--- a/logicrunner/handle_ledgerpendingrequest.go
+++ b/logicrunner/handle_ledgerpendingrequest.go
@@ -136,7 +136,7 @@ func (u *UnsafeGetLedgerPendingRequest) Proceed(ctx context.Context) error {
 	u.hasPending = true
 	es.LedgerHasMoreRequests = true
 
-	t := NewTranscript(ctx, requestRef, *request)
+	t := NewTranscript(ctx, *requestRef, *request)
 	t.FromLedger = true
 	broker.Prepend(ctx, true, t)
 

--- a/logicrunner/logicexecutor.go
+++ b/logicrunner/logicexecutor.go
@@ -149,10 +149,11 @@ func (le *logicExecutor) genLogicCallContext(
 	codeDesc artifacts.CodeDescriptor,
 ) *insolar.LogicCallContext {
 	request := transcript.Request
+	reqRef := transcript.RequestRef
 	res := &insolar.LogicCallContext{
 		Mode: insolar.ExecuteCallMode,
 
-		Request: transcript.RequestRef,
+		Request: &reqRef,
 
 		Callee:    nil, // below
 		Prototype: protoDesc.HeadRef(),
@@ -169,7 +170,7 @@ func (le *logicExecutor) genLogicCallContext(
 		// should be the same as request.Object
 		res.Callee = oDesc.HeadRef()
 	} else {
-		res.Callee = transcript.RequestRef
+		res.Callee = &reqRef
 	}
 
 	return res

--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -462,7 +462,7 @@ func convertQueueToMessageQueue(ctx context.Context, queue []*Transcript) []mess
 	var traces string
 	for _, elem := range queue {
 		mq = append(mq, message.ExecutionQueueElement{
-			RequestRef: *elem.RequestRef,
+			RequestRef: elem.RequestRef,
 			Request:    *elem.Request,
 		})
 

--- a/logicrunner/logicrunner_rpc_methods.go
+++ b/logicrunner/logicrunner_rpc_methods.go
@@ -527,7 +527,7 @@ func buildIncomingAndOutgoingCallRequests(
 		Arguments: req.Arguments,
 
 		APIRequestID: current.Request.APIRequestID,
-		Reason:       *current.RequestRef,
+		Reason:       current.RequestRef,
 	}
 
 	// Currently IncomingRequest and OutgoingRequest are almost exact copies of each other
@@ -551,7 +551,7 @@ func buildIncomingAndOutgoingCallRequests(
 		Arguments: req.Arguments,
 
 		APIRequestID: current.Request.APIRequestID,
-		Reason:       *current.RequestRef,
+		Reason:       current.RequestRef,
 	}
 
 	if req.Saga {
@@ -584,7 +584,7 @@ func buildIncomingAndOutgoingSaveAsChildRequests(
 		Arguments: req.ArgsSerialized,
 
 		APIRequestID: current.Request.APIRequestID,
-		Reason:       *current.RequestRef,
+		Reason:       current.RequestRef,
 	}
 
 	outgoing := record.OutgoingRequest{
@@ -599,7 +599,7 @@ func buildIncomingAndOutgoingSaveAsChildRequests(
 		Arguments: req.ArgsSerialized,
 
 		APIRequestID: current.Request.APIRequestID,
-		Reason:       *current.RequestRef,
+		Reason:       current.RequestRef,
 	}
 
 	return &incoming, &outgoing
@@ -623,7 +623,7 @@ func buildIncomingAndOutgoingSaveAsDelegateRequests(
 		Arguments: req.ArgsSerialized,
 
 		APIRequestID: current.Request.APIRequestID,
-		Reason:       *current.RequestRef,
+		Reason:       current.RequestRef,
 	}
 
 	outgoing := record.OutgoingRequest{
@@ -638,7 +638,7 @@ func buildIncomingAndOutgoingSaveAsDelegateRequests(
 		Arguments: req.ArgsSerialized,
 
 		APIRequestID: current.Request.APIRequestID,
-		Reason:       *current.RequestRef,
+		Reason:       current.RequestRef,
 	}
 
 	return &incoming, &outgoing

--- a/logicrunner/logicrunner_rpc_methods_test.go
+++ b/logicrunner/logicrunner_rpc_methods_test.go
@@ -26,9 +26,7 @@ func TestRouteCallRegistersOutgoingRequestWithValidReason(t *testing.T) {
 
 	rpcm := NewExecutionProxyImplementation(dc, cr, am)
 	ctx := context.Background()
-	transcript := NewTranscript(ctx, &requestRef, record.IncomingRequest{})
-	reason := gen.Reference()
-	transcript.RequestRef = &reason
+	transcript := NewTranscript(ctx, requestRef, record.IncomingRequest{})
 	req := rpctypes.UpRouteReq{Wait: true}
 	resp := &rpctypes.UpRouteResp{}
 
@@ -55,7 +53,7 @@ func TestRouteCallRegistersOutgoingRequestWithValidReason(t *testing.T) {
 	err := rpcm.RouteCall(ctx, transcript, req, resp)
 	require.NoError(t, err)
 	require.NotNil(t, outreq)
-	require.Equal(t, reason, outreq.Reason)
+	require.Equal(t, requestRef, outreq.Reason)
 }
 
 func TestRouteCallRegistersSaga(t *testing.T) {
@@ -69,9 +67,7 @@ func TestRouteCallRegistersSaga(t *testing.T) {
 
 	rpcm := NewExecutionProxyImplementation(dc, cr, am)
 	ctx := context.Background()
-	transcript := NewTranscript(ctx, &requestRef, record.IncomingRequest{})
-	reason := gen.Reference()
-	transcript.RequestRef = &reason
+	transcript := NewTranscript(ctx, requestRef, record.IncomingRequest{})
 	req := rpctypes.UpRouteReq{Saga: true}
 	resp := &rpctypes.UpRouteResp{}
 
@@ -91,7 +87,7 @@ func TestRouteCallRegistersSaga(t *testing.T) {
 	err := rpcm.RouteCall(ctx, transcript, req, resp)
 	require.NoError(t, err)
 	require.NotNil(t, outreq)
-	require.Equal(t, reason, outreq.Reason)
+	require.Equal(t, requestRef, outreq.Reason)
 }
 
 func TestSaveAsChildRegistersOutgoingRequestWithValidReason(t *testing.T) {
@@ -105,9 +101,7 @@ func TestSaveAsChildRegistersOutgoingRequestWithValidReason(t *testing.T) {
 
 	rpcm := NewExecutionProxyImplementation(dc, cr, am)
 	ctx := context.Background()
-	transcript := NewTranscript(ctx, &requestRef, record.IncomingRequest{})
-	reason := gen.Reference()
-	transcript.RequestRef = &reason
+	transcript := NewTranscript(ctx, requestRef, record.IncomingRequest{})
 	req := rpctypes.UpSaveAsChildReq{}
 	resp := &rpctypes.UpSaveAsChildResp{}
 
@@ -136,7 +130,7 @@ func TestSaveAsChildRegistersOutgoingRequestWithValidReason(t *testing.T) {
 	err := rpcm.SaveAsChild(ctx, transcript, req, resp)
 	require.NoError(t, err)
 	require.NotNil(t, outreq)
-	require.Equal(t, reason, outreq.Reason)
+	require.Equal(t, requestRef, outreq.Reason)
 }
 
 func TestSaveAsDelegateRegistersOutgoingRequestWithValidReason(t *testing.T) {
@@ -150,9 +144,7 @@ func TestSaveAsDelegateRegistersOutgoingRequestWithValidReason(t *testing.T) {
 
 	rpcm := NewExecutionProxyImplementation(dc, cr, am)
 	ctx := context.Background()
-	transcript := NewTranscript(ctx, &requestRef, record.IncomingRequest{})
-	reason := gen.Reference()
-	transcript.RequestRef = &reason
+	transcript := NewTranscript(ctx, requestRef, record.IncomingRequest{})
 	req := rpctypes.UpSaveAsDelegateReq{}
 	resp := &rpctypes.UpSaveAsDelegateResp{}
 
@@ -181,5 +173,5 @@ func TestSaveAsDelegateRegistersOutgoingRequestWithValidReason(t *testing.T) {
 	err := rpcm.SaveAsDelegate(ctx, transcript, req, resp)
 	require.NoError(t, err)
 	require.NotNil(t, outreq)
-	require.Equal(t, reason, outreq.Reason)
+	require.Equal(t, requestRef, outreq.Reason)
 }

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -493,7 +493,7 @@ func (suite *LogicRunnerTestSuite) TestPrepareState() {
 					test.object.queueLen--
 
 					reqRef := gen.Reference()
-					broker.mutable.Push(&Transcript{RequestRef: &reqRef})
+					broker.mutable.Push(&Transcript{RequestRef: reqRef})
 				}
 			}
 
@@ -1176,7 +1176,7 @@ func (s *LogicRunnerTestSuite) TestImmutableOrder() {
 		APIRequestID: utils.RandTraceID(),
 		Immutable:    false,
 	}
-	mutableTranscript := NewTranscript(s.ctx, &mutableRequestRef, mutableRequest)
+	mutableTranscript := NewTranscript(s.ctx, mutableRequestRef, mutableRequest)
 
 	immutableRequest1 := record.IncomingRequest{
 		ReturnMode:   record.ReturnResult,
@@ -1184,7 +1184,7 @@ func (s *LogicRunnerTestSuite) TestImmutableOrder() {
 		APIRequestID: utils.RandTraceID(),
 		Immutable:    true,
 	}
-	immutableTranscript1 := NewTranscript(s.ctx, &immutableRequestRef1, immutableRequest1)
+	immutableTranscript1 := NewTranscript(s.ctx, immutableRequestRef1, immutableRequest1)
 
 	immutableRequest2 := record.IncomingRequest{
 		ReturnMode:   record.ReturnResult,
@@ -1192,7 +1192,7 @@ func (s *LogicRunnerTestSuite) TestImmutableOrder() {
 		APIRequestID: utils.RandTraceID(),
 		Immutable:    true,
 	}
-	immutableTranscript2 := NewTranscript(s.ctx, &immutableRequestRef2, immutableRequest2)
+	immutableTranscript2 := NewTranscript(s.ctx, immutableRequestRef2, immutableRequest2)
 
 	// Set custom executor, that'll:
 	// 1) mutable will start execution and wait until something will ping it on channel 1
@@ -1266,7 +1266,7 @@ func (s *LogicRunnerTestSuite) TestImmutableIsReal() {
 		APIRequestID: utils.RandTraceID(),
 		Immutable:    true,
 	}
-	immutableTranscript1 := NewTranscript(s.ctx, &immutableRequestRef1, immutableRequest1)
+	immutableTranscript1 := NewTranscript(s.ctx, immutableRequestRef1, immutableRequest1)
 
 	s.re.ExecuteAndSaveMock.Return(&reply.CallMethod{Result: []byte{1, 2, 3}}, nil)
 	s.re.SendReplyMock.Return()
@@ -1379,7 +1379,7 @@ func (s *LogicRunnerOnPulseTestSuite) TestWithNotEmptyQueue() {
 	reqRef := gen.Reference()
 	broker.mutable.Push(&Transcript{
 		Context:    s.ctx,
-		RequestRef: &reqRef,
+		RequestRef: reqRef,
 		Request:    &record.IncomingRequest{},
 	})
 	es.pending = message.NotPending
@@ -1582,7 +1582,7 @@ func (s *LRUnsafeGetLedgerPendingRequestTestSuite) TestAlreadyHaveLedgerQueueEle
 	broker.Put(s.ctx, false, &Transcript{
 		FromLedger:   true,
 		LogicContext: &insolar.LogicCallContext{},
-		RequestRef:   &reqRef,
+		RequestRef:   reqRef,
 		Request:      &record.IncomingRequest{},
 	})
 

--- a/logicrunner/requestsexecutor.go
+++ b/logicrunner/requestsexecutor.go
@@ -106,21 +106,22 @@ func (e *requestsExecutor) Save(
 
 	am := e.ArtifactManager
 	request := transcript.Request
+	reqRef := transcript.RequestRef
 
 	switch {
 	case res.Activation:
 		err := e.ArtifactManager.ActivateObject(
-			ctx, *transcript.RequestRef, *request.Base, *request.Prototype,
+			ctx, reqRef, *request.Base, *request.Prototype,
 			request.CallType == record.CTSaveAsDelegate,
 			res.NewMemory,
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't activate object")
 		}
-		return &reply.CallConstructor{Object: transcript.RequestRef}, err
+		return &reply.CallConstructor{Object: &reqRef}, err
 	case res.Deactivation:
 		err := am.DeactivateObject(
-			ctx, *transcript.RequestRef, transcript.ObjectDescriptor, res.Result,
+			ctx, reqRef, transcript.ObjectDescriptor, res.Result,
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't deactivate object")
@@ -128,14 +129,14 @@ func (e *requestsExecutor) Save(
 		return &reply.CallMethod{Result: res.Result}, nil
 	case res.NewMemory != nil:
 		err := am.UpdateObject(
-			ctx, *transcript.RequestRef, transcript.ObjectDescriptor, res.NewMemory, res.Result,
+			ctx, reqRef, transcript.ObjectDescriptor, res.NewMemory, res.Result,
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't update object")
 		}
 		return &reply.CallMethod{Result: res.Result}, nil
 	default:
-		_, err := am.RegisterResult(ctx, *request.Object, *transcript.RequestRef, res.Result)
+		_, err := am.RegisterResult(ctx, *request.Object, reqRef, res.Result)
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't save results")
 		}
@@ -162,7 +163,7 @@ func (e *requestsExecutor) SendReply(
 		ctx,
 		&message.ReturnResults{
 			Target:     target,
-			RequestRef: *transcript.RequestRef,
+			RequestRef: transcript.RequestRef,
 			Reply:      re,
 			Error:      errstr,
 		},

--- a/logicrunner/requestsexecutor_test.go
+++ b/logicrunner/requestsexecutor_test.go
@@ -55,7 +55,7 @@ func TestRequestsExecutor_ExecuteAndSave(t *testing.T) {
 		{
 			name: "success, constructor",
 			transcript: &Transcript{
-				RequestRef: &requestRef,
+				RequestRef: requestRef,
 				Request: &record.IncomingRequest{
 					CallType:  record.CTSaveAsChild,
 					Base:      &baseRef,
@@ -186,7 +186,7 @@ func TestRequestsExecutor_Save(t *testing.T) {
 		{
 			name: "activation",
 			transcript: &Transcript{
-				RequestRef: &requestRef,
+				RequestRef: requestRef,
 				Request: &record.IncomingRequest{
 					Base:      &baseRef,
 					Prototype: &protoRef,
@@ -199,7 +199,7 @@ func TestRequestsExecutor_Save(t *testing.T) {
 		{
 			name: "activation error",
 			transcript: &Transcript{
-				RequestRef: &requestRef,
+				RequestRef: requestRef,
 				Request: &record.IncomingRequest{
 					Base:      &baseRef,
 					Prototype: &protoRef,
@@ -212,7 +212,7 @@ func TestRequestsExecutor_Save(t *testing.T) {
 		{
 			name: "deactivation",
 			transcript: &Transcript{
-				RequestRef: &requestRef,
+				RequestRef: requestRef,
 				Request:    &record.IncomingRequest{},
 			},
 			result: &RequestResult{Deactivation: true, Result: []byte{1, 2, 3}},
@@ -222,7 +222,7 @@ func TestRequestsExecutor_Save(t *testing.T) {
 		{
 			name: "deactivation error",
 			transcript: &Transcript{
-				RequestRef: &requestRef,
+				RequestRef: requestRef,
 				Request:    &record.IncomingRequest{},
 			},
 			result: &RequestResult{Deactivation: true, Result: []byte{1, 2, 3}},
@@ -232,7 +232,7 @@ func TestRequestsExecutor_Save(t *testing.T) {
 		{
 			name: "update",
 			transcript: &Transcript{
-				RequestRef: &requestRef,
+				RequestRef: requestRef,
 				Request:    &record.IncomingRequest{},
 			},
 			result: &RequestResult{NewMemory: []byte{3, 2, 1}, Result: []byte{1, 2, 3}},
@@ -242,7 +242,7 @@ func TestRequestsExecutor_Save(t *testing.T) {
 		{
 			name: "update error",
 			transcript: &Transcript{
-				RequestRef: &requestRef,
+				RequestRef: requestRef,
 				Request:    &record.IncomingRequest{},
 			},
 			result: &RequestResult{NewMemory: []byte{3, 2, 1}, Result: []byte{1, 2, 3}},
@@ -252,7 +252,7 @@ func TestRequestsExecutor_Save(t *testing.T) {
 		{
 			name: "result without update",
 			transcript: &Transcript{
-				RequestRef: &requestRef,
+				RequestRef: requestRef,
 				Request:    &record.IncomingRequest{Object: &objRef},
 			},
 			result: &RequestResult{Result: []byte{1, 2, 3}},
@@ -262,7 +262,7 @@ func TestRequestsExecutor_Save(t *testing.T) {
 		{
 			name: "result without update, error",
 			transcript: &Transcript{
-				RequestRef: &requestRef,
+				RequestRef: requestRef,
 				Request:    &record.IncomingRequest{Object: &objRef},
 			},
 			result: &RequestResult{Result: []byte{1, 2, 3}},
@@ -310,7 +310,7 @@ func TestRequestsExecutor_SendReply(t *testing.T) {
 			name: "success",
 			transcript: &Transcript{
 				RequesterNode: &nodeRef,
-				RequestRef:    &reqRef,
+				RequestRef:    reqRef,
 				Request:       &record.IncomingRequest{},
 			},
 			reply: &reply.CallConstructor{Object: &requestRef},
@@ -326,7 +326,7 @@ func TestRequestsExecutor_SendReply(t *testing.T) {
 			name: "error",
 			transcript: &Transcript{
 				RequesterNode: &nodeRef,
-				RequestRef:    &reqRef,
+				RequestRef:    reqRef,
 				Request:       &record.IncomingRequest{},
 			},
 			reply: &reply.CallConstructor{Object: &requestRef},

--- a/logicrunner/rpc_methods_test.go
+++ b/logicrunner/rpc_methods_test.go
@@ -156,7 +156,7 @@ func TestValidationProxyImplementation_RouteCall(t *testing.T) {
 			transcript: &Transcript{
 				LogicContext: &insolar.LogicCallContext{},
 				Request:      &record.IncomingRequest{},
-				RequestRef:   &reqRef1,
+				RequestRef:   reqRef1,
 				OutgoingRequests: []OutgoingRequest{
 					{
 						Request: record.IncomingRequest{


### PR DESCRIPTION
this field is required and it's easy to do the following mistake:

for _, qe := range p.msg.Queue {
    transcript := NewTranscript(ctx, &qe.RequestRef, qe.Request)
    ...
}

all transcripts in above code have the same request reference as all
pointers point at the same reference.

