### PR TITLE
INS-2798: return error if we try to activate duplicate record

### DIFF
--- a/ledger/light/proc/activate_object.go
+++ b/ledger/light/proc/activate_object.go
@@ -105,17 +105,10 @@ func (a *ActivateObject) Proceed(ctx context.Context) error {
 	}
 
 	err = a.dep.records.Set(ctx, a.activateID, rec)
-
-	if err == object.ErrOverride {
-		// Since there is no deduplication yet it's quite possible that there will be
-		// two writes by the same key. For this reason currently instead of reporting
-		// an error we return OK (nil error). When deduplication will be implemented
-		// we should change `nil` to `ErrOverride` here.
-		logger.Errorf("can't save record into storage: %s", err)
-		return nil
-	} else if err != nil {
+	if err != nil {
 		return errors.Wrap(err, "can't save record into storage")
 	}
+
 	// We are activating the object. There is no index for it anywhere.
 	idx := object.FilamentIndex{
 		Lifeline: object.Lifeline{

--- a/ledger/light/proc/activate_object_test.go
+++ b/ledger/light/proc/activate_object_test.go
@@ -71,11 +71,7 @@ func TestActivateObject_RecordOverrideErr(t *testing.T) {
 	)
 
 	err := p.Proceed(ctx)
-	// Since there is no deduplication yet it's quite possible that there will be
-	// two writes by the same key. For this reason currently instead of reporting
-	// an error we return OK (nil error). When deduplication will be implemented
-	// we should check `ErrOverride` here.
-	require.NoError(t, err)
+	require.Error(t, err)
 }
 
 func TestActivateObject_RecordErr(t *testing.T) {


### PR DESCRIPTION
1) this should be an error with or without deduplication

2) the old code wasn't returning anything, resulted in watermill timeout
   on the caller side

3) our tests setup doesn't execute duplicated requests at the moment
