### PR TITLE
a few improvements in contract requestor

### DIFF
--- a/contractrequester/contractrequester_test.go
+++ b/contractrequester/contractrequester_test.go
@@ -18,17 +18,16 @@ package contractrequester
 
 import (
 	"context"
-	"runtime"
 	"testing"
 	"time"
 
 	"github.com/gojuno/minimock"
-	"github.com/insolar/insolar/insolar/jet"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/insolar/insolar/component"
 	"github.com/insolar/insolar/insolar"
+	"github.com/insolar/insolar/insolar/gen"
+	"github.com/insolar/insolar/insolar/jet"
 	"github.com/insolar/insolar/insolar/message"
 	"github.com/insolar/insolar/insolar/pulse"
 	"github.com/insolar/insolar/insolar/record"
@@ -38,11 +37,9 @@ import (
 	"github.com/insolar/insolar/testutils"
 )
 
-func mockMessageBus(t *testing.T, result insolar.Reply) *testutils.MessageBusMock {
+func mockMessageBus(t minimock.Tester, result insolar.Reply) *testutils.MessageBusMock {
 	mbMock := testutils.NewMessageBusMock(t)
-	mbMock.SendFunc = func(c context.Context, m insolar.Message, o *insolar.MessageSendOptions) (r insolar.Reply, r1 error) {
-		return result, nil
-	}
+	mbMock.SendMock.Return(result, nil)
 	return mbMock
 }
 
@@ -61,7 +58,7 @@ func TestNew(t *testing.T) {
 	require.Equal(t, messageBus, contractRequester.MessageBus)
 }
 
-func mockPulseAccessor(t *testing.T) pulse.Accessor {
+func mockPulseAccessor(t minimock.Tester) pulse.Accessor {
 	pulseAccessor := pulse.NewAccessorMock(t)
 	currentPulse := insolar.FirstPulseNumber
 	pulseAccessor.LatestFunc = func(p context.Context) (r insolar.Pulse, r1 error) {
@@ -74,7 +71,7 @@ func mockPulseAccessor(t *testing.T) pulse.Accessor {
 	return pulseAccessor
 }
 
-func mockJetCoordinator(t *testing.T) jet.Coordinator {
+func mockJetCoordinator(t minimock.Tester) jet.Coordinator {
 	coordinator := jet.NewCoordinatorMock(t)
 	coordinator.MeFunc = func() (r insolar.Reference) {
 		return testutils.RandomRef()
@@ -82,112 +79,120 @@ func mockJetCoordinator(t *testing.T) jet.Coordinator {
 	return coordinator
 }
 
-func TestContractRequester_SendRequest(t *testing.T) {
+func TestContractRequester_Start(t *testing.T) {
 	ctx := inslogger.TestContext(t)
-	ref := testutils.RandomRef()
+	mc := minimock.NewController(t)
+	defer mc.Finish()
 
-	mbm := mockMessageBus(t, &reply.RegisterRequest{})
 	cReq, err := New()
-	assert.NoError(t, err)
-	cReq.MessageBus = mbm
-
-	cReq.PulseAccessor = mockPulseAccessor(t)
-
-	cReq.JetCoordinator = mockJetCoordinator(t)
-
-	mbm.MustRegisterMock.Return()
-	cReq.Start(ctx)
-
-	go func() {
-		resLen := 0
-		for resLen == 0 {
-			cReq.ResultMutex.Lock()
-			resLen = len(cReq.ResultMap)
-			cReq.ResultMutex.Unlock()
-			runtime.Gosched()
-		}
-
-		cReq.ResultMutex.Lock()
-		for _, v := range cReq.ResultMap {
-			v <- &message.ReturnResults{
-				Reply: &reply.CallMethod{},
-			}
-		}
-		cReq.ResultMutex.Unlock()
-	}()
-	result, err := cReq.SendRequest(ctx, &ref, "TestMethod", []interface{}{})
-
 	require.NoError(t, err)
-	require.Equal(t, &reply.CallMethod{}, result)
-}
 
-func TestContractRequester_SendRequest_RouteError(t *testing.T) {
-	ctx := inslogger.TestContext(t)
-	ref := testutils.RandomRef()
+	cReq.MessageBus = testutils.NewMessageBusMock(mc).
+		MustRegisterMock.Return()
 
-	mbm := mockMessageBus(t, &reply.CallMethod{})
-	cReq, err := New()
-	assert.NoError(t, err)
-	cReq.MessageBus = mbm
-	cReq.PulseAccessor = mockPulseAccessor(t)
-	cReq.JetCoordinator = mockJetCoordinator(t)
-
-	mbm.MustRegisterMock.Return()
 	err = cReq.Start(ctx)
 	require.NoError(t, err)
-
-	ifResultMapEmpty := func() bool {
-		cReq.ResultMutex.Lock()
-		defer cReq.ResultMutex.Unlock()
-		return len(cReq.ResultMap) == 0
-	}
-
-	go func() {
-		for ifResultMapEmpty() {
-			runtime.Gosched()
-		}
-		cReq.ResultMutex.Lock()
-		for _, v := range cReq.ResultMap {
-			v <- &message.ReturnResults{
-				Reply: nil,
-			}
-		}
-		cReq.ResultMutex.Unlock()
-	}()
-
-	result, err := cReq.SendRequest(ctx, &ref, "TestMethod", []interface{}{})
-	require.Nil(t, result)
 }
 
-func TestCallMethodCanceled(t *testing.T) {
-	ctx := context.Background()
-	ctx, cancelFunc := context.WithTimeout(ctx, time.Second)
-	defer cancelFunc()
+func TestContractRequester_SendRequest(t *testing.T) {
+	ctx := inslogger.TestContext(t)
+	mc := minimock.NewController(t)
+	defer mc.Finish()
+
+	ref := gen.Reference()
+
+	cReq, err := New()
+	require.NoError(t, err)
+
+	cReq.PulseAccessor = mockPulseAccessor(mc)
+	cReq.JetCoordinator = mockJetCoordinator(mc)
+	cReq.PlatformCryptographyScheme = testutils.NewPlatformCryptographyScheme()
+
+	table := []struct {
+		name          string
+		resultMessage message.ReturnResults
+		earlyResult   bool
+	}{
+		{
+			name: "success",
+			resultMessage: message.ReturnResults{
+				Reply: &reply.CallMethod{},
+			},
+		},
+		{
+			name: "early result, before registration",
+			resultMessage: message.ReturnResults{
+				Reply: &reply.CallMethod{},
+			},
+		},
+	}
+
+	for _, test := range table {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+
+			cReq.MessageBus = testutils.NewMessageBusMock(mc).SendMock.
+				Set(func(ctx context.Context, m insolar.Message, opt *insolar.MessageSendOptions) (insolar.Reply, error) {
+					request := m.(*message.CallMethod).IncomingRequest
+
+					hash, err := cReq.calcRequestHash(request)
+					require.NoError(t, err)
+					requestRef := insolar.NewReference(*insolar.NewID(insolar.FirstPulseNumber, hash[:]))
+
+					resultSender := func () {
+						res := test.resultMessage
+						res.RequestRef = *requestRef
+						cReq.result(ctx, &res)
+					}
+					if test.earlyResult {
+						resultSender()
+					} else {
+						go func() {
+							time.Sleep(time.Millisecond)
+							resultSender()
+						}()
+					}
+
+					return &reply.RegisterRequest{Request: *requestRef}, nil
+				})
+
+			result, err := cReq.SendRequest(ctx, &ref, "TestMethod", []interface{}{})
+			require.NoError(t, err)
+			require.Equal(t, &reply.CallMethod{}, result)
+		})
+	}
+}
+
+func TestContractRequester_CallMethod_Timeout(t *testing.T) {
+	ctx := inslogger.TestContext(t)
+	mc := minimock.NewController(t)
+	defer mc.Finish()
 
 	cr, err := New()
 	require.NoError(t, err)
 
-	mc := minimock.NewController(t)
-	defer mc.Finish()
+	cr.callTimeout = 1*time.Nanosecond
 
-	mb := testutils.NewMessageBusMock(mc)
-	cr.MessageBus = mb
-	cr.PulseAccessor = mockPulseAccessor(t)
-	cr.JetCoordinator = mockJetCoordinator(t)
+	cr.PlatformCryptographyScheme = testutils.NewPlatformCryptographyScheme()
+
+	cr.PulseAccessor = mockPulseAccessor(mc)
+	cr.JetCoordinator = mockJetCoordinator(mc)
 
 	ref := testutils.RandomRef()
 	prototypeRef := testutils.RandomRef()
 	method := testutils.RandomString()
 
-	var reqHash [insolar.RecordHashSize]byte
+	mb := testutils.NewMessageBusMock(mc)
+	mb.SendFunc = func(ctx context.Context, m insolar.Message, opt *insolar.MessageSendOptions) (insolar.Reply, error) {
+		request := m.(*message.CallMethod).IncomingRequest
 
-	mb.SendFunc = func(p context.Context, p1 insolar.Message, p2 *insolar.MessageSendOptions) (r insolar.Reply, r1 error) {
-		for k := range cr.ResultMap {
-			reqHash = k
-			break
-		}
-		return &reply.RegisterRequest{}, nil
+		hash, err := cr.calcRequestHash(request)
+		require.NoError(t, err)
+		requestRef := insolar.NewReference(*insolar.NewID(insolar.FirstPulseNumber, hash[:]))
+
+		return &reply.RegisterRequest{Request: *requestRef}, nil
 	}
+	cr.MessageBus = mb
 
 	msg := &message.CallMethod{
 		IncomingRequest: record.IncomingRequest{
@@ -197,67 +202,11 @@ func TestCallMethodCanceled(t *testing.T) {
 			Arguments: insolar.Arguments{},
 		},
 	}
+
 	_, err = cr.CallMethod(ctx, msg)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "canceled")
-
-	_, ok := cr.ResultMap[reqHash]
-	assert.Equal(t, false, ok)
-}
-
-func TestCallMethodWaitResults(t *testing.T) {
-	ctx := context.Background()
-	ctx, cancelFunc := context.WithTimeout(ctx, time.Second*10)
-	defer cancelFunc()
-
-	cr, err := New()
-	require.NoError(t, err)
-
-	mc := minimock.NewController(t)
-	defer mc.Finish()
-
-	mb := testutils.NewMessageBusMock(mc)
-	cr.MessageBus = mb
-	cr.PulseAccessor = mockPulseAccessor(t)
-	cr.JetCoordinator = mockJetCoordinator(t)
-
-	ref := testutils.RandomRef()
-	prototypeRef := testutils.RandomRef()
-	method := testutils.RandomString()
-
-	var reqHash [insolar.RecordHashSize]byte
-
-	mb.SendFunc = func(p context.Context, p1 insolar.Message, p2 *insolar.MessageSendOptions) (r insolar.Reply, r1 error) {
-		for k := range cr.ResultMap {
-			reqHash = k
-			break
-		}
-
-		go func() {
-			_, ok := p1.(*message.CallMethod)
-			require.Equal(t, ok, true)
-
-			cr.ResultMutex.Lock()
-			defer cr.ResultMutex.Unlock()
-			resChan, ok := cr.ResultMap[reqHash]
-			resChan <- &message.ReturnResults{
-				Reply: &reply.CallMethod{},
-			}
-		}()
-		return &reply.RegisterRequest{}, nil
-	}
-
-	msg := &message.CallMethod{
-		IncomingRequest: record.IncomingRequest{
-			Object:    &ref,
-			Prototype: &prototypeRef,
-			Method:    method,
-			Arguments: insolar.Arguments{},
-		},
-	}
-
-	_, err = cr.CallMethod(ctx, msg)
-	require.NoError(t, err)
+	require.Contains(t, err.Error(), "canceled")
+	require.Contains(t, err.Error(), "timeout")
 }
 
 func TestReceiveResult(t *testing.T) {


### PR DESCRIPTION
* inject platform cryptography, don't create a new one every time
* make sure registered request have the same hash
