### PR TITLE
INS-2981: correct signature marshalling

### DIFF
--- a/api/requester/requester.go
+++ b/api/requester/requester.go
@@ -23,6 +23,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/asn1"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -232,43 +233,22 @@ func Sign(privateKey crypto.PrivateKey, data []byte) (string, error) {
 		return "", errors.Wrap(err, "[ sign ] Cant sign data")
 	}
 
-	return pointsToDER(r, s), nil
+	return marshalSig(r, s)
 }
 
-// Convert signature points do DER format
-func pointsToDER(r, s *big.Int) string {
-	prefixPoint := func(b []byte) []byte {
-		if len(b) == 0 {
-			b = []byte{0x00}
-		}
-		if b[0]&0x80 != 0 {
-			paddedBytes := make([]byte, len(b)+1)
-			copy(paddedBytes[1:], b)
-			b = paddedBytes
-		}
-		return b
+// marshalSig encodes ECDSA signature to ASN.1.
+func marshalSig(r, s *big.Int) (string, error) {
+	var ecdsaSig struct {
+		R, S *big.Int
+	}
+	ecdsaSig.R, ecdsaSig.S = r, s
+
+	asnSig, err := asn1.Marshal(ecdsaSig)
+	if err != nil {
+		return "", err
 	}
 
-	rb := prefixPoint(r.Bytes())
-	sb := prefixPoint(s.Bytes())
-
-	// DER encoding:
-	// der prefix - 30
-	// length of the res of signature - 45
-	// marker for r value - 02
-	// length of r value - 21
-	// r value
-	// marker for s value - 02
-	// length of s value - 21
-	// s value
-	// 0x30 + z + 0x02 + len(rb) + rb + 0x02 + len(sb) + sb
-	length := 2 + len(rb) + 2 + len(sb)
-
-	der := append([]byte{0x30, byte(length), 0x02, byte(len(rb))}, rb...)
-	der = append(der, 0x02, byte(len(sb)))
-	der = append(der, sb...)
-
-	return base64.StdEncoding.EncodeToString(der)
+	return base64.StdEncoding.EncodeToString(asnSig), nil
 }
 
 // Send first gets seed and after that makes target request

--- a/api/requester/requester_test.go
+++ b/api/requester/requester_test.go
@@ -278,7 +278,7 @@ func TestStatus(t *testing.T) {
 	require.Equal(t, resp, &testStatusResponse)
 }
 
-func TestPointToDER(t *testing.T) {
+func TestMarshalSig(t *testing.T) {
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	msg := "test"
@@ -286,11 +286,13 @@ func TestPointToDER(t *testing.T) {
 
 	r1, s1, err := ecdsa.Sign(rand.Reader, privateKey, hash[:])
 	require.NoError(t, err)
-	derString := pointsToDER(r1, s1)
+	derString, err := marshalSig(r1, s1)
+	require.NoError(t, err)
 
 	sig, err := base64.StdEncoding.DecodeString(derString)
 
-	r2, s2 := foundation.PointsFromDER(sig)
+	r2, s2, err := foundation.UnmarshalSig(sig)
+	require.NoError(t, err)
 
 	require.Equal(t, r1, r2, errors.Errorf("Invalid S number"))
 	require.Equal(t, s1, s2, errors.Errorf("Invalid R number"))


### PR DESCRIPTION
**- What I did**
Replaced handmade ECDSA signature serialization with stdlib ASN.1 marshaling.

**- How I did it**
I've found an unmarshaling example in [crypto/openpgp](https://github.com/golang/crypto/blob/master/openpgp/packet/signature.go#L563) library and implemented serialization the same way.