### PR TITLE
INS-3008: added root member reference auto set

### DIFF
--- a/api/call.go
+++ b/api/call.go
@@ -176,10 +176,21 @@ func processRequest(ctx context.Context,
 	return ctx, rawBody, nil
 }
 
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
 func setRootReferenceIfNeeded(request *requester.Request) {
-	if request.Params.CallSite == "member.create" ||
-		request.Params.CallSite == "member.migrationCreate" ||
-		request.Params.CallSite == "member.get" {
+	if request.Params.Reference != "" {
+		return
+	}
+	methods := []string{"member.create", "member.migrationCreate", "member.get"}
+	if contains(methods, request.Params.CallSite) {
 		request.Params.Reference = genesisrefs.ContractRootMember.String()
 	}
 }

--- a/api/call.go
+++ b/api/call.go
@@ -90,7 +90,7 @@ func (ar *Runner) makeCall(ctx context.Context, request requester.Request, rawBo
 
 	reference, err := insolar.NewReferenceFromBase58(request.Params.Reference)
 	if err != nil {
-		return nil, errors.Wrapf(err, "[ makeCall ] failed to parse params.Reference: %s, method: %S", genesisrefs.ContractRootMember.String(), request.Params.CallSite)
+		return nil, errors.Wrap(err, "[ makeCall ] failed to parse params.Reference")
 	}
 
 	requestArgs, err := insolar.MarshalArgs(rawBody, signature, pulseTimeStamp)

--- a/api/sdk/sdk.go
+++ b/api/sdk/sdk.go
@@ -176,7 +176,7 @@ func (sdk *SDK) CreateMember() (*Member, string, error) {
 	}
 	publicKeyStr := string(publicKey)
 
-	userConfig, err := requester.CreateUserConfig(sdk.rootMember.Caller, privateKeyStr, publicKeyStr)
+	userConfig, err := requester.CreateUserConfig("", privateKeyStr, publicKeyStr)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "failed to create user config for request")
 	}

--- a/functest/member_create_test.go
+++ b/functest/member_create_test.go
@@ -28,7 +28,6 @@ import (
 func TestMemberCreate(t *testing.T) {
 	member, err := newUserWithKeys()
 	require.NoError(t, err)
-	member.ref = root.ref
 	result, err := retryableMemberCreate(member, true)
 	require.NoError(t, err)
 	output, ok := result.(map[string]interface{})
@@ -39,7 +38,6 @@ func TestMemberCreate(t *testing.T) {
 func TestMemberCreateWithBadKey(t *testing.T) {
 	member, err := newUserWithKeys()
 	require.NoError(t, err)
-	member.ref = root.ref
 	member.pubKey = "fake"
 	_, err = retryableMemberCreate(member, false)
 	require.NotNil(t, err)
@@ -49,7 +47,6 @@ func TestMemberCreateWithBadKey(t *testing.T) {
 func TestMemberCreateWithSamePublicKey(t *testing.T) {
 	member, err := newUserWithKeys()
 	require.NoError(t, err)
-	member.ref = root.ref
 
 	_, err = retryableMemberCreate(member, true)
 	require.NoError(t, err)

--- a/functest/member_get_test.go
+++ b/functest/member_get_test.go
@@ -28,16 +28,16 @@ import (
 
 func TestMemberGet(t *testing.T) {
 	member1 := *createMember(t)
-	member2 := member1
-	member2.ref = root.ref
-	res, err := signedRequest(&member2, "member.get", nil)
+	member2, _ := newUserWithKeys()
+	member2.pubKey = member1.pubKey
+	member2.privKey = member1.privKey
+	res, err := signedRequest(member2, "member.get", nil)
 	require.Nil(t, err)
 	require.Equal(t, member1.ref, res.(map[string]interface{})["reference"].(string))
 }
 
 func TestMigrationMemberGet(t *testing.T) {
 	member1, _ := newUserWithKeys()
-	member1.ref = root.ref
 
 	ba := testutils.RandomString()
 	_, _ = signedRequest(&migrationAdmin, "migration.addBurnAddresses", map[string]interface{}{"burnAddresses": []string{ba}})
@@ -45,7 +45,6 @@ func TestMigrationMemberGet(t *testing.T) {
 	res1, err := retryableMemberMigrationCreate(member1, true)
 
 	member2 := *member1
-	member2.ref = root.ref
 	res2, err := signedRequest(&member2, "member.get", nil)
 	require.Nil(t, err)
 	require.Equal(t, res1.(map[string]interface{})["reference"].(string), res2.(map[string]interface{})["reference"].(string))
@@ -54,7 +53,6 @@ func TestMigrationMemberGet(t *testing.T) {
 
 func TestMemberGetWrongPublicKey(t *testing.T) {
 	member1, _ := newUserWithKeys()
-	member1.ref = root.ref
 	_, err := signedRequest(member1, "member.get", nil)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "member for this public key does not exist")

--- a/functest/member_migration_create_test.go
+++ b/functest/member_migration_create_test.go
@@ -30,7 +30,6 @@ import (
 func TestMemberMigrationCreate(t *testing.T) {
 	member, err := newUserWithKeys()
 	require.NoError(t, err)
-	member.ref = root.ref
 	ba := testutils.RandomString()
 	_, _ = signedRequest(&migrationAdmin, "migration.addBurnAddresses", map[string]interface{}{"burnAddresses": []string{ba}})
 	result, err := retryableMemberMigrationCreate(member, true)
@@ -44,14 +43,12 @@ func TestMemberMigrationCreate(t *testing.T) {
 func TestMemberMigrationCreateWhenNoBurnAddressesLeft(t *testing.T) {
 	member1, err := newUserWithKeys()
 	require.NoError(t, err)
-	member1.ref = root.ref
 	addBurnAddress(t)
 	_, err = retryableMemberMigrationCreate(member1, true)
 	require.Nil(t, err)
 
 	member2, err := newUserWithKeys()
 	require.NoError(t, err)
-	member2.ref = root.ref
 
 	_, err = retryableMemberMigrationCreate(member2, true)
 	require.NotNil(t, err)
@@ -61,7 +58,6 @@ func TestMemberMigrationCreateWhenNoBurnAddressesLeft(t *testing.T) {
 func TestMemberMigrationCreateWithBadKey(t *testing.T) {
 	member, err := newUserWithKeys()
 	require.NoError(t, err)
-	member.ref = root.ref
 	member.pubKey = "fake"
 	_, err = retryableMemberMigrationCreate(member, false)
 	require.NotNil(t, err)
@@ -71,7 +67,6 @@ func TestMemberMigrationCreateWithBadKey(t *testing.T) {
 func TestMemberMigrationCreateWithSamePublicKey(t *testing.T) {
 	member, err := newUserWithKeys()
 	require.NoError(t, err)
-	member.ref = root.ref
 
 	addBurnAddress(t)
 
@@ -86,7 +81,6 @@ func TestMemberMigrationCreateWithSamePublicKey(t *testing.T) {
 
 	memberForBurn, err := newUserWithKeys()
 	require.NoError(t, err)
-	memberForBurn.ref = root.ref
 
 	_, err = retryableMemberMigrationCreate(memberForBurn, true)
 }
@@ -94,7 +88,6 @@ func TestMemberMigrationCreateWithSamePublicKey(t *testing.T) {
 func TestMemberMigrationCreateWithSameBurnAddress(t *testing.T) {
 	member1, err := newUserWithKeys()
 	require.NoError(t, err)
-	member1.ref = root.ref
 
 	ba := testutils.RandomString()
 	_, _ = signedRequest(&migrationAdmin, "migration.addBurnAddresses", map[string]interface{}{"burnAddresses": []string{ba, ba}})
@@ -104,7 +97,6 @@ func TestMemberMigrationCreateWithSameBurnAddress(t *testing.T) {
 
 	member2, err := newUserWithKeys()
 	require.NoError(t, err)
-	member2.ref = root.ref
 
 	_, err = retryableMemberMigrationCreate(member2, true)
 	require.NotNil(t, err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added root member reference auto set in request.
**- How I did it**
Check in API what method in request. If it is `member.create, member.migrationCreate, member.get` then set reference to genesisrefs.ContractRootMember. 
Also edited tests and sdk
**- How to verify it**
Launch tests and bench
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
API RootRef auto set 
