### PR TITLE
[INS-3025] delete hardcoded INSOLAR_LOG_LEVEL from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ ci_test_slow: ## run slow tests just once, redirects json output to file (CI)
 ci_test_func: ## run functest 3 times, redirects json output to file (CI)
 	# GOMAXPROCS=2, because we launch at least 5 insolard nodes in functest + 1 pulsar,
 	# so try to be more honest with processors allocation.
-	GOMAXPROCS=2 CGO_ENABLED=1 INSOLAR_LOG_LEVEL=error \
+	GOMAXPROCS=$(CI_GOMAXPROCS) CGO_ENABLED=1  \
 		go test $(CI_TEST_ARGS) $(TEST_ARGS) -json -tags functest -v ./functest -count 3 -failfast | tee ci_test_func.json
 
 .PHONY: ci_test_integrtest


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
