### PR TITLE
INS-3096: skip tests while we waiting for a few fixes landing in master

### DIFF
--- a/functest/get_balance_test.go
+++ b/functest/get_balance_test.go
@@ -35,6 +35,8 @@ func TestGetBalance(t *testing.T) {
 }
 
 func TestGetBalanceWrongRef(t *testing.T) {
+	t.Skip("skipping until we fix a few bugs (INS-3096)")
+
 	_, err := getBalance(&root, testutils.RandomRef().String())
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "index not found")

--- a/functest/register_node_test.go
+++ b/functest/register_node_test.go
@@ -66,6 +66,8 @@ func TestRegisterNodeLightMaterial(t *testing.T) {
 }
 
 func TestRegisterNodeNotExistRole(t *testing.T) {
+	t.Skip("skipping until we fix a few bugs (INS-3096)")
+
 	_, err := registerNodeSignedCall(map[string]interface{}{"publicKey": TESTPUBLICKEY, "role": "some_not_fancy_role"})
 	require.Contains(t, err.Error(),
 		"role is not supported: some_not_fancy_role")

--- a/functest/send_money_test.go
+++ b/functest/send_money_test.go
@@ -60,6 +60,8 @@ func TestTransferMoney(t *testing.T) {
 }
 
 func TestTransferMoneyFromNotExist(t *testing.T) {
+	t.Skip("skipping until we fix a few bugs (INS-3096)")
+
 	firstMember := createMember(t)
 	firstMember.ref = testutils.RandomRef().String()
 
@@ -77,6 +79,8 @@ func TestTransferMoneyFromNotExist(t *testing.T) {
 }
 
 func TestTransferMoneyToNotExist(t *testing.T) {
+	t.Skip("skipping until we fix a few bugs (INS-3096)")
+
 	firstMember := createMember(t)
 	oldFirstBalance := getBalanceNoErr(t, firstMember, firstMember.ref)
 


### PR DESCRIPTION
these tests result in forever open requests on ledger that affect other
tests, result in timeouts. we're fixing root cause right now.

