### PR TITLE
WLT-767: changed contract constructors names

### DIFF
--- a/bootstrap/contracts/contracts.go
+++ b/bootstrap/contracts/contracts.go
@@ -67,7 +67,7 @@ func NodeDomain() insolar.GenesisContractState {
 }
 
 func GetMemberGenesisContractState(publicKey string, name string, parent string, walletRef insolar.Reference) insolar.GenesisContractState {
-	m, err := member.New(genesisrefs.ContractRootDomain, name, publicKey, "", insolar.Reference{})
+	m, err := member.NewMember(genesisrefs.ContractRootDomain, name, publicKey, "", insolar.Reference{})
 	if err != nil {
 		panic(fmt.Sprintf("'%s' member constructor failed", name))
 	}
@@ -83,7 +83,7 @@ func GetMemberGenesisContractState(publicKey string, name string, parent string,
 }
 
 func GetWalletGenesisContractState(balance string, name string, parent string) insolar.GenesisContractState {
-	w, err := wallet.New(balance)
+	w, err := wallet.NewWallet(balance)
 	if err != nil {
 		panic("failed to create ` " + name + "` wallet instance")
 	}
@@ -98,7 +98,7 @@ func GetWalletGenesisContractState(balance string, name string, parent string) i
 }
 
 func GetCostCenterGenesisContractState() insolar.GenesisContractState {
-	cc, err := costcenter.New(genesisrefs.ContractFeeWallet, genesisrefs.ContractStandardTariff)
+	cc, err := costcenter.NewCostCenter(genesisrefs.ContractFeeWallet, genesisrefs.ContractStandardTariff)
 	if err != nil {
 		panic("failed to create cost center instance")
 	}
@@ -113,7 +113,7 @@ func GetCostCenterGenesisContractState() insolar.GenesisContractState {
 }
 
 func GetTariffGenesisContractState() insolar.GenesisContractState {
-	t, err := tariff.New()
+	t, err := tariff.NewTariff()
 	if err != nil {
 		panic("failed to create tariff instance")
 	}

--- a/logicrunner/builtin/contract/costcenter/costcenter.go
+++ b/logicrunner/builtin/contract/costcenter/costcenter.go
@@ -30,7 +30,7 @@ type CostCenter struct {
 }
 
 // New creates new cost center.
-func New(commissionWallet insolar.Reference, currentTariff insolar.Reference) (*CostCenter, error) {
+func NewCostCenter(commissionWallet insolar.Reference, currentTariff insolar.Reference) (*CostCenter, error) {
 	return &CostCenter{
 		CommissionWallet: commissionWallet,
 		CurrentTariff:    currentTariff,

--- a/logicrunner/builtin/contract/costcenter/costcenter.wrapper.go
+++ b/logicrunner/builtin/contract/costcenter/costcenter.wrapper.go
@@ -264,7 +264,7 @@ func INSMETHOD_GetCurrentTariff(object []byte, data []byte) ([]byte, []byte, err
 	return state, ret, err
 }
 
-func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
+func INSCONSTRUCTOR_NewCostCenter(data []byte) ([]byte, error) {
 	ph := common.CurrentProxyCtx
 	ph.SetSystemError(nil)
 	args := [2]interface{}{}
@@ -275,11 +275,11 @@ func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
 
 	err := ph.Deserialize(data, &args)
 	if err != nil {
-		e := &ExtendableError{S: "[ FakeNew ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
+		e := &ExtendableError{S: "[ FakeNewCostCenter ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
 		return nil, e
 	}
 
-	ret0, ret1 := New(args0, args1)
+	ret0, ret1 := NewCostCenter(args0, args1)
 	if ph.GetSystemError() != nil {
 		return nil, ph.GetSystemError()
 	}
@@ -294,7 +294,7 @@ func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
 	}
 
 	if ret0 == nil {
-		e := &ExtendableError{S: "[ FakeNew ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Constructor returns nil"}
+		e := &ExtendableError{S: "[ FakeNewCostCenter ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Constructor returns nil"}
 		return nil, e
 	}
 
@@ -312,7 +312,7 @@ func Initialize() XXX_insolar.ContractWrapper {
 			"GetCurrentTariff": INSMETHOD_GetCurrentTariff,
 		},
 		Constructors: XXX_insolar.ContractConstructors{
-			"New": INSCONSTRUCTOR_New,
+			"NewCostCenter": INSCONSTRUCTOR_NewCostCenter,
 		},
 	}
 }

--- a/logicrunner/builtin/contract/deposit/deposit.go
+++ b/logicrunner/builtin/contract/deposit/deposit.go
@@ -61,7 +61,7 @@ func (d *Deposit) GetAmount() (string, error) {
 }
 
 // New creates new deposit.
-func New(migrationDaemonConfirms [3]string, txHash string, amount string) (*Deposit, error) {
+func NewDeposit(migrationDaemonConfirms [3]string, txHash string, amount string) (*Deposit, error) {
 	currentPulse, err := foundation.GetPulseNumber()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current pulse: %s", err.Error())

--- a/logicrunner/builtin/contract/deposit/deposit.wrapper.go
+++ b/logicrunner/builtin/contract/deposit/deposit.wrapper.go
@@ -267,7 +267,7 @@ func INSMETHOD_Confirm(object []byte, data []byte) ([]byte, []byte, error) {
 	return state, ret, err
 }
 
-func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
+func INSCONSTRUCTOR_NewDeposit(data []byte) ([]byte, error) {
 	ph := common.CurrentProxyCtx
 	ph.SetSystemError(nil)
 	args := [3]interface{}{}
@@ -280,11 +280,11 @@ func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
 
 	err := ph.Deserialize(data, &args)
 	if err != nil {
-		e := &ExtendableError{S: "[ FakeNew ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
+		e := &ExtendableError{S: "[ FakeNewDeposit ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
 		return nil, e
 	}
 
-	ret0, ret1 := New(args0, args1, args2)
+	ret0, ret1 := NewDeposit(args0, args1, args2)
 	if ph.GetSystemError() != nil {
 		return nil, ph.GetSystemError()
 	}
@@ -299,7 +299,7 @@ func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
 	}
 
 	if ret0 == nil {
-		e := &ExtendableError{S: "[ FakeNew ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Constructor returns nil"}
+		e := &ExtendableError{S: "[ FakeNewDeposit ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Constructor returns nil"}
 		return nil, e
 	}
 
@@ -317,7 +317,7 @@ func Initialize() XXX_insolar.ContractWrapper {
 			"Confirm":   INSMETHOD_Confirm,
 		},
 		Constructors: XXX_insolar.ContractConstructors{
-			"New": INSCONSTRUCTOR_New,
+			"NewDeposit": INSCONSTRUCTOR_NewDeposit,
 		},
 	}
 }

--- a/logicrunner/builtin/contract/member/member.go
+++ b/logicrunner/builtin/contract/member/member.go
@@ -61,7 +61,7 @@ func (m *Member) GetPublicKey() (string, error) {
 }
 
 // New creates new member.
-func New(rootDomain insolar.Reference, name string, key string, burnAddress string, walletRef insolar.Reference) (*Member, error) {
+func NewMember(rootDomain insolar.Reference, name string, key string, burnAddress string, walletRef insolar.Reference) (*Member, error) {
 	return &Member{
 		RootDomain:  rootDomain,
 		Deposits:    map[string]insolar.Reference{},
@@ -407,13 +407,13 @@ func (m *Member) createMember(name string, key string, burnAddress string) (*mem
 		return nil, fmt.Errorf("key is not valid")
 	}
 
-	wHolder := wallet.New(big.NewInt(1000000000).String())
+	wHolder := wallet.NewWallet(big.NewInt(1000000000).String())
 	walletRef, err := wHolder.AsChild(m.RootDomain)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create wallet for  member: %s", err.Error())
 	}
 
-	memberHolder := member.New(m.RootDomain, name, key, burnAddress, walletRef.Reference)
+	memberHolder := member.NewMember(m.RootDomain, name, key, burnAddress, walletRef.Reference)
 	created, err := memberHolder.AsChild(m.RootDomain)
 	if err != nil {
 		return nil, fmt.Errorf("failed to save as child: %s", err.Error())
@@ -461,7 +461,7 @@ func (m *Member) depositMigration(txHash string, burnAddress string, amount *big
 	if !found {
 		migrationDaemonConfirms := [3]string{}
 		migrationDaemonConfirms[mdIndex] = m.GetReference().String()
-		dHolder := deposit.New(migrationDaemonConfirms, txHash, amount.String())
+		dHolder := deposit.NewDeposit(migrationDaemonConfirms, txHash, amount.String())
 		txDeposit, err := dHolder.AsChild(tokenHolderRef)
 		if err != nil {
 			return fmt.Errorf("failed to save as delegate: %s", err.Error())

--- a/logicrunner/builtin/contract/member/member.wrapper.go
+++ b/logicrunner/builtin/contract/member/member.wrapper.go
@@ -440,7 +440,7 @@ func INSMETHOD_GetBurnAddress(object []byte, data []byte) ([]byte, []byte, error
 	return state, ret, err
 }
 
-func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
+func INSCONSTRUCTOR_NewMember(data []byte) ([]byte, error) {
 	ph := common.CurrentProxyCtx
 	ph.SetSystemError(nil)
 	args := [5]interface{}{}
@@ -457,11 +457,11 @@ func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
 
 	err := ph.Deserialize(data, &args)
 	if err != nil {
-		e := &ExtendableError{S: "[ FakeNew ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
+		e := &ExtendableError{S: "[ FakeNewMember ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
 		return nil, e
 	}
 
-	ret0, ret1 := New(args0, args1, args2, args3, args4)
+	ret0, ret1 := NewMember(args0, args1, args2, args3, args4)
 	if ph.GetSystemError() != nil {
 		return nil, ph.GetSystemError()
 	}
@@ -476,7 +476,7 @@ func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
 	}
 
 	if ret0 == nil {
-		e := &ExtendableError{S: "[ FakeNew ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Constructor returns nil"}
+		e := &ExtendableError{S: "[ FakeNewMember ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Constructor returns nil"}
 		return nil, e
 	}
 
@@ -498,7 +498,7 @@ func Initialize() XXX_insolar.ContractWrapper {
 			"GetBurnAddress": INSMETHOD_GetBurnAddress,
 		},
 		Constructors: XXX_insolar.ContractConstructors{
-			"New": INSCONSTRUCTOR_New,
+			"NewMember": INSCONSTRUCTOR_NewMember,
 		},
 	}
 }

--- a/logicrunner/builtin/contract/tariff/tariff.go
+++ b/logicrunner/builtin/contract/tariff/tariff.go
@@ -28,7 +28,7 @@ type Tariff struct {
 }
 
 // New creates new tariff.
-func New() (*Tariff, error) {
+func NewTariff() (*Tariff, error) {
 	return &Tariff{}, nil
 }
 

--- a/logicrunner/builtin/contract/tariff/tariff.wrapper.go
+++ b/logicrunner/builtin/contract/tariff/tariff.wrapper.go
@@ -132,18 +132,18 @@ func INSMETHOD_CalcFee(object []byte, data []byte) ([]byte, []byte, error) {
 	return state, ret, err
 }
 
-func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
+func INSCONSTRUCTOR_NewTariff(data []byte) ([]byte, error) {
 	ph := common.CurrentProxyCtx
 	ph.SetSystemError(nil)
 	args := []interface{}{}
 
 	err := ph.Deserialize(data, &args)
 	if err != nil {
-		e := &ExtendableError{S: "[ FakeNew ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
+		e := &ExtendableError{S: "[ FakeNewTariff ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
 		return nil, e
 	}
 
-	ret0, ret1 := New()
+	ret0, ret1 := NewTariff()
 	if ph.GetSystemError() != nil {
 		return nil, ph.GetSystemError()
 	}
@@ -158,7 +158,7 @@ func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
 	}
 
 	if ret0 == nil {
-		e := &ExtendableError{S: "[ FakeNew ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Constructor returns nil"}
+		e := &ExtendableError{S: "[ FakeNewTariff ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Constructor returns nil"}
 		return nil, e
 	}
 
@@ -173,7 +173,7 @@ func Initialize() XXX_insolar.ContractWrapper {
 			"CalcFee": INSMETHOD_CalcFee,
 		},
 		Constructors: XXX_insolar.ContractConstructors{
-			"New": INSCONSTRUCTOR_New,
+			"NewTariff": INSCONSTRUCTOR_NewTariff,
 		},
 	}
 }

--- a/logicrunner/builtin/contract/wallet/wallet.go
+++ b/logicrunner/builtin/contract/wallet/wallet.go
@@ -38,7 +38,7 @@ type Wallet struct {
 }
 
 // New creates new wallet.
-func New(balance string) (*Wallet, error) {
+func NewWallet(balance string) (*Wallet, error) {
 	return &Wallet{
 		Balance: balance,
 	}, nil

--- a/logicrunner/builtin/contract/wallet/wallet.wrapper.go
+++ b/logicrunner/builtin/contract/wallet/wallet.wrapper.go
@@ -270,7 +270,7 @@ func INSMETHOD_GetBalance(object []byte, data []byte) ([]byte, []byte, error) {
 	return state, ret, err
 }
 
-func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
+func INSCONSTRUCTOR_NewWallet(data []byte) ([]byte, error) {
 	ph := common.CurrentProxyCtx
 	ph.SetSystemError(nil)
 	args := [1]interface{}{}
@@ -279,11 +279,11 @@ func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
 
 	err := ph.Deserialize(data, &args)
 	if err != nil {
-		e := &ExtendableError{S: "[ FakeNew ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
+		e := &ExtendableError{S: "[ FakeNewWallet ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
 		return nil, e
 	}
 
-	ret0, ret1 := New(args0)
+	ret0, ret1 := NewWallet(args0)
 	if ph.GetSystemError() != nil {
 		return nil, ph.GetSystemError()
 	}
@@ -298,7 +298,7 @@ func INSCONSTRUCTOR_New(data []byte) ([]byte, error) {
 	}
 
 	if ret0 == nil {
-		e := &ExtendableError{S: "[ FakeNew ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Constructor returns nil"}
+		e := &ExtendableError{S: "[ FakeNewWallet ] ( INSCONSTRUCTOR_* ) ( Generated Method ) Constructor returns nil"}
 		return nil, e
 	}
 
@@ -316,7 +316,7 @@ func Initialize() XXX_insolar.ContractWrapper {
 			"GetBalance": INSMETHOD_GetBalance,
 		},
 		Constructors: XXX_insolar.ContractConstructors{
-			"New": INSCONSTRUCTOR_New,
+			"NewWallet": INSCONSTRUCTOR_NewWallet,
 		},
 	}
 }

--- a/logicrunner/builtin/proxy/costcenter/costcenter.go
+++ b/logicrunner/builtin/proxy/costcenter/costcenter.go
@@ -58,8 +58,8 @@ func GetPrototype() insolar.Reference {
 	return *PrototypeReference
 }
 
-// New is constructor
-func New(commissionWallet insolar.Reference, currentTariff insolar.Reference) *ContractConstructorHolder {
+// NewCostCenter is constructor
+func NewCostCenter(commissionWallet insolar.Reference, currentTariff insolar.Reference) *ContractConstructorHolder {
 	var args [2]interface{}
 	args[0] = commissionWallet
 	args[1] = currentTariff
@@ -70,7 +70,7 @@ func New(commissionWallet insolar.Reference, currentTariff insolar.Reference) *C
 		panic(err)
 	}
 
-	return &ContractConstructorHolder{constructorName: "New", argsSerialized: argsSerialized}
+	return &ContractConstructorHolder{constructorName: "NewCostCenter", argsSerialized: argsSerialized}
 }
 
 // GetReference returns reference of the object

--- a/logicrunner/builtin/proxy/deposit/deposit.go
+++ b/logicrunner/builtin/proxy/deposit/deposit.go
@@ -60,8 +60,8 @@ func GetPrototype() insolar.Reference {
 	return *PrototypeReference
 }
 
-// New is constructor
-func New(migrationDaemonConfirms [3]string, txHash string, amount string) *ContractConstructorHolder {
+// NewDeposit is constructor
+func NewDeposit(migrationDaemonConfirms [3]string, txHash string, amount string) *ContractConstructorHolder {
 	var args [3]interface{}
 	args[0] = migrationDaemonConfirms
 	args[1] = txHash
@@ -73,7 +73,7 @@ func New(migrationDaemonConfirms [3]string, txHash string, amount string) *Contr
 		panic(err)
 	}
 
-	return &ContractConstructorHolder{constructorName: "New", argsSerialized: argsSerialized}
+	return &ContractConstructorHolder{constructorName: "NewDeposit", argsSerialized: argsSerialized}
 }
 
 // GetReference returns reference of the object

--- a/logicrunner/builtin/proxy/member/member.go
+++ b/logicrunner/builtin/proxy/member/member.go
@@ -91,8 +91,8 @@ func GetPrototype() insolar.Reference {
 	return *PrototypeReference
 }
 
-// New is constructor
-func New(rootDomain insolar.Reference, name string, key string, burnAddress string, walletRef insolar.Reference) *ContractConstructorHolder {
+// NewMember is constructor
+func NewMember(rootDomain insolar.Reference, name string, key string, burnAddress string, walletRef insolar.Reference) *ContractConstructorHolder {
 	var args [5]interface{}
 	args[0] = rootDomain
 	args[1] = name
@@ -106,7 +106,7 @@ func New(rootDomain insolar.Reference, name string, key string, burnAddress stri
 		panic(err)
 	}
 
-	return &ContractConstructorHolder{constructorName: "New", argsSerialized: argsSerialized}
+	return &ContractConstructorHolder{constructorName: "NewMember", argsSerialized: argsSerialized}
 }
 
 // GetReference returns reference of the object

--- a/logicrunner/builtin/proxy/tariff/tariff.go
+++ b/logicrunner/builtin/proxy/tariff/tariff.go
@@ -58,8 +58,8 @@ func GetPrototype() insolar.Reference {
 	return *PrototypeReference
 }
 
-// New is constructor
-func New() *ContractConstructorHolder {
+// NewTariff is constructor
+func NewTariff() *ContractConstructorHolder {
 	var args [0]interface{}
 
 	var argsSerialized []byte
@@ -68,7 +68,7 @@ func New() *ContractConstructorHolder {
 		panic(err)
 	}
 
-	return &ContractConstructorHolder{constructorName: "New", argsSerialized: argsSerialized}
+	return &ContractConstructorHolder{constructorName: "NewTariff", argsSerialized: argsSerialized}
 }
 
 // GetReference returns reference of the object

--- a/logicrunner/builtin/proxy/wallet/wallet.go
+++ b/logicrunner/builtin/proxy/wallet/wallet.go
@@ -58,8 +58,8 @@ func GetPrototype() insolar.Reference {
 	return *PrototypeReference
 }
 
-// New is constructor
-func New(balance string) *ContractConstructorHolder {
+// NewWallet is constructor
+func NewWallet(balance string) *ContractConstructorHolder {
 	var args [1]interface{}
 	args[0] = balance
 
@@ -69,7 +69,7 @@ func New(balance string) *ContractConstructorHolder {
 		panic(err)
 	}
 
-	return &ContractConstructorHolder{constructorName: "New", argsSerialized: argsSerialized}
+	return &ContractConstructorHolder{constructorName: "NewWallet", argsSerialized: argsSerialized}
 }
 
 // GetReference returns reference of the object


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
 Changed contract constructors names. Because observer node can't understand what smartcontract was created by name of constructor.
**- How I did it**
 Changed contract constructors names
**- How to verify it**
Launch
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Smart constructors names