### PR TITLE
INS-3109: fixed panic if incorrect params

### DIFF
--- a/functest/new_api_test.go
+++ b/functest/new_api_test.go
@@ -143,3 +143,10 @@ func TestIncorrectMethodName(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualError(t, contractError(res), "rpc method does not exist")
 }
+
+func TestIncorrectParams(t *testing.T) {
+	firstMember := createMember(t)
+
+	_, err := signedRequest(firstMember, "member.transfer", firstMember.ref)
+	require.Contains(t, err.Error(), "failed to cast request.Params.CallParams: expected map[string]interface{}, got string")
+}

--- a/logicrunner/builtin/contract/member/member.go
+++ b/logicrunner/builtin/contract/member/member.go
@@ -142,7 +142,11 @@ func (m *Member) Call(signedRequest []byte) (interface{}, error) {
 		return m.memberGet(request.Params.PublicKey)
 	}
 
-	params := request.Params.CallParams.(map[string]interface{})
+	var params map[string]interface{}
+	var ok bool
+	if params, ok = request.Params.CallParams.(map[string]interface{}); !ok {
+		return nil, fmt.Errorf("failed to cast request.Params.CallParams: expected map[string]interface{}, got %T", request.Params.CallParams)
+	}
 
 	switch request.Params.CallSite {
 	case "contract.registerNode":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed panic if call with invalid params
**- How I did it**
Added comparison statement
**- How to verify it**
launch TestIncorrectParams
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
