### PR TITLE
INS-3011 use thread safe t in concurency test

### DIFF
--- a/functest/pressure_test.go
+++ b/functest/pressure_test.go
@@ -19,6 +19,7 @@
 package functest
 
 import (
+	"github.com/insolar/insolar/insolar/utils"
 	"sync"
 	"testing"
 
@@ -60,7 +61,7 @@ func (c *One) Dec() (int, error) {
 	protoRef := uploadContractOnce(t, "testPressure", contractCode)
 
 	t.Run("one object, sequential calls", func(t *testing.T) {
-		syncT := &SyncT{T: t}
+		syncT := &utils.SyncT{T: t}
 
 		objectRef := callConstructor(syncT, protoRef, "New")
 
@@ -73,7 +74,7 @@ func (c *One) Dec() (int, error) {
 	})
 
 	t.Run("one object, parallel calls", func(t *testing.T) {
-		syncT := &SyncT{T: t}
+		syncT := &utils.SyncT{T: t}
 
 		objectRef := callConstructor(syncT, protoRef, "New")
 
@@ -92,7 +93,7 @@ func (c *One) Dec() (int, error) {
 	})
 
 	t.Run("ten objects, sequential calls", func(t *testing.T) {
-		syncT := &SyncT{T: t}
+		syncT := &utils.SyncT{T: t}
 
 		wg := sync.WaitGroup{}
 		wg.Add(10)
@@ -112,7 +113,7 @@ func (c *One) Dec() (int, error) {
 	})
 
 	t.Run("ten objects, parallel calls", func(t *testing.T) {
-		syncT := &SyncT{T: t}
+		syncT := &utils.SyncT{T: t}
 
 		wg := sync.WaitGroup{}
 		wg.Add(100)

--- a/functest/pressure_test.go
+++ b/functest/pressure_test.go
@@ -19,11 +19,12 @@
 package functest
 
 import (
-	"github.com/insolar/insolar/insolar/utils"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/insolar/insolar/insolar/utils"
 )
 
 func TestPressureOnSystem(t *testing.T) {

--- a/functest/utils_test.go
+++ b/functest/utils_test.go
@@ -29,7 +29,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/insolar/insolar/api"
@@ -510,97 +509,3 @@ func callMethodNoChecks(t testing.TB, objectRef *insolar.Reference, method strin
 
 	return callRes
 }
-
-type SyncT struct {
-	*testing.T
-
-	mu sync.Mutex
-}
-
-var _ testing.TB = (*SyncT)(nil)
-
-func (t SyncT) Error(args ...interface{}) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.T.Error(args...)
-}
-func (t SyncT) Errorf(format string, args ...interface{}) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.T.Errorf(format, args...)
-}
-func (t SyncT) Fail() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.T.Fail()
-}
-func (t SyncT) FailNow() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.T.FailNow()
-}
-func (t SyncT) Failed() bool {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	return t.T.Failed()
-}
-func (t SyncT) Fatal(args ...interface{}) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.T.Fatal(args...)
-}
-func (t SyncT) Fatalf(format string, args ...interface{}) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.T.Fatalf(format, args...)
-}
-func (t SyncT) Log(args ...interface{}) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.T.Log(args...)
-}
-func (t SyncT) Logf(format string, args ...interface{}) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.T.Logf(format, args...)
-}
-func (t SyncT) Name() string {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	return t.T.Name()
-}
-func (t SyncT) Skip(args ...interface{}) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.T.Skip(args...)
-}
-func (t SyncT) SkipNow() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.T.SkipNow()
-}
-func (t SyncT) Skipf(format string, args ...interface{}) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.T.Skipf(format, args...)
-}
-func (t SyncT) Skipped() bool {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	return t.T.Skipped()
-}
-func (t SyncT) Helper() {}

--- a/insolar/utils/utils.go
+++ b/insolar/utils/utils.go
@@ -79,88 +79,88 @@ type SyncT struct {
 
 var _ testing.TB = (*SyncT)(nil)
 
-func (t SyncT) Error(args ...interface{}) {
+func (t *SyncT) Error(args ...interface{}) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.T.Error(args...)
 }
-func (t SyncT) Errorf(format string, args ...interface{}) {
+func (t *SyncT) Errorf(format string, args ...interface{}) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.T.Errorf(format, args...)
 }
-func (t SyncT) Fail() {
+func (t *SyncT) Fail() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.T.Fail()
 }
-func (t SyncT) FailNow() {
+func (t *SyncT) FailNow() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.T.FailNow()
 }
-func (t SyncT) Failed() bool {
+func (t *SyncT) Failed() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	return t.T.Failed()
 }
-func (t SyncT) Fatal(args ...interface{}) {
+func (t *SyncT) Fatal(args ...interface{}) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.T.Fatal(args...)
 }
-func (t SyncT) Fatalf(format string, args ...interface{}) {
+func (t *SyncT) Fatalf(format string, args ...interface{}) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.T.Fatalf(format, args...)
 }
-func (t SyncT) Log(args ...interface{}) {
+func (t *SyncT) Log(args ...interface{}) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.T.Log(args...)
 }
-func (t SyncT) Logf(format string, args ...interface{}) {
+func (t *SyncT) Logf(format string, args ...interface{}) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.T.Logf(format, args...)
 }
-func (t SyncT) Name() string {
+func (t *SyncT) Name() string {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	return t.T.Name()
 }
-func (t SyncT) Skip(args ...interface{}) {
+func (t *SyncT) Skip(args ...interface{}) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.T.Skip(args...)
 }
-func (t SyncT) SkipNow() {
+func (t *SyncT) SkipNow() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.T.SkipNow()
 }
-func (t SyncT) Skipf(format string, args ...interface{}) {
+func (t *SyncT) Skipf(format string, args ...interface{}) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.T.Skipf(format, args...)
 }
-func (t SyncT) Skipped() bool {
+func (t *SyncT) Skipped() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	return t.T.Skipped()
 }
-func (t SyncT) Helper() {}
+func (t *SyncT) Helper() {}

--- a/insolar/utils/utils.go
+++ b/insolar/utils/utils.go
@@ -19,9 +19,11 @@ package utils
 import (
 	"context"
 	"encoding/binary"
+	"sync"
+	"testing"
 
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 )
 
 type traceIDKey struct{}
@@ -68,3 +70,97 @@ func CircleXOR(value, src []byte) []byte {
 	}
 	return result
 }
+
+type SyncT struct {
+	*testing.T
+
+	mu sync.Mutex
+}
+
+var _ testing.TB = (*SyncT)(nil)
+
+func (t SyncT) Error(args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.T.Error(args...)
+}
+func (t SyncT) Errorf(format string, args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.T.Errorf(format, args...)
+}
+func (t SyncT) Fail() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.T.Fail()
+}
+func (t SyncT) FailNow() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.T.FailNow()
+}
+func (t SyncT) Failed() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.T.Failed()
+}
+func (t SyncT) Fatal(args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.T.Fatal(args...)
+}
+func (t SyncT) Fatalf(format string, args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.T.Fatalf(format, args...)
+}
+func (t SyncT) Log(args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.T.Log(args...)
+}
+func (t SyncT) Logf(format string, args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.T.Logf(format, args...)
+}
+func (t SyncT) Name() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.T.Name()
+}
+func (t SyncT) Skip(args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.T.Skip(args...)
+}
+func (t SyncT) SkipNow() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.T.SkipNow()
+}
+func (t SyncT) Skipf(format string, args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.T.Skipf(format, args...)
+}
+func (t SyncT) Skipped() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.T.Skipped()
+}
+func (t SyncT) Helper() {}

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -345,21 +345,22 @@ func (suite *LogicRunnerTestSuite) TestConcurrency() {
 
 	suite.jc.IsMeAuthorizedNowMock.Return(true, nil)
 
+	syncT := utils.SyncT{T: suite.T()}
 	meRef := testutils.RandomRef()
-	nodeMock := network.NewNetworkNodeMock(suite.T())
+	nodeMock := network.NewNetworkNodeMock(syncT)
 	nodeMock.IDMock.Return(meRef)
 
-	od := artifacts.NewObjectDescriptorMock(suite.T())
+	od := artifacts.NewObjectDescriptorMock(syncT)
 	od.PrototypeMock.Return(&protoRef, nil)
 	od.MemoryMock.Return([]byte{1, 2, 3})
 	od.ParentMock.Return(&parentRef)
 	od.HeadRefMock.Return(&objectRef)
 
-	pd := artifacts.NewObjectDescriptorMock(suite.T())
+	pd := artifacts.NewObjectDescriptorMock(syncT)
 	pd.CodeMock.Return(&codeRef, nil)
 	pd.HeadRefMock.Return(&protoRef)
 
-	cd := artifacts.NewCodeDescriptorMock(suite.T())
+	cd := artifacts.NewCodeDescriptorMock(syncT)
 	cd.MachineTypeMock.Return(insolar.MachineTypeBuiltin)
 	cd.RefMock.Return(&codeRef)
 

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -345,7 +345,7 @@ func (suite *LogicRunnerTestSuite) TestConcurrency() {
 
 	suite.jc.IsMeAuthorizedNowMock.Return(true, nil)
 
-	syncT := utils.SyncT{T: suite.T()}
+	syncT := &utils.SyncT{T: suite.T()}
 	meRef := testutils.RandomRef()
 	nodeMock := network.NewNetworkNodeMock(syncT)
 	nodeMock.IDMock.Return(meRef)


### PR DESCRIPTION
**- What I did**
fix concurrency test
**- How I did it**
move SyncT to testutils and reuse it
**- How to verify it**
run 
go test ./logicrunner/ -run '^TestLogicRunner$' -timeout 0 -count 100000 -failfast -v -race
and wait 2 hours