### PR TITLE
drop unused field Transcript.RequesterNode

### DIFF
--- a/logicrunner/currentexecution.go
+++ b/logicrunner/currentexecution.go
@@ -40,7 +40,6 @@ type Transcript struct {
 	LogicContext     *insolar.LogicCallContext
 	Request          *record.IncomingRequest
 	RequestRef       insolar.Reference
-	RequesterNode    *insolar.Reference
 	Nonce            uint64
 	Deactivate       bool
 	OutgoingRequests []OutgoingRequest

--- a/logicrunner/requestsexecutor_test.go
+++ b/logicrunner/requestsexecutor_test.go
@@ -326,7 +326,6 @@ func TestRequestsExecutor_SendReply(t *testing.T) {
 	defer mc.Wait(time.Minute)
 
 	requestRef := gen.Reference()
-	nodeRef := gen.Reference()
 
 	reqRef := testutils.RandomRef()
 
@@ -340,7 +339,6 @@ func TestRequestsExecutor_SendReply(t *testing.T) {
 		{
 			name: "success",
 			transcript: &Transcript{
-				RequesterNode: &nodeRef,
 				RequestRef: reqRef,
 				Request:    &record.IncomingRequest{},
 			},
@@ -356,7 +354,6 @@ func TestRequestsExecutor_SendReply(t *testing.T) {
 		{
 			name: "error",
 			transcript: &Transcript{
-				RequesterNode: &nodeRef,
 				RequestRef: reqRef,
 				Request:    &record.IncomingRequest{},
 			},


### PR DESCRIPTION
RequesterNode is not used anymore, we use fields from the request

it was a duplication
