### PR TITLE
INS-3011 suite.Require isn't tread safe

### DIFF
--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -381,18 +381,18 @@ func (suite *LogicRunnerTestSuite) TestConcurrency() {
 				Pulse:   pulseNum,
 			}
 			buf, err := wrapper.Marshal()
-			suite.Require().NoError(err)
+			require.NoError(syncT, err)
 
 			wmMsg := message2.NewMessage(watermill.NewUUID(), buf)
 			wmMsg.Metadata.Set(bus.MetaPulse, pulseNum.String())
 			sp, err := instracer.Serialize(context.Background())
-			suite.Require().NoError(err)
+			require.NoError(syncT, err)
 			wmMsg.Metadata.Set(bus.MetaSpanData, string(sp))
 			wmMsg.Metadata.Set(bus.MetaType, fmt.Sprintf("%s", msg.Type()))
 			wmMsg.Metadata.Set(bus.MetaTraceID, "req-"+strconv.Itoa(i))
 
 			_, err = suite.lr.FlowDispatcher.Process(wmMsg)
-			suite.Require().NoError(err)
+			require.NoError(syncT, err)
 		}(i)
 	}
 


### PR DESCRIPTION
**- What I did**
fix race in test code
**- How I did it**
use syncT.Require instead of suite.Require
