### PR TITLE
INS-3141: one retry on flow cancelled

### DIFF
--- a/insolar/bus/retryer.go
+++ b/insolar/bus/retryer.go
@@ -34,15 +34,15 @@ import (
 type RetrySender struct {
 	sender        Sender
 	pulseAccessor pulse.Accessor
-	tries         uint
+	retries       int
 }
 
 // NewRetrySender creates RetrySender instance with provided values.
-func NewRetrySender(sender Sender, pulseAccessor pulse.Accessor, tries uint) *RetrySender {
+func NewRetrySender(sender Sender, pulseAccessor pulse.Accessor, retries int) *RetrySender {
 	r := &RetrySender{
 		sender:        sender,
 		pulseAccessor: pulseAccessor,
-		tries:         tries,
+		retries:       retries,
 	}
 	return r
 }
@@ -62,7 +62,7 @@ func (r *RetrySender) Reply(ctx context.Context, origin payload.Meta, reply *mes
 func (r *RetrySender) SendRole(
 	ctx context.Context, msg *message.Message, role insolar.DynamicRole, ref insolar.Reference,
 ) (<-chan *message.Message, func()) {
-	tries := r.tries
+	retries := r.retries
 	once := sync.Once{}
 	done := make(chan struct{})
 	replyChan := make(chan *message.Message)
@@ -79,7 +79,7 @@ func (r *RetrySender) SendRole(
 		}
 
 		received := false
-		for tries > 0 && !received {
+		for retries >= 0 && !received {
 			var err error
 			lastPulse, err = r.waitForPulseChange(ctx, lastPulse)
 			if err != nil {
@@ -89,11 +89,11 @@ func (r *RetrySender) SendRole(
 
 			reps, d := r.sender.SendRole(ctx, msg, role, ref)
 			received = tryReceive(ctx, reps, done, replyChan)
-			tries--
+			retries--
 			d()
 		}
 
-		if tries == 0 && !received {
+		if retries < 0 && !received {
 			logger.Error(errors.Errorf("flow cancelled, retries exceeded"))
 		}
 	}()

--- a/insolar/bus/waiter.go
+++ b/insolar/bus/waiter.go
@@ -36,7 +36,7 @@ type WaitOKSender struct {
 }
 
 // NewWaitOKWithRetrySender creates WaitOKSender instance with RetrySender as Sender.
-func NewWaitOKWithRetrySender(sender Sender, pulseAccessor pulse.Accessor, retries int) *WaitOKSender {
+func NewWaitOKWithRetrySender(sender Sender, pulseAccessor pulse.Accessor, retries uint) *WaitOKSender {
 	r := NewRetrySender(sender, pulseAccessor, retries)
 	c := NewWaitOKSender(r)
 	return c

--- a/insolar/bus/waiter.go
+++ b/insolar/bus/waiter.go
@@ -19,6 +19,7 @@ package bus
 import (
 	"bytes"
 	"context"
+
 	"github.com/insolar/insolar/insolar/pulse"
 
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -35,8 +36,8 @@ type WaitOKSender struct {
 }
 
 // NewWaitOKWithRetrySender creates WaitOKSender instance with RetrySender as Sender.
-func NewWaitOKWithRetrySender(sender Sender, pulseAccessor pulse.Accessor, tries uint) *WaitOKSender {
-	r := NewRetrySender(sender, pulseAccessor, tries)
+func NewWaitOKWithRetrySender(sender Sender, pulseAccessor pulse.Accessor, retries int) *WaitOKSender {
+	r := NewRetrySender(sender, pulseAccessor, retries)
 	c := NewWaitOKSender(r)
 	return c
 }

--- a/insolar/bus/waiter_test.go
+++ b/insolar/bus/waiter_test.go
@@ -18,8 +18,9 @@ package bus
 
 import (
 	"context"
-	"github.com/insolar/insolar/insolar/pulse"
 	"testing"
+
+	"github.com/insolar/insolar/insolar/pulse"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/insolar/insolar/insolar"
@@ -42,15 +43,15 @@ func TestWaitOKSender_SendRole_RetryExceeded(t *testing.T) {
 	msg, err := payload.NewMessage(&payload.State{})
 	require.NoError(t, err)
 
-	tries := 3
+	retries := 3
 
 	pa := pulse.NewAccessorMock(t)
 	pa.LatestMock.Set(accessorMock(t).Latest)
-	c := NewWaitOKWithRetrySender(sender, pa, uint(tries))
+	c := NewWaitOKWithRetrySender(sender, pa, retries)
 
 	c.SendRole(context.Background(), msg, insolar.DynamicRoleLightExecutor, testutils.RandomRef())
 
-	require.EqualValues(t, tries, sender.SendRoleAfterCounter())
+	require.EqualValues(t, retries+1, sender.SendRoleAfterCounter())
 }
 
 func sendOK(ch chan<- *message.Message) {

--- a/insolar/bus/waiter_test.go
+++ b/insolar/bus/waiter_test.go
@@ -43,7 +43,7 @@ func TestWaitOKSender_SendRole_RetryExceeded(t *testing.T) {
 	msg, err := payload.NewMessage(&payload.State{})
 	require.NoError(t, err)
 
-	retries := 3
+	retries := uint(3)
 
 	pa := pulse.NewAccessorMock(t)
 	pa.LatestMock.Set(accessorMock(t).Latest)

--- a/logicrunner/artifacts/client.go
+++ b/logicrunner/artifacts/client.go
@@ -174,7 +174,7 @@ func (m *client) RegisterIncomingRequest(ctx context.Context, request *record.In
 func (m *client) RegisterOutgoingRequest(ctx context.Context, request *record.OutgoingRequest) (*payload.RequestInfo, error) {
 	outgoingRequest := &payload.SetOutgoingRequest{Request: record.Wrap(request)}
 	res, err := m.registerRequest(
-		ctx, request, outgoingRequest, bus.NewRetrySender(m.sender, m.PulseAccessor, 3),
+		ctx, request, outgoingRequest, bus.NewRetrySender(m.sender, m.PulseAccessor, 1),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "RegisterOutgoingRequest")
@@ -211,7 +211,7 @@ func (m *client) GetCode(
 	getCodePl := &payload.GetCode{CodeID: *code.Record()}
 
 	pl, err := m.sendToLight(
-		ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 3), getCodePl, code,
+		ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1), getCodePl, code,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to send GetCode")
@@ -282,7 +282,7 @@ func (m *client) GetObject(
 		return nil, errors.Wrap(err, "failed to marshal message")
 	}
 
-	r := bus.NewRetrySender(m.sender, m.PulseAccessor, 3)
+	r := bus.NewRetrySender(m.sender, m.PulseAccessor, 1)
 	reps, done := r.SendRole(ctx, msg, insolar.DynamicRoleLightExecutor, head)
 	defer done()
 
@@ -534,7 +534,7 @@ func (m *client) DeployCode(
 	}
 
 	pl, err := m.sendToLight(
-		ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 3),
+		ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1),
 		psc, *insolar.NewReference(recID),
 	)
 	if err != nil {
@@ -630,7 +630,7 @@ func (m *client) activateObject(
 		Result: resultBuf,
 	}
 
-	pl, err := m.sendToLight(ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 3), pa, obj)
+	pl, err := m.sendToLight(ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1), pa, obj)
 	if err != nil {
 		return errors.Wrap(err, "can't send activation and result records")
 	}
@@ -670,7 +670,7 @@ func (m *client) RegisterResult(
 	) (*insolar.ID, error) {
 
 		payloadOutput, err := m.sendToLight(
-			ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 3), payloadInput, obj,
+			ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1), payloadInput, obj,
 		)
 		if err != nil {
 			return nil, err

--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -114,7 +114,7 @@ func (lr *LogicRunner) Init(ctx context.Context) error {
 		lr.OutgoingSender,
 	)
 
-	lr.SenderWithRetry = bus.NewWaitOKWithRetrySender(lr.Sender, lr.PulseAccessor, 3)
+	lr.SenderWithRetry = bus.NewWaitOKWithRetrySender(lr.Sender, lr.PulseAccessor, 1)
 
 	lr.rpc = lrCommon.NewRPC(
 		NewRPCMethods(lr.ArtifactManager, lr.DescriptorsCache, lr.ContractRequester, lr.StateStorage, lr.OutgoingSender),


### PR DESCRIPTION
**- What I did**
- Change `tries` field in `RetrySender` struct to `retries` - now max number of attempts to send request is 1+retries (one send+amount of retries).
- _flow cancelled_ error retries only one time

**- How to verify it**
Runs tests.
