### PR TITLE
INS-3122: get rid of testutils.Random<Whatever> functions

### DIFF
--- a/certificate/manager_test.go
+++ b/certificate/manager_test.go
@@ -17,14 +17,15 @@
 package certificate
 
 import (
-	"github.com/insolar/insolar/cryptography"
-	"github.com/insolar/insolar/insolar"
-	"github.com/insolar/insolar/platformpolicy"
-	"github.com/insolar/insolar/testutils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/insolar/insolar/cryptography"
+	"github.com/insolar/insolar/insolar"
+	"github.com/insolar/insolar/insolar/gen"
+	"github.com/insolar/insolar/platformpolicy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewManagerReadCertificate(t *testing.T) {
@@ -45,7 +46,7 @@ func newDiscovery() (*BootstrapNode, insolar.CryptographyService) {
 	cs := cryptography.NewKeyBoundCryptographyService(key)
 	pk, _ := cs.GetPublicKey()
 	pubKeyBuf, _ := kp.ExportPublicKeyPEM(pk)
-	ref := testutils.RandomRef().String()
+	ref := gen.Reference().String()
 	n := NewBootstrapNode(pk, string(pubKeyBuf), " ", ref, insolar.StaticRoleVirtual.String())
 	return n, cs
 }
@@ -62,7 +63,7 @@ func TestSignAndVerifyCertificate(t *testing.T) {
 
 	cert := &Certificate{}
 	cert.PublicKey = string(publicKey[:])
-	cert.Reference = testutils.RandomRef().String()
+	cert.Reference = gen.Reference().String()
 	cert.Role = insolar.StaticRoleHeavyMaterial.String()
 	cert.MinRoles.HeavyMaterial = 1
 	cert.MinRoles.Virtual = 4

--- a/insolar/jetcoordinator/jetcoordinator_test.go
+++ b/insolar/jetcoordinator/jetcoordinator_test.go
@@ -268,7 +268,7 @@ func TestJetCoordinator_NodeForJet_GoToHeavy(t *testing.T) {
 	generator := entropygenerator.StandardEntropyGenerator{}
 	pulseAccessor.LatestMock.Return(insolar.Pulse{PulseNumber: insolar.FirstPulseNumber, Entropy: generator.GenerateEntropy()}, nil)
 
-	expectedID := insolar.NewReference(testutils.RandomID())
+	expectedID := insolar.NewReference(gen.ID())
 	activeNodesStorageMock := node.NewAccessorMock(t)
 	activeNodesStorageMock.InRoleMock.Set(func(p insolar.PulseNumber, p1 insolar.StaticRole) (r []insolar.Node, r1 error) {
 		require.Equal(t, insolar.FirstPulseNumber, int(p))
@@ -302,7 +302,7 @@ func TestJetCoordinator_NodeForJet_GoToLight(t *testing.T) {
 	generator := entropygenerator.StandardEntropyGenerator{}
 	pulseAccessor.LatestMock.Return(insolar.Pulse{PulseNumber: insolar.PulseNumber(insolar.FirstPulseNumber + 1), Entropy: generator.GenerateEntropy()}, nil)
 
-	expectedID := insolar.NewReference(testutils.RandomID())
+	expectedID := insolar.NewReference(gen.ID())
 	activeNodesStorageMock := node.NewAccessorMock(t)
 	activeNodesStorageMock.InRoleMock.Set(func(p insolar.PulseNumber, p1 insolar.StaticRole) (r []insolar.Node, r1 error) {
 		require.Equal(t, insolar.FirstPulseNumber+1, int(p))

--- a/insolar/record_test.go
+++ b/insolar/record_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/gen"
-	"github.com/insolar/insolar/testutils"
 	base58 "github.com/jbenet/go-base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,7 +29,7 @@ import (
 //ID and Reference serialization tests
 
 func TestNewIDFromBytes(t *testing.T) {
-	id := testutils.RandomID()
+	id := gen.ID()
 	actualID := *insolar.NewIDFromBytes(id.Bytes())
 	require.Equal(t, id, actualID)
 
@@ -38,7 +37,7 @@ func TestNewIDFromBytes(t *testing.T) {
 }
 
 func TestNewIDFromBase58(t *testing.T) {
-	id := testutils.RandomID()
+	id := gen.ID()
 	idStr := base58.Encode(id[:])
 	id2, err := insolar.NewIDFromBase58(idStr)
 	require.NoError(t, err)
@@ -47,15 +46,15 @@ func TestNewIDFromBase58(t *testing.T) {
 }
 
 func TestRecordID_String(t *testing.T) {
-	id := testutils.RandomID()
+	id := gen.ID()
 	idStr := base58.Encode(id[:])
 
 	assert.Equal(t, idStr, id.String())
 }
 
 func TestNewRefFromBase58(t *testing.T) {
-	recordID := testutils.RandomID()
-	domainID := testutils.RandomID()
+	recordID := gen.ID()
+	domainID := gen.ID()
 	refStr := recordID.String() + insolar.RecordRefIDSeparator + domainID.String()
 
 	expectedRef := insolar.NewReference(recordID)

--- a/ledger/light/executor/jet_fetcher_test.go
+++ b/ledger/light/executor/jet_fetcher_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/instrumentation/inslogger"
-	"github.com/insolar/insolar/testutils"
 )
 
 func TestJetTreeUpdater_otherNodesForPulse(t *testing.T) {
@@ -155,7 +154,7 @@ func TestJetTreeUpdater_fetchActualJetFromOtherNodes(t *testing.T) {
 	}
 
 	t.Run("MB error on fetching actual jet", func(t *testing.T) {
-		target := testutils.RandomID()
+		target := gen.ID()
 		jtu := &fetcher{
 			Nodes:       initNodes(mc),
 			JetStorage:  js,
@@ -175,7 +174,7 @@ func TestJetTreeUpdater_fetchActualJetFromOtherNodes(t *testing.T) {
 	})
 
 	t.Run("MB got one not actual jet", func(t *testing.T) {
-		objectID := testutils.RandomID()
+		objectID := gen.ID()
 		jtu := &fetcher{
 			Nodes:       initNodes(mc),
 			JetStorage:  js,
@@ -211,7 +210,7 @@ func TestJetTreeUpdater_fetchActualJetFromOtherNodes(t *testing.T) {
 	})
 
 	t.Run("MB got one actual jet ( from light )", func(t *testing.T) {
-		objectID := testutils.RandomID()
+		objectID := gen.ID()
 		jtu := &fetcher{
 			Nodes:       initNodes(mc),
 			JetStorage:  js,
@@ -250,7 +249,7 @@ func TestJetTreeUpdater_fetchActualJetFromOtherNodes(t *testing.T) {
 
 	t.Run("MB got one actual jet ( from other light )", func(t *testing.T) {
 		ans := node.NewAccessorMock(mc)
-		objectID := testutils.RandomID()
+		objectID := gen.ID()
 		target := insolar.NewReference(objectID)
 		ans.InRoleMock.Expect(
 			100, insolar.StaticRoleLightMaterial,
@@ -318,7 +317,7 @@ func TestJetTreeUpdater_fetchJet(t *testing.T) {
 		sequencer:   map[seqKey]*seqEntry{},
 	}
 
-	target := testutils.RandomID()
+	target := gen.ID()
 
 	t.Run("quick reply, data is up to date", func(t *testing.T) {
 		fjmr := *insolar.NewJetID(0, nil)

--- a/ledger/object/index_db_test.go
+++ b/ledger/object/index_db_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/insolar/insolar/insolar/record"
 	"github.com/insolar/insolar/insolar/store"
 	"github.com/insolar/insolar/instrumentation/inslogger"
-	"github.com/insolar/insolar/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,7 +37,7 @@ func TestIndexKey(t *testing.T) {
 	t.Parallel()
 
 	testPulseNumber := insolar.GenesisPulse.PulseNumber
-	expectedKey := indexKey{objID: testutils.RandomID(), pn: testPulseNumber}
+	expectedKey := indexKey{objID: gen.ID(), pn: testPulseNumber}
 
 	rawID := expectedKey.ID()
 

--- a/ledger/object/record_test.go
+++ b/ledger/object/record_test.go
@@ -39,7 +39,7 @@ import (
 func TestRecordKey(t *testing.T) {
 	t.Parallel()
 
-	expectedKey := recordKey(testutils.RandomID())
+	expectedKey := recordKey(gen.ID())
 
 	rawID := expectedKey.ID()
 

--- a/logicrunner/handle_abandonedrequestsnotification_test.go
+++ b/logicrunner/handle_abandonedrequestsnotification_test.go
@@ -7,7 +7,7 @@ import (
 func TestHandleAbandonedRequestsNotification_Present(t *testing.T) {
 	t.Skip("we disabled handling of this notification for now")
 
-	//objectId := testutils.RandomID()
+	//objectId := gen.ID()
 	//objectRef := *insolar.NewReference(objectId)
 	//msg := &message.AbandonedRequestsNotification{Object: objectId}
 	//parcel := &message.Parcel{Msg: msg}
@@ -72,4 +72,3 @@ func TestHandleAbandonedRequestsNotification_Present(t *testing.T) {
 	//suite.Equal(true, broker.ledgerHasMoreRequests)
 	//_ = suite.lr.Stop(suite.ctx)
 }
-

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -344,7 +344,7 @@ func (suite *LogicRunnerTestSuite) TestConcurrency() {
 	suite.am.HasPendingsMock.Return(false, nil)
 
 	suite.am.RegisterIncomingRequestMock.Set(func(ctx context.Context, r *record.IncomingRequest) (*payload.RequestInfo, error) {
-		reqId := testutils.RandomID()
+		reqId := gen.ID()
 		return &payload.RequestInfo{RequestID: reqId, ObjectID: *objectRef.Record()}, nil
 	})
 

--- a/testutils/core.go
+++ b/testutils/core.go
@@ -18,17 +18,13 @@ package testutils
 
 import (
 	"crypto"
-	"crypto/rand"
-	"fmt"
 	"hash"
-	"math/big"
 
 	"github.com/gojuno/minimock"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/crypto/sha3"
 
 	"github.com/insolar/insolar/insolar"
-	"github.com/insolar/insolar/insolar/bits"
 )
 
 // RandomString generates random uuid and return it as a string
@@ -38,73 +34,6 @@ func RandomString() string {
 		panic(err)
 	}
 	return newUUID.String()
-}
-
-// RandomRef generates random object reference
-// Deprecated: use gen.Reference()
-func RandomRef() insolar.Reference {
-	ref := [insolar.RecordRefSize]byte{}
-	_, err := rand.Read(ref[:insolar.RecordIDSize])
-	if err != nil {
-		panic(err)
-	}
-	return ref
-}
-
-// RandomID generates random object ID
-func RandomID() insolar.ID {
-	id := [insolar.RecordIDSize]byte{}
-	_, err := rand.Read(id[:])
-	if err != nil {
-		panic(err)
-	}
-	return id
-}
-
-// RandomJet generates random jet with random depth.
-// DEPRECATED: use gen.JetID
-func RandomJet() insolar.ID {
-	// don't be too huge (i.e. 255)
-	n, err := rand.Int(rand.Reader, big.NewInt(128))
-	if err != nil {
-		panic(err)
-	}
-
-	depth := uint8(n.Int64())
-	return RandomJetWithDepth(depth)
-}
-
-// RandomJetWithDepth generates random jet with provided depth.
-func RandomJetWithDepth(depth uint8) insolar.ID {
-	jetbuf := make([]byte, insolar.RecordHashSize)
-	_, err := rand.Read(jetbuf)
-	if err != nil {
-		panic(err)
-	}
-	return insolar.ID(*insolar.NewJetID(depth, bits.ResetBits(jetbuf[1:], depth)))
-}
-
-// JetFromString converts string representation of Jet to insolar.ID.
-//
-// Examples: "010" converts to Jet with depth 3 and prefix "01".
-func JetFromString(s string) insolar.ID {
-	jetPrefix := make([]byte, insolar.JetPrefixSize)
-	depth := uint8(len(s))
-	for i, char := range s {
-		byteOffset := i / 8
-		bitsOffset := 7 - uint(i%8)
-		switch char {
-		case '0':
-		case '1':
-			add := uint8(1 << bitsOffset)
-			jetPrefix[byteOffset] += add
-		default:
-			panic(fmt.Errorf(
-				"%v character is non 0 or 1, but %v (input string='%v')", i, char, s))
-		}
-	}
-	return insolar.ID(*insolar.NewJetID(depth, jetPrefix))
-
 }
 
 type cryptographySchemeMock struct{}


### PR DESCRIPTION
**- What I did**
Removed testutils.Random<Whatever> functions and replaced their usages with gen.* alternatives.