### PR TITLE
INS-3237: added new option for RetrySender (number of messages to wait)

### DIFF
--- a/insolar/bus/retryer.go
+++ b/insolar/bus/retryer.go
@@ -21,13 +21,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/insolar/insolar/insolar/pulse"
-
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/pkg/errors"
+
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/payload"
+	"github.com/insolar/insolar/insolar/pulse"
 	"github.com/insolar/insolar/instrumentation/inslogger"
-	"github.com/pkg/errors"
 )
 
 // RetrySender allows to send messaged via provided Sender with retries.
@@ -35,16 +35,17 @@ type RetrySender struct {
 	sender        Sender
 	pulseAccessor pulse.Accessor
 	retries       uint
+	responseCount uint
 }
 
 // NewRetrySender creates RetrySender instance with provided values.
-func NewRetrySender(sender Sender, pulseAccessor pulse.Accessor, retries uint) *RetrySender {
-	r := &RetrySender{
+func NewRetrySender(sender Sender, pulseAccessor pulse.Accessor, retries uint, responseCount uint) *RetrySender {
+	return &RetrySender{
 		sender:        sender,
 		pulseAccessor: pulseAccessor,
 		retries:       retries,
+		responseCount: responseCount,
 	}
-	return r
 }
 
 func (r *RetrySender) SendTarget(ctx context.Context, msg *message.Message, target insolar.Reference) (<-chan *message.Message, func()) {
@@ -72,12 +73,6 @@ func (r *RetrySender) SendRole(
 		logger := inslogger.FromContext(ctx)
 		var lastPulse insolar.PulseNumber
 
-		select {
-		case <-done:
-			return
-		default:
-		}
-
 		received := false
 		for tries > 0 && !received {
 			var err error
@@ -88,7 +83,7 @@ func (r *RetrySender) SendRole(
 			}
 
 			reps, d := r.sender.SendRole(ctx, msg, role, ref)
-			received = tryReceive(ctx, reps, done, replyChan)
+			received = tryReceive(ctx, reps, done, replyChan, r.responseCount)
 			tries--
 			d()
 		}
@@ -123,39 +118,64 @@ func (r *RetrySender) waitForPulseChange(ctx context.Context, lastPulse insolar.
 	}
 }
 
+type messageType int
+
+const (
+	messageTypeNotError messageType = iota
+	messageTypeErrorRetryable
+	messageTypeErrorNonRetryable
+)
+
 // tryReceive returns false if we get retryable error,
 // and true if reply was successfully received or client don't want anymore replies
-func tryReceive(ctx context.Context, reps <-chan *message.Message, done chan struct{}, receiver chan<- *message.Message) bool {
-	for {
+func tryReceive(
+	ctx context.Context,
+	reps <-chan *message.Message,
+	done chan struct{},
+	receiver chan<- *message.Message,
+	responseCount uint,
+) bool {
+	for i := uint(0); i < responseCount; i++ {
+		rep, ok := <-reps
+		if !ok {
+			return true
+		}
+
+		var leave bool
+		switch getErrorType(ctx, rep) {
+		case messageTypeErrorRetryable:
+			return false
+		case messageTypeErrorNonRetryable:
+			leave = true
+		default:
+		}
+
 		select {
 		case <-done:
-			return true
-		case rep, ok := <-reps:
-			if !ok {
-				return true
-			}
-			if isRetryableError(ctx, rep) {
-				return false
-			}
-
-			select {
-			case <-done:
-				return true
-			case receiver <- rep:
-			}
+		case receiver <- rep:
+		}
+		if leave {
+			break
 		}
 	}
+
+	return true
 }
 
-func isRetryableError(ctx context.Context, rep *message.Message) bool {
+func getErrorType(ctx context.Context, rep *message.Message) messageType {
 	replyPayload, err := payload.UnmarshalFromMeta(rep.Payload)
 	if err != nil {
-		return false
+		return messageTypeNotError
 	}
+
 	p, ok := replyPayload.(*payload.Error)
-	if ok && (p.Code == payload.CodeFlowCanceled) {
-		inslogger.FromContext(ctx).Errorf("flow cancelled, retrying (error message - %s)", p.Text)
-		return true
+	if ok {
+		if p.Code == payload.CodeFlowCanceled {
+			inslogger.FromContext(ctx).Errorf("flow cancelled, retrying (error message - %s)", p.Text)
+			return messageTypeErrorRetryable
+		}
+
+		return messageTypeErrorNonRetryable
 	}
-	return false
+	return messageTypeNotError
 }

--- a/insolar/bus/waiter.go
+++ b/insolar/bus/waiter.go
@@ -37,7 +37,7 @@ type WaitOKSender struct {
 
 // NewWaitOKWithRetrySender creates WaitOKSender instance with RetrySender as Sender.
 func NewWaitOKWithRetrySender(sender Sender, pulseAccessor pulse.Accessor, retries uint) *WaitOKSender {
-	r := NewRetrySender(sender, pulseAccessor, retries)
+	r := NewRetrySender(sender, pulseAccessor, retries, 1)
 	c := NewWaitOKSender(r)
 	return c
 }

--- a/logicrunner/artifacts/client.go
+++ b/logicrunner/artifacts/client.go
@@ -174,7 +174,7 @@ func (m *client) RegisterIncomingRequest(ctx context.Context, request *record.In
 func (m *client) RegisterOutgoingRequest(ctx context.Context, request *record.OutgoingRequest) (*payload.RequestInfo, error) {
 	outgoingRequest := &payload.SetOutgoingRequest{Request: record.Wrap(request)}
 	res, err := m.registerRequest(
-		ctx, request, outgoingRequest, bus.NewRetrySender(m.sender, m.PulseAccessor, 1),
+		ctx, request, outgoingRequest, bus.NewRetrySender(m.sender, m.PulseAccessor, 1, 1),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "RegisterOutgoingRequest")
@@ -211,7 +211,7 @@ func (m *client) GetCode(
 	getCodePl := &payload.GetCode{CodeID: *code.Record()}
 
 	pl, err := m.sendToLight(
-		ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1), getCodePl, code,
+		ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1, 1), getCodePl, code,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to send GetCode")
@@ -282,7 +282,7 @@ func (m *client) GetObject(
 		return nil, errors.Wrap(err, "failed to marshal message")
 	}
 
-	r := bus.NewRetrySender(m.sender, m.PulseAccessor, 1)
+	r := bus.NewRetrySender(m.sender, m.PulseAccessor, 1, 2)
 	reps, done := r.SendRole(ctx, msg, insolar.DynamicRoleLightExecutor, head)
 	defer done()
 
@@ -534,7 +534,7 @@ func (m *client) DeployCode(
 	}
 
 	pl, err := m.sendToLight(
-		ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1),
+		ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1, 1),
 		psc, *insolar.NewReference(recID),
 	)
 	if err != nil {
@@ -630,7 +630,7 @@ func (m *client) activateObject(
 		Result: resultBuf,
 	}
 
-	pl, err := m.sendToLight(ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1), pa, obj)
+	pl, err := m.sendToLight(ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1, 1), pa, obj)
 	if err != nil {
 		return errors.Wrap(err, "can't send activation and result records")
 	}
@@ -670,7 +670,7 @@ func (m *client) RegisterResult(
 	) (*insolar.ID, error) {
 
 		payloadOutput, err := m.sendToLight(
-			ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1), payloadInput, obj,
+			ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1, 1), payloadInput, obj,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
- it'll allow us to eliminate WaitOKSender/WaitOKWithRetrySender
- removed premature `done()` check that'll lead to request won't be send
  at all

side-effect: if someone'll send us `payload.Error` - it'll be the last message in the queue