### PR TITLE
Use insolar prefix for all insolar servers invocations

### DIFF
--- a/server/internal/heavy/server.go
+++ b/server/internal/heavy/server.go
@@ -71,7 +71,6 @@ func (s *Server) Serve() {
 	}
 
 	cfg := &cfgHolder.Configuration
-	cfg.Metrics.Namespace = "insolard"
 
 	fmt.Println("Starts with configuration:\n", configuration.ToString(cfgHolder.Configuration))
 

--- a/server/internal/light/server.go
+++ b/server/internal/light/server.go
@@ -55,7 +55,6 @@ func (s *Server) Serve() {
 		log.Warn("failed to load configuration from file: ", err.Error())
 	}
 	cfg := &cfgHolder.Configuration
-	cfg.Metrics.Namespace = "insolard"
 
 	fmt.Println("Starts with configuration:\n", configuration.ToString(cfgHolder.Configuration))
 

--- a/server/internal/virtual/server.go
+++ b/server/internal/virtual/server.go
@@ -57,7 +57,6 @@ func (s *Server) Serve() {
 	}
 
 	cfg := &cfgHolder.Configuration
-	cfg.Metrics.Namespace = "insolard"
 
 	traceID := "main_" + utils.RandTraceID()
 	ctx, inslog := initLogger(context.Background(), cfg.Log, traceID)


### PR DESCRIPTION
because metrics should be service-wide, not process-wide and we already have
server type in collected metrics (added by Prometheus server)
