### PR TITLE
INS-3277: fix logging in jetkeeper: don't logError if lengthes are different

### DIFF
--- a/ledger/heavy/executor/jetkeeper.go
+++ b/ledger/heavy/executor/jetkeeper.go
@@ -359,25 +359,26 @@ func (jk *dbJetKeeper) getTopSyncJets() ([]insolar.JetID, error) {
 
 }
 
-func compareJets(what []insolar.JetID, actualJetsSet map[insolar.JetID]struct{}) error {
+func compareJets(ctx context.Context, what []insolar.JetID, actualJetsSet map[insolar.JetID]struct{}) (bool, error) {
 	if len(actualJetsSet) != len(what) {
 		if len(actualJetsSet) > len(what) {
-			return errors.New("num actual jets is more then topSyncJets." +
+			return false, errors.New("num actual jets is more then topSyncJets." +
 				" TopSyncJets: " + insolar.JetIDCollection(what).DebugString() +
 				". Actual: " + insolar.JetIDCollection(infoToList(actualJetsSet)).DebugString())
 		}
-		return errors.New("lengths are different")
+		inslogger.FromContext(ctx).Debug("actual and top sync pule jets are still different")
+		return false, nil
 	}
 
 	for _, expID := range what {
 		if _, ok := actualJetsSet[expID]; !ok {
-			return errors.New("jet sets are different. it's too bad. " +
+			return false, errors.New("jet sets are different. it's too bad. " +
 				". TopSyncJets: " + insolar.JetIDCollection(what).DebugString() +
 				". Actual: " + insolar.JetIDCollection(infoToList(actualJetsSet)).DebugString())
 		}
 	}
 
-	return nil
+	return true, nil
 }
 
 func (jk *dbJetKeeper) checkPulseConsistency(ctx context.Context, pulse insolar.PulseNumber, checkBackup bool) bool {
@@ -414,16 +415,22 @@ func (jk *dbJetKeeper) checkPulseConsistency(ctx context.Context, pulse insolar.
 	logger.Debug("topSyncJets: ", insolar.JetIDCollection(topSyncJets).DebugString(), "  |  ",
 		"actualJets: ", insolar.JetIDCollection(infoToList(actualJetsSet)).DebugString())
 
-	err = compareJets(topSyncJets, actualJetsSet)
+	areEqual, err := compareJets(ctx, topSyncJets, actualJetsSet)
 	if err != nil {
 		logger.Error("top sync jets and actual jets are different. Pulse: ", pulse, ". Err: ", err)
 		return false
 	}
+	if !areEqual {
+		return false
+	}
 
 	currentJetTree := jk.jetTrees.All(ctx, pulse)
-	err = compareJets(currentJetTree, actualJetsSet)
+	areEqual, err = compareJets(ctx, currentJetTree, actualJetsSet)
 	if err != nil {
 		logger.Error("current jet tree and actual jets are different. Pulse: ", pulse, ". Err: ", err)
+		return false
+	}
+	if !areEqual {
 		return false
 	}
 

--- a/ledger/heavy/executor/jetkeeper_test.go
+++ b/ledger/heavy/executor/jetkeeper_test.go
@@ -259,7 +259,13 @@ func TestDbJetKeeper_DifferentActualAndExpectedJets(t *testing.T) {
 
 	err = jetKeeper.AddDropConfirmation(ctx, testPulse, testJet, false)
 	require.NoError(t, err)
+
+	require.False(t, jetKeeper.HasAllJetConfirms(ctx, testPulse))
+
+	err = jetKeeper.AddBackupConfirmation(ctx, testPulse)
+	require.NoError(t, err)
 	require.Equal(t, insolar.GenesisPulse.PulseNumber, jetKeeper.TopSyncPulse())
+	require.False(t, jetKeeper.HasAllJetConfirms(ctx, testPulse))
 }
 
 func TestDbJetKeeper_DifferentNumberOfActualAndExpectedJets(t *testing.T) {
@@ -277,14 +283,21 @@ func TestDbJetKeeper_DifferentNumberOfActualAndExpectedJets(t *testing.T) {
 	err := jets.Update(ctx, testPulse, true, testJet)
 	require.NoError(t, err)
 
-	err = jetKeeper.AddHotConfirmation(ctx, testPulse, left, true)
+	err = jetKeeper.AddHotConfirmation(ctx, testPulse, left, false)
 	require.NoError(t, err)
 
-	err = jetKeeper.AddHotConfirmation(ctx, testPulse, right, true)
+	err = jetKeeper.AddHotConfirmation(ctx, testPulse, right, false)
 	require.NoError(t, err)
 
-	err = jetKeeper.AddDropConfirmation(ctx, testPulse, testJet, true)
+	err = jetKeeper.AddDropConfirmation(ctx, testPulse, right, false)
 	require.NoError(t, err)
+
+	err = jetKeeper.AddDropConfirmation(ctx, testPulse, left, false)
+	require.NoError(t, err)
+
+	err = jetKeeper.AddBackupConfirmation(ctx, testPulse)
+	require.NoError(t, err)
+
 	require.Equal(t, insolar.GenesisPulse.PulseNumber, jetKeeper.TopSyncPulse())
 }
 


### PR DESCRIPTION
…ferent: it's ok situation

<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Don't do error logging in case of different length of topSync jets and incoming jets, since it's possible situation when not all jets still come.

**- How I did it**

**- How to verify it**
Run tests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
