### PR TITLE
INS-3219: changes in results matcher

### DIFF
--- a/logicrunner/pulsemanager/pulsemanager.go
+++ b/logicrunner/pulsemanager/pulsemanager.go
@@ -148,7 +148,7 @@ func (m *PulseManager) setUnderGilSection(ctx context.Context, newPulse insolar.
 	// We must clear resultsMatcher before any ReturnResults or StillExecution messages for new pulse will be received
 	// StillExecution messages use Dispatcher for processing, so we must do Dispatcher.BeginPulse AFTER clear
 	// ReturnResults messages use MessageBus for processing, which use GIL for stopping messages. So we must do unlock GIL AFTER clear
-	m.resultsMatcher.Clear()
+	m.resultsMatcher.Clear(ctx)
 
 	return &storagePulse, nil
 }

--- a/logicrunner/result_matcher.go
+++ b/logicrunner/result_matcher.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"sync"
 
+	"github.com/pkg/errors"
+
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/flow"
 	"github.com/insolar/insolar/insolar/message"
@@ -27,7 +29,6 @@ import (
 	"github.com/insolar/insolar/insolar/utils"
 	"github.com/insolar/insolar/instrumentation/inslogger"
 	"github.com/insolar/insolar/messagebus"
-	"github.com/pkg/errors"
 )
 
 //go:generate minimock -i github.com/insolar/insolar/logicrunner.ResultMatcher -o ./ -s _mock.go -g
@@ -35,7 +36,7 @@ import (
 type ResultMatcher interface {
 	AddStillExecution(ctx context.Context, msg *payload.StillExecuting)
 	AddUnwantedResponse(ctx context.Context, msg *message.ReturnResults) error
-	Clear()
+	Clear(ctx context.Context)
 }
 
 type resultWithTraceID struct {
@@ -59,17 +60,21 @@ func newResultsMatcher(lr *LogicRunner) *resultsMatcher {
 	}
 }
 
-func (rm *resultsMatcher) send(ctx context.Context, msg insolar.Message, receiver *insolar.Reference) {
+func (rm *resultsMatcher) send(ctx context.Context, msg *message.ReturnResults, receiver insolar.Reference) {
+	logger := inslogger.FromContext(ctx)
+
+	logger.Debug("resending result of request ", msg.RequestRef.String(), " to ", receiver.String())
+
 	sender := messagebus.BuildSender(
 		rm.lr.MessageBus.Send,
 		messagebus.RetryIncorrectPulse(rm.lr.PulseAccessor),
 		messagebus.RetryFlowCancelled(rm.lr.PulseAccessor),
 	)
 	_, err := sender(ctx, msg, &insolar.MessageSendOptions{
-		Receiver: receiver,
+		Receiver: &receiver,
 	})
 	if err != nil {
-		inslogger.FromContext(ctx).Warn(errors.Wrap(err, "[ resultsMatcher::send ] Couldn't resend response"))
+		logger.Error(errors.Wrap(err, "couldn't resend response"))
 	}
 }
 
@@ -77,11 +82,13 @@ func (rm *resultsMatcher) AddStillExecution(ctx context.Context, msg *payload.St
 	rm.lock.Lock()
 	defer rm.lock.Unlock()
 
+	inslogger.FromContext(ctx).Debug("got pendings confirmation")
+
 	for _, reqRef := range msg.RequestRefs {
 		if response, ok := rm.unwantedResponses[reqRef]; ok {
 			ctx = inslogger.ContextWithTrace(ctx, response.traceID)
-			inslogger.FromContext(ctx).Debug("[ resultsMatcher::AddStillExecution ] resend unwanted response ", reqRef)
-			go rm.send(ctx, &response.result, &msg.Executor)
+			go rm.send(ctx, &response.result, msg.Executor)
+			delete(rm.unwantedResponses, reqRef)
 		}
 		rm.executionNodes[reqRef] = msg.Executor
 	}
@@ -90,17 +97,17 @@ func (rm *resultsMatcher) AddStillExecution(ctx context.Context, msg *payload.St
 func (rm *resultsMatcher) AddUnwantedResponse(ctx context.Context, msg *message.ReturnResults) error {
 	rm.lock.Lock()
 	defer rm.lock.Unlock()
-	object := *msg.Target.Record()
 
+	object := *msg.Target.Record()
 	err := rm.isStillExecutor(ctx, object)
 	if err != nil {
 		return err
 	}
 
+	inslogger.FromContext(ctx).Debug("got unwanted response to request ", msg.RequestRef.String())
+
 	if node, ok := rm.executionNodes[msg.Reason]; ok {
-		inslogger.FromContext(ctx).Debug("[ resultsMatcher::AddUnwantedResponse ] resend unwanted response ", msg.Reason)
-		go rm.send(ctx, msg, &node)
-		delete(rm.unwantedResponses, msg.Reason)
+		go rm.send(ctx, msg, node)
 		return nil
 	}
 	rm.unwantedResponses[msg.Reason] = resultWithTraceID{utils.TraceID(ctx), *msg}
@@ -124,9 +131,15 @@ func (rm *resultsMatcher) isStillExecutor(ctx context.Context, object insolar.ID
 	return nil
 }
 
-func (rm *resultsMatcher) Clear() {
+func (rm *resultsMatcher) Clear(ctx context.Context) {
 	rm.lock.Lock()
 	defer rm.lock.Unlock()
+
 	rm.executionNodes = make(map[insolar.Reference]insolar.Reference)
+
+	logger := inslogger.FromContext(ctx)
+	for reqRef := range rm.unwantedResponses {
+		logger.Warn("not claimed response to request ", reqRef.String(), ", not confirmed pending?")
+	}
 	rm.unwantedResponses = make(map[insolar.Reference]resultWithTraceID)
 }


### PR DESCRIPTION
* delete(rm.unwantedResponses, reqRef) in correct place when
  recieved still executing message, not when we recieved unwanted
  results
* improve logging
* log all not matched unwanted results, this means still executing
  didn't come during the pulse
* use less pointers