### PR TITLE
INS-3219: when execution returns to node executing pending

### DIFF
--- a/logicrunner/executionbroker.go
+++ b/logicrunner/executionbroker.go
@@ -450,9 +450,6 @@ func (q *ExecutionBroker) PrevExecutorPendingResult(ctx context.Context, prevExe
 	case insolar.InPending:
 		if q.isActive() {
 			logger.Debug("execution returned to node that is still executing pending")
-
-			q.pending = insolar.NotPending
-			q.PendingConfirmed = false
 		} else if prevExecState == insolar.NotPending {
 			logger.Debug("executor we came to thinks that execution pending, but previous said to continue")
 


### PR DESCRIPTION
old code was not accounting existing of registry and that broker
is new every pulse.

new reality is that object is in pending even if pending execution
is on this node

old code was starting second mutable execution on the same node
and if it was the same request then context on outgoing calls was
shared resulting in different Nonce values and creating new
requests.