### PR TITLE
INS-3308: fix hasher for request checker

### DIFF
--- a/ledger/light/integration/server_test.go
+++ b/ledger/light/integration/server_test.go
@@ -242,7 +242,7 @@ func NewServer(
 			filamentCalculator,
 			Coordinator,
 			jetFetcher,
-			CryptoScheme.ReferenceHasher(),
+			CryptoScheme,
 			ServerBus,
 		)
 

--- a/server/internal/light/components.go
+++ b/server/internal/light/components.go
@@ -250,7 +250,7 @@ func newComponents(ctx context.Context, cfg configuration.Configuration) (*compo
 			filamentCalculator,
 			Coordinator,
 			jetFetcher,
-			CryptoScheme.ReferenceHasher(),
+			CryptoScheme,
 			Sender,
 		)
 


### PR DESCRIPTION
**- What I did**
Fix hasher for request checker

**- How I did it**
Change arguments for singleton constructor of request checker - from `hash.Hasher` to `Insolar.PlatformCryptographyScheme` (because we need new `hasher` every time when we use id calculation)
