### PR TITLE
Ins 3295 additional checks for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ test_func: functest ## alias for functest
 
 .PHONY: test_slow
 test_slow: ## run tests with slowtest tag
-	CGO_ENABLED=1 go test $(TEST_ARGS) -tags slowtest ./logicrunner/... ./server/internal/...
+	CGO_ENABLED=1 go test $(TEST_ARGS) -tags slowtest ./logicrunner/... ./server/internal/... ./ledger/light/integration
 
 .PHONY: test
 test: test_unit ## alias for test_unit

--- a/ledger/light/integration/abandoned_notification_test.go
+++ b/ledger/light/integration/abandoned_notification_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+// +build slowtest
 
 package integration_test
 

--- a/ledger/light/integration/jet_split_test.go
+++ b/ledger/light/integration/jet_split_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+// +build slowtest
 
 package integration_test
 

--- a/ledger/light/integration/light_replication_test.go
+++ b/ledger/light/integration/light_replication_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+// +build slowtest
 
 package integration_test
 

--- a/ledger/light/integration/light_test.go
+++ b/ledger/light/integration/light_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+// +build slowtest
 
 package integration_test
 

--- a/ledger/light/integration/light_test.go
+++ b/ledger/light/integration/light_test.go
@@ -51,8 +51,6 @@ func Test_BootstrapCalls(t *testing.T) {
 
 	// First pulse goes in storage then interrupts.
 	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
-	s.SetPulse(ctx)
 
 	t.Run("messages after two pulses return result", func(t *testing.T) {
 		p, _ := CallSetCode(ctx, s)
@@ -70,8 +68,6 @@ func Test_BasicOperations(t *testing.T) {
 	defer s.Stop()
 
 	// First pulse goes in storage then interrupts.
-	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
 	s.SetPulse(ctx)
 
 	runner := func(t *testing.T) {

--- a/ledger/light/integration/operations_test.go
+++ b/ledger/light/integration/operations_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+// +build slowtest
 
 package integration_test
 

--- a/ledger/light/integration/operations_test.go
+++ b/ledger/light/integration/operations_test.go
@@ -75,10 +75,6 @@ func CallGetCode(ctx context.Context, s *Server, id insolar.ID) payload.Payload 
 	return nil
 }
 
-// func MakeSetIncomingRequestFromAPI(objectID, reasonID insolar.ID, isCreation bool) (payload.SetIncomingRequest, record.Virtual) {
-// 	return MakeSetIncomingRequest(objectID, reasonID, insolar.ID{}, isCreation, true)
-// }
-
 func MakeSetIncomingRequest(objectID, reasonID insolar.ID, reasonObjectID insolar.ID, isCreation, isAPI bool) (payload.SetIncomingRequest, record.Virtual) {
 	args := make([]byte, 100)
 	_, err := rand.Read(args)

--- a/ledger/light/integration/operations_test.go
+++ b/ledger/light/integration/operations_test.go
@@ -75,7 +75,13 @@ func CallGetCode(ctx context.Context, s *Server, id insolar.ID) payload.Payload 
 	return nil
 }
 
-func MakeSetIncomingRequest(objectID, reasonID insolar.ID, reasonObjectID insolar.ID, isCreation, isAPI bool) (payload.SetIncomingRequest, record.Virtual) {
+func MakeSetIncomingRequest(
+	objectID insolar.ID,
+	reasonID insolar.ID,
+	reasonObjectID insolar.ID,
+	isCreation bool,
+	isAPI bool,
+) (payload.SetIncomingRequest, record.Virtual) {
 	args := make([]byte, 100)
 	_, err := rand.Read(args)
 	panicIfErr(err)
@@ -95,6 +101,36 @@ func MakeSetIncomingRequest(objectID, reasonID insolar.ID, reasonObjectID insola
 		req.APINode = gen.Reference()
 	} else {
 		req.Caller = *insolar.NewReference(reasonObjectID)
+	}
+
+	rec := record.Wrap(&req)
+	pl := payload.SetIncomingRequest{
+		Request: rec,
+	}
+	return pl, rec
+}
+
+func MakeSetIncomingRequestDetached(
+	objectID insolar.ID,
+	reasonID insolar.ID,
+	reasonObjectID insolar.ID,
+	isCreation bool,
+) (payload.SetIncomingRequest, record.Virtual) {
+	args := make([]byte, 100)
+	_, err := rand.Read(args)
+	panicIfErr(err)
+
+	req := record.IncomingRequest{
+		Arguments:  args,
+		Reason:     *insolar.NewReference(reasonID),
+		ReturnMode: record.ReturnNoWait,
+		Caller:     *insolar.NewReference(reasonObjectID),
+	}
+
+	if isCreation {
+		req.CallType = record.CTSaveAsChild
+	} else {
+		req.Object = insolar.NewReference(objectID)
 	}
 
 	rec := record.Wrap(&req)

--- a/ledger/light/integration/requests_test.go
+++ b/ledger/light/integration/requests_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+// +build slowtest
 
 package integration_test
 

--- a/ledger/light/integration/requests_test.go
+++ b/ledger/light/integration/requests_test.go
@@ -44,8 +44,6 @@ func Test_IncomingRequest_Check(t *testing.T) {
 
 	// First pulse goes in storage then interrupts.
 	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
-	s.SetPulse(ctx)
 
 	t.Run("registered is older than reason returns error", func(t *testing.T) {
 		msg, _ := MakeSetIncomingRequest(gen.ID(), gen.IDWithPulse(s.Pulse()+1), insolar.ID{}, true, true)
@@ -130,8 +128,6 @@ func Test_IncomingRequest_Duplicate(t *testing.T) {
 	defer s.Stop()
 
 	// First pulse goes in storage then interrupts.
-	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
 	s.SetPulse(ctx)
 
 	t.Run("creation request duplicate found", func(t *testing.T) {
@@ -263,8 +259,6 @@ func Test_OutgoingRequest_Duplicate(t *testing.T) {
 
 	// First pulse goes in storage then interrupts.
 	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
-	s.SetPulse(ctx)
 
 	t.Run("method request duplicate found", func(t *testing.T) {
 		args := make([]byte, 100)
@@ -344,8 +338,6 @@ func Test_DetachedRequest_notification(t *testing.T) {
 
 	// First pulse goes in storage then interrupts.
 	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
-	s.SetPulse(ctx)
 
 	t.Run("detached notification sent on detached reason close", func(t *testing.T) {
 		msg, _ := MakeSetIncomingRequest(gen.ID(), gen.IDWithPulse(s.Pulse()), insolar.ID{}, true, true)
@@ -394,12 +386,9 @@ func Test_Result_Duplicate(t *testing.T) {
 
 	// First pulse goes in storage then interrupts.
 	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
-	s.SetPulse(ctx)
-
-	msg, _ := MakeSetIncomingRequest(gen.ID(), gen.IDWithPulse(s.Pulse()), insolar.ID{}, true, true)
 
 	// Set request.
+	msg, _ := MakeSetIncomingRequest(gen.ID(), gen.IDWithPulse(s.Pulse()), insolar.ID{}, true, true)
 	rep := SendMessage(ctx, s, &msg)
 	RequireNotError(rep)
 	require.Nil(t, rep.(*payload.RequestInfo).Request)
@@ -440,8 +429,6 @@ func Test_IncomingRequest_ClosedReason(t *testing.T) {
 	defer s.Stop()
 
 	// First pulse goes in storage then interrupts.
-	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
 	s.SetPulse(ctx)
 
 	var reasonID insolar.ID
@@ -490,8 +477,6 @@ func Test_OutgoingRequest_ClosedReason(t *testing.T) {
 
 	// First pulse goes in storage then interrupts.
 	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
-	s.SetPulse(ctx)
 
 	var reasonID insolar.ID
 
@@ -534,8 +519,6 @@ func Test_Requests_OutgoingReason(t *testing.T) {
 	defer s.Stop()
 
 	// First pulse goes in storage then interrupts.
-	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
 	s.SetPulse(ctx)
 
 	var rootID, reasonID insolar.ID
@@ -591,8 +574,6 @@ func Test_OutgoingRequests_DifferentObjects(t *testing.T) {
 
 	// First pulse goes in storage then interrupts.
 	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
-	s.SetPulse(ctx)
 
 	var rootID, rootID2 insolar.ID
 
@@ -633,8 +614,6 @@ func Test_OutgoingDetached_InPendings(t *testing.T) {
 	defer s.Stop()
 
 	// First pulse goes in storage then interrupts.
-	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
 	s.SetPulse(ctx)
 
 	var rootID, secondReqId insolar.ID
@@ -697,8 +676,6 @@ func Test_IncomingRequest_DifferentResults(t *testing.T) {
 	defer s.Stop()
 
 	// First pulse goes in storage then interrupts.
-	s.SetPulse(ctx)
-	// Second pulse goes in storage and starts processing, including pulse change in flow dispatcher.
 	s.SetPulse(ctx)
 
 	var reasonID insolar.ID

--- a/ledger/light/integration/server_test.go
+++ b/ledger/light/integration/server_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+// +build slowtest
 
 package integration_test
 

--- a/ledger/light/proc/set_result.go
+++ b/ledger/light/proc/set_result.go
@@ -247,7 +247,7 @@ func (p *SetResult) Proceed(ctx context.Context) error {
 	return nil
 }
 
-// EarliestPending checks if received result closes earliest request. If so, it should return new earliest request or
+// calcPending checks if received result closes earliest request. If so, it should return new earliest request or
 // nil if the last request was closed.
 func calcPending(opened []record.CompositeFilamentRecord, closedRequestID insolar.ID) (*insolar.PulseNumber, error) {
 	// If we don't have pending requests BEFORE we try to save result, something went wrong.
@@ -277,7 +277,7 @@ func calcPending(opened []record.CompositeFilamentRecord, closedRequestID insola
 	return &p, nil
 }
 
-// FindClosed looks for request that was closed by provided result. Returns error if not found.
+// findClosed looks for request that was closed by provided result. Returns error if not found.
 func findClosed(reqs []record.CompositeFilamentRecord, result record.Result) (record.CompositeFilamentRecord, error) {
 	for _, req := range reqs {
 		if req.RecordID == *result.Request.Record() {
@@ -296,7 +296,7 @@ func findClosed(reqs []record.CompositeFilamentRecord, result record.Result) (re
 		}
 }
 
-// NotifyDetached sends notifications about detached requests that are ready for execution.
+// notifyDetached sends notifications about detached requests that are ready for execution.
 func notifyDetached(
 	ctx context.Context,
 	sender bus.Sender,


### PR DESCRIPTION
**- What I did**
- Move `./ledger/light/integration/` tests to `slowtest`-tag
- Remove useless `Server.SetPulse` into tests initialisation (when if don't needed)
- Add new check for `request from another object with root object reason in detached mode when reason closed already.`

**- How to verify it**
`go test -tags slowtest ./ledger/light/integration/`

