### PR TITLE
cleanup results matcher

### DIFF
--- a/logicrunner/handle_still_executing.go
+++ b/logicrunner/handle_still_executing.go
@@ -51,7 +51,7 @@ func (h *HandleStillExecuting) Present(ctx context.Context, f flow.Flow) error {
 	}
 	defer done()
 
-	h.dep.ResultsMatcher.AddStillExecution(ctx, &message)
+	h.dep.ResultsMatcher.AddStillExecution(ctx, message)
 
 	broker := h.dep.StateStorage.UpsertExecutionState(message.ObjectRef)
 	broker.PrevExecutorStillExecuting(ctx)

--- a/logicrunner/logicrunner.go
+++ b/logicrunner/logicrunner.go
@@ -85,7 +85,6 @@ func NewLogicRunner(cfg *configuration.LogicRunner, publisher watermillMsg.Publi
 		Sender:    sender,
 	}
 
-	res.ResultsMatcher = newResultsMatcher(&res)
 	return &res, nil
 }
 
@@ -107,6 +106,7 @@ func (lr *LogicRunner) Init(ctx context.Context) error {
 		lr.OutgoingSender,
 		lr.ShutdownFlag,
 	)
+	lr.ResultsMatcher = newResultsMatcher(lr.Sender, lr.PulseAccessor)
 
 	lr.rpc = lrCommon.NewRPC(
 		NewRPCMethods(
@@ -320,5 +320,6 @@ func (lr *LogicRunner) AddUnwantedResponse(ctx context.Context, msg insolar.Payl
 	}
 	defer done()
 
-	return lr.ResultsMatcher.AddUnwantedResponse(ctx, m)
+	lr.ResultsMatcher.AddUnwantedResponse(ctx, *m)
+	return nil
 }

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -416,6 +416,8 @@ func TestLogicRunner_OnPulse(t *testing.T) {
 						isDone()
 					})
 
+				lr.ResultsMatcher = newResultsMatcher(lr.Sender, lr.PulseAccessor)
+
 				return lr
 			},
 		},
@@ -438,6 +440,8 @@ func TestLogicRunner_OnPulse(t *testing.T) {
 					func(ctx context.Context, isDone func() bool) {
 						isDone()
 					})
+
+				lr.ResultsMatcher = newResultsMatcher(lr.Sender, lr.PulseAccessor)
 
 				return lr
 			},
@@ -509,6 +513,8 @@ func TestLogicRunner_OnPulse_Order(t *testing.T) {
 			orderChan <- OrderFlagDone
 			isDone()
 		})
+
+	lr.ResultsMatcher = newResultsMatcher(lr.Sender, lr.PulseAccessor)
 
 	oldPulse := insolar.Pulse{PulseNumber: pulse.MinTimePulse}
 	newPulse := insolar.Pulse{PulseNumber: pulse.MinTimePulse + 1}

--- a/logicrunner/result_matcher_mock.go
+++ b/logicrunner/result_matcher_mock.go
@@ -16,14 +16,14 @@ import (
 type ResultMatcherMock struct {
 	t minimock.Tester
 
-	funcAddStillExecution          func(ctx context.Context, msg *payload.StillExecuting)
-	inspectFuncAddStillExecution   func(ctx context.Context, msg *payload.StillExecuting)
+	funcAddStillExecution          func(ctx context.Context, msg payload.StillExecuting)
+	inspectFuncAddStillExecution   func(ctx context.Context, msg payload.StillExecuting)
 	afterAddStillExecutionCounter  uint64
 	beforeAddStillExecutionCounter uint64
 	AddStillExecutionMock          mResultMatcherMockAddStillExecution
 
-	funcAddUnwantedResponse          func(ctx context.Context, msg *payload.ReturnResults) (err error)
-	inspectFuncAddUnwantedResponse   func(ctx context.Context, msg *payload.ReturnResults)
+	funcAddUnwantedResponse          func(ctx context.Context, msg payload.ReturnResults)
+	inspectFuncAddUnwantedResponse   func(ctx context.Context, msg payload.ReturnResults)
 	afterAddUnwantedResponseCounter  uint64
 	beforeAddUnwantedResponseCounter uint64
 	AddUnwantedResponseMock          mResultMatcherMockAddUnwantedResponse
@@ -74,11 +74,11 @@ type ResultMatcherMockAddStillExecutionExpectation struct {
 // ResultMatcherMockAddStillExecutionParams contains parameters of the ResultMatcher.AddStillExecution
 type ResultMatcherMockAddStillExecutionParams struct {
 	ctx context.Context
-	msg *payload.StillExecuting
+	msg payload.StillExecuting
 }
 
 // Expect sets up expected params for ResultMatcher.AddStillExecution
-func (mmAddStillExecution *mResultMatcherMockAddStillExecution) Expect(ctx context.Context, msg *payload.StillExecuting) *mResultMatcherMockAddStillExecution {
+func (mmAddStillExecution *mResultMatcherMockAddStillExecution) Expect(ctx context.Context, msg payload.StillExecuting) *mResultMatcherMockAddStillExecution {
 	if mmAddStillExecution.mock.funcAddStillExecution != nil {
 		mmAddStillExecution.mock.t.Fatalf("ResultMatcherMock.AddStillExecution mock is already set by Set")
 	}
@@ -98,7 +98,7 @@ func (mmAddStillExecution *mResultMatcherMockAddStillExecution) Expect(ctx conte
 }
 
 // Inspect accepts an inspector function that has same arguments as the ResultMatcher.AddStillExecution
-func (mmAddStillExecution *mResultMatcherMockAddStillExecution) Inspect(f func(ctx context.Context, msg *payload.StillExecuting)) *mResultMatcherMockAddStillExecution {
+func (mmAddStillExecution *mResultMatcherMockAddStillExecution) Inspect(f func(ctx context.Context, msg payload.StillExecuting)) *mResultMatcherMockAddStillExecution {
 	if mmAddStillExecution.mock.inspectFuncAddStillExecution != nil {
 		mmAddStillExecution.mock.t.Fatalf("Inspect function is already set for ResultMatcherMock.AddStillExecution")
 	}
@@ -122,7 +122,7 @@ func (mmAddStillExecution *mResultMatcherMockAddStillExecution) Return() *Result
 }
 
 //Set uses given function f to mock the ResultMatcher.AddStillExecution method
-func (mmAddStillExecution *mResultMatcherMockAddStillExecution) Set(f func(ctx context.Context, msg *payload.StillExecuting)) *ResultMatcherMock {
+func (mmAddStillExecution *mResultMatcherMockAddStillExecution) Set(f func(ctx context.Context, msg payload.StillExecuting)) *ResultMatcherMock {
 	if mmAddStillExecution.defaultExpectation != nil {
 		mmAddStillExecution.mock.t.Fatalf("Default expectation is already set for the ResultMatcher.AddStillExecution method")
 	}
@@ -136,7 +136,7 @@ func (mmAddStillExecution *mResultMatcherMockAddStillExecution) Set(f func(ctx c
 }
 
 // AddStillExecution implements ResultMatcher
-func (mmAddStillExecution *ResultMatcherMock) AddStillExecution(ctx context.Context, msg *payload.StillExecuting) {
+func (mmAddStillExecution *ResultMatcherMock) AddStillExecution(ctx context.Context, msg payload.StillExecuting) {
 	mm_atomic.AddUint64(&mmAddStillExecution.beforeAddStillExecutionCounter, 1)
 	defer mm_atomic.AddUint64(&mmAddStillExecution.afterAddStillExecutionCounter, 1)
 
@@ -253,25 +253,20 @@ type mResultMatcherMockAddUnwantedResponse struct {
 
 // ResultMatcherMockAddUnwantedResponseExpectation specifies expectation struct of the ResultMatcher.AddUnwantedResponse
 type ResultMatcherMockAddUnwantedResponseExpectation struct {
-	mock    *ResultMatcherMock
-	params  *ResultMatcherMockAddUnwantedResponseParams
-	results *ResultMatcherMockAddUnwantedResponseResults
+	mock   *ResultMatcherMock
+	params *ResultMatcherMockAddUnwantedResponseParams
+
 	Counter uint64
 }
 
 // ResultMatcherMockAddUnwantedResponseParams contains parameters of the ResultMatcher.AddUnwantedResponse
 type ResultMatcherMockAddUnwantedResponseParams struct {
 	ctx context.Context
-	msg *payload.ReturnResults
-}
-
-// ResultMatcherMockAddUnwantedResponseResults contains results of the ResultMatcher.AddUnwantedResponse
-type ResultMatcherMockAddUnwantedResponseResults struct {
-	err error
+	msg payload.ReturnResults
 }
 
 // Expect sets up expected params for ResultMatcher.AddUnwantedResponse
-func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) Expect(ctx context.Context, msg *payload.ReturnResults) *mResultMatcherMockAddUnwantedResponse {
+func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) Expect(ctx context.Context, msg payload.ReturnResults) *mResultMatcherMockAddUnwantedResponse {
 	if mmAddUnwantedResponse.mock.funcAddUnwantedResponse != nil {
 		mmAddUnwantedResponse.mock.t.Fatalf("ResultMatcherMock.AddUnwantedResponse mock is already set by Set")
 	}
@@ -291,7 +286,7 @@ func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) Expect(ctx c
 }
 
 // Inspect accepts an inspector function that has same arguments as the ResultMatcher.AddUnwantedResponse
-func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) Inspect(f func(ctx context.Context, msg *payload.ReturnResults)) *mResultMatcherMockAddUnwantedResponse {
+func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) Inspect(f func(ctx context.Context, msg payload.ReturnResults)) *mResultMatcherMockAddUnwantedResponse {
 	if mmAddUnwantedResponse.mock.inspectFuncAddUnwantedResponse != nil {
 		mmAddUnwantedResponse.mock.t.Fatalf("Inspect function is already set for ResultMatcherMock.AddUnwantedResponse")
 	}
@@ -302,7 +297,7 @@ func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) Inspect(f fu
 }
 
 // Return sets up results that will be returned by ResultMatcher.AddUnwantedResponse
-func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) Return(err error) *ResultMatcherMock {
+func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) Return() *ResultMatcherMock {
 	if mmAddUnwantedResponse.mock.funcAddUnwantedResponse != nil {
 		mmAddUnwantedResponse.mock.t.Fatalf("ResultMatcherMock.AddUnwantedResponse mock is already set by Set")
 	}
@@ -310,12 +305,12 @@ func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) Return(err e
 	if mmAddUnwantedResponse.defaultExpectation == nil {
 		mmAddUnwantedResponse.defaultExpectation = &ResultMatcherMockAddUnwantedResponseExpectation{mock: mmAddUnwantedResponse.mock}
 	}
-	mmAddUnwantedResponse.defaultExpectation.results = &ResultMatcherMockAddUnwantedResponseResults{err}
+
 	return mmAddUnwantedResponse.mock
 }
 
 //Set uses given function f to mock the ResultMatcher.AddUnwantedResponse method
-func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) Set(f func(ctx context.Context, msg *payload.ReturnResults) (err error)) *ResultMatcherMock {
+func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) Set(f func(ctx context.Context, msg payload.ReturnResults)) *ResultMatcherMock {
 	if mmAddUnwantedResponse.defaultExpectation != nil {
 		mmAddUnwantedResponse.mock.t.Fatalf("Default expectation is already set for the ResultMatcher.AddUnwantedResponse method")
 	}
@@ -328,29 +323,8 @@ func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) Set(f func(c
 	return mmAddUnwantedResponse.mock
 }
 
-// When sets expectation for the ResultMatcher.AddUnwantedResponse which will trigger the result defined by the following
-// Then helper
-func (mmAddUnwantedResponse *mResultMatcherMockAddUnwantedResponse) When(ctx context.Context, msg *payload.ReturnResults) *ResultMatcherMockAddUnwantedResponseExpectation {
-	if mmAddUnwantedResponse.mock.funcAddUnwantedResponse != nil {
-		mmAddUnwantedResponse.mock.t.Fatalf("ResultMatcherMock.AddUnwantedResponse mock is already set by Set")
-	}
-
-	expectation := &ResultMatcherMockAddUnwantedResponseExpectation{
-		mock:   mmAddUnwantedResponse.mock,
-		params: &ResultMatcherMockAddUnwantedResponseParams{ctx, msg},
-	}
-	mmAddUnwantedResponse.expectations = append(mmAddUnwantedResponse.expectations, expectation)
-	return expectation
-}
-
-// Then sets up ResultMatcher.AddUnwantedResponse return parameters for the expectation previously defined by the When method
-func (e *ResultMatcherMockAddUnwantedResponseExpectation) Then(err error) *ResultMatcherMock {
-	e.results = &ResultMatcherMockAddUnwantedResponseResults{err}
-	return e.mock
-}
-
 // AddUnwantedResponse implements ResultMatcher
-func (mmAddUnwantedResponse *ResultMatcherMock) AddUnwantedResponse(ctx context.Context, msg *payload.ReturnResults) (err error) {
+func (mmAddUnwantedResponse *ResultMatcherMock) AddUnwantedResponse(ctx context.Context, msg payload.ReturnResults) {
 	mm_atomic.AddUint64(&mmAddUnwantedResponse.beforeAddUnwantedResponseCounter, 1)
 	defer mm_atomic.AddUint64(&mmAddUnwantedResponse.afterAddUnwantedResponseCounter, 1)
 
@@ -368,7 +342,7 @@ func (mmAddUnwantedResponse *ResultMatcherMock) AddUnwantedResponse(ctx context.
 	for _, e := range mmAddUnwantedResponse.AddUnwantedResponseMock.expectations {
 		if minimock.Equal(e.params, params) {
 			mm_atomic.AddUint64(&e.Counter, 1)
-			return e.results.err
+			return
 		}
 	}
 
@@ -380,17 +354,15 @@ func (mmAddUnwantedResponse *ResultMatcherMock) AddUnwantedResponse(ctx context.
 			mmAddUnwantedResponse.t.Errorf("ResultMatcherMock.AddUnwantedResponse got unexpected parameters, want: %#v, got: %#v%s\n", *want, got, minimock.Diff(*want, got))
 		}
 
-		results := mmAddUnwantedResponse.AddUnwantedResponseMock.defaultExpectation.results
-		if results == nil {
-			mmAddUnwantedResponse.t.Fatal("No results are set for the ResultMatcherMock.AddUnwantedResponse")
-		}
-		return (*results).err
+		return
+
 	}
 	if mmAddUnwantedResponse.funcAddUnwantedResponse != nil {
-		return mmAddUnwantedResponse.funcAddUnwantedResponse(ctx, msg)
+		mmAddUnwantedResponse.funcAddUnwantedResponse(ctx, msg)
+		return
 	}
 	mmAddUnwantedResponse.t.Fatalf("Unexpected call to ResultMatcherMock.AddUnwantedResponse. %v %v", ctx, msg)
-	return
+
 }
 
 // AddUnwantedResponseAfterCounter returns a count of finished ResultMatcherMock.AddUnwantedResponse invocations

--- a/logicrunner/result_matcher_test.go
+++ b/logicrunner/result_matcher_test.go
@@ -1,0 +1,204 @@
+//
+// Copyright 2019 Insolar Technologies GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package logicrunner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/gojuno/minimock"
+
+	"github.com/insolar/insolar/insolar"
+	"github.com/insolar/insolar/insolar/bus"
+	"github.com/insolar/insolar/insolar/flow"
+	"github.com/insolar/insolar/insolar/gen"
+	"github.com/insolar/insolar/insolar/payload"
+	"github.com/insolar/insolar/insolar/pulse"
+	"github.com/insolar/insolar/instrumentation/inslogger"
+)
+
+func replyMessage(msg *message.Message) *message.Message {
+	replyMsg := payload.MustNewMessage(&payload.Error{Text: "test error", Code: payload.CodeUnknown})
+	meta := payload.Meta{
+		Payload: msg.Payload,
+	}
+	buf, _ := meta.Marshal()
+	replyMsg.Payload = buf
+	return replyMsg
+}
+
+func sendTargetHelper(
+	ctx context.Context, msg *message.Message, target insolar.Reference,
+) (<-chan *message.Message, func()) {
+	res := make(chan *message.Message)
+	go func() { res <- replyMessage(msg) }()
+	return res, func() { close(res) }
+}
+
+func TestResultsMatcher_AddStillExecution(t *testing.T) {
+	tests := []struct {
+		name  string
+		mocks func(ctx context.Context, t minimock.Tester) (ResultMatcher, payload.StillExecuting)
+	}{
+		{
+			name: "empty matcher",
+			mocks: func(ctx context.Context, t minimock.Tester) (ResultMatcher, payload.StillExecuting) {
+				rm := newResultsMatcher(nil, nil)
+				msg := payload.StillExecuting{}
+				return rm, msg
+			},
+		},
+		{
+			name: "match",
+			mocks: func(ctx context.Context, t minimock.Tester) (ResultMatcher, payload.StillExecuting) {
+				reqRef := gen.Reference()
+				nodeRef := gen.Reference()
+
+				pa := pulse.NewAccessorMock(t)
+				pa.LatestMock.Set(func(p context.Context) (insolar.Pulse, error) {
+					return insolar.Pulse{
+						PulseNumber: 1000,
+					}, nil
+				})
+
+				rm := newResultsMatcher(
+					bus.NewSenderMock(t).SendTargetMock.Set(sendTargetHelper), pa,
+				)
+
+				rm.AddUnwantedResponse(ctx, payload.ReturnResults{
+					Reason: reqRef,
+				})
+
+				msg := payload.StillExecuting{
+					Executor:    nodeRef,
+					RequestRefs: []insolar.Reference{reqRef},
+				}
+				return rm, msg
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := flow.TestContextWithPulse(inslogger.TestContext(t), gen.PulseNumber())
+			mc := minimock.NewController(t)
+
+			rm, msg := test.mocks(ctx, mc)
+			rm.AddStillExecution(ctx, msg)
+
+			mc.Wait(1 * time.Second)
+			mc.Finish()
+		})
+	}
+}
+
+func TestResultsMatcher_AddUnwantedResponse(t *testing.T) {
+	tests := []struct {
+		name  string
+		mocks func(ctx context.Context, t minimock.Tester) (ResultMatcher, payload.ReturnResults)
+		error bool
+	}{
+		{
+			name: "empty matcher",
+			mocks: func(ctx context.Context, t minimock.Tester) (ResultMatcher, payload.ReturnResults) {
+				rm := newResultsMatcher(nil, nil)
+				msg := payload.ReturnResults{}
+				return rm, msg
+			},
+		},
+		{
+			name: "match",
+			mocks: func(ctx context.Context, t minimock.Tester) (ResultMatcher, payload.ReturnResults) {
+				reqRef := gen.Reference()
+				nodeRef := gen.Reference()
+
+				pa := pulse.NewAccessorMock(t)
+				pa.LatestMock.Set(func(p context.Context) (insolar.Pulse, error) {
+					return insolar.Pulse{
+						PulseNumber: 1000,
+					}, nil
+				})
+
+				rm := newResultsMatcher(
+					bus.NewSenderMock(t).SendTargetMock.Set(sendTargetHelper), pa,
+				)
+
+				rm.AddStillExecution(ctx, payload.StillExecuting{
+					Executor:    nodeRef,
+					RequestRefs: []insolar.Reference{reqRef},
+				})
+				msg := payload.ReturnResults{
+					Reason: reqRef,
+				}
+				return rm, msg
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := flow.TestContextWithPulse(inslogger.TestContext(t), gen.PulseNumber())
+			mc := minimock.NewController(t)
+
+			rm, msg := test.mocks(ctx, mc)
+			rm.AddUnwantedResponse(ctx, msg)
+
+			mc.Wait(1 * time.Second)
+			mc.Finish()
+		})
+	}
+}
+
+func TestResultsMatcher_Clear(t *testing.T) {
+	tests := []struct {
+		name  string
+		mocks func(ctx context.Context, t minimock.Tester) ResultMatcher
+		error bool
+	}{
+		{
+			name: "success",
+			mocks: func(ctx context.Context, t minimock.Tester) ResultMatcher {
+				reqRef1 := gen.Reference()
+				reqRef2 := gen.Reference()
+
+				rm := newResultsMatcher(nil, nil)
+
+				rm.AddStillExecution(ctx, payload.StillExecuting{
+					RequestRefs: []insolar.Reference{reqRef1},
+				})
+
+				rm.AddUnwantedResponse(ctx, payload.ReturnResults{
+					Reason: reqRef2,
+				})
+
+				return rm
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := flow.TestContextWithPulse(inslogger.TestContext(t), gen.PulseNumber())
+			mc := minimock.NewController(t)
+
+			rm := test.mocks(ctx, mc)
+			rm.Clear(ctx)
+
+			mc.Wait(1 * time.Second)
+			mc.Finish()
+		})
+	}
+}


### PR DESCRIPTION
* don't inject whole LR into ResultsMatcher, just required comps
* use less pointers, more values
* method couldn't return error, change signature
* add tests