### PR TITLE
INS-3122: replace some ObjectReferences with RecordReferences

### DIFF
--- a/cmd/insgocc/insgocc.go
+++ b/cmd/insgocc/insgocc.go
@@ -350,7 +350,7 @@ func main() {
 				output := newOutputFlag("")
 				err := openDefaultProxyPath(output, insolar.MachineTypeBuiltin, contract.Parsed)
 				checkError(err)
-				reference := genesisrefs.GenerateFromContractID(preprocessor.PrototypeType, contract.Name, contract.Version)
+				reference := genesisrefs.GenerateProtoReferenceFromContractID(preprocessor.PrototypeType, contract.Name, contract.Version)
 				err = contract.Parsed.WriteProxy(reference.String(), output.writer)
 				checkError(err)
 

--- a/functest/register_parent_test.go
+++ b/functest/register_parent_test.go
@@ -79,7 +79,7 @@ func New() (*Two, error) {
 func NewWithOne(oneNumber int) (*Two, error) {
 	holder := one.NewWithNumber(oneNumber)
 
-	objOne, err := holder.AsChild(foundation.GetRequestReference())
+	objOne, err := holder.AsChild(foundation.GetRootDomain())
 
 	if err != nil {
 		return nil, err

--- a/functest/test_utils.go
+++ b/functest/test_utils.go
@@ -294,10 +294,9 @@ func signedRequest(t *testing.T, URL string, user *launchnet.User, method string
 	if err != nil {
 		errMsg = err.Error()
 	}
-	emptyRef := insolar.NewEmptyReference()
 
 	require.NotEqual(t, "", refStr, "request ref is empty: %s", errMsg)
-	require.NotEqual(t, emptyRef.String(), refStr, "request ref is zero: %s", errMsg)
+	require.NotEqual(t, insolar.NewEmptyReference().String(), refStr, "request ref is zero: %s", errMsg)
 
 	_, err = insolar.NewReferenceFromBase58(refStr)
 	require.Nil(t, err)
@@ -431,9 +430,7 @@ func uploadContract(t testing.TB, contractName string, contractCode string) *ins
 
 	prototypeRef, err := insolar.NewReferenceFromBase58(uploadRes.Result.PrototypeRef)
 	require.NoError(t, err)
-
-	emptyRef := make([]byte, insolar.RecordRefSize)
-	require.NotEqual(t, insolar.NewReferenceFromBytes(emptyRef), prototypeRef)
+	require.False(t, prototypeRef.IsEmpty())
 
 	return prototypeRef
 }

--- a/insolar/api/reason.go
+++ b/insolar/api/reason.go
@@ -7,5 +7,6 @@ import (
 
 func MakeReason(pulse insolar.PulseNumber, data []byte) insolar.Reference {
 	hasher := platformpolicy.NewPlatformCryptographyScheme().ReferenceHasher()
-	return *insolar.NewReference(*insolar.NewID(pulse, hasher.Hash(data)))
+	reasonID := *insolar.NewID(pulse, hasher.Hash(data))
+	return *insolar.NewRecordReference(reasonID)
 }

--- a/insolar/gen/reference.go
+++ b/insolar/gen/reference.go
@@ -105,6 +105,11 @@ func Reference() insolar.Reference {
 	return *insolar.NewReference(ID())
 }
 
+// Reference generates random reference.
+func RecordReference() insolar.Reference {
+	return *insolar.NewRecordReference(ID())
+}
+
 // UniqueReferences generates multiple random unique References.
 func UniqueReferences(a int) []insolar.Reference {
 	refs := make([]insolar.Reference, a)

--- a/insolar/genesisrefs/refs.go
+++ b/insolar/genesisrefs/refs.go
@@ -31,22 +31,22 @@ const (
 )
 
 var PredefinedPrototypes = map[string]insolar.Reference{
-	insolar.GenesisNameRootDomain + PrototypeSuffix:            *GenerateFromContractID(PrototypeType, insolar.GenesisNameRootDomain, 0),
-	insolar.GenesisNameNodeDomain + PrototypeSuffix:            *GenerateFromContractID(PrototypeType, insolar.GenesisNameNodeDomain, 0),
-	insolar.GenesisNameNodeRecord + PrototypeSuffix:            *GenerateFromContractID(PrototypeType, insolar.GenesisNameNodeRecord, 0),
-	insolar.GenesisNameRootMember + PrototypeSuffix:            *GenerateFromContractID(PrototypeType, insolar.GenesisNameMember, 0),
-	insolar.GenesisNameRootWallet + PrototypeSuffix:            *GenerateFromContractID(PrototypeType, insolar.GenesisNameWallet, 0),
-	insolar.GenesisNameRootAccount + PrototypeSuffix:           *GenerateFromContractID(PrototypeType, insolar.GenesisNameAccount, 0),
-	insolar.GenesisNameCostCenter + PrototypeSuffix:            *GenerateFromContractID(PrototypeType, insolar.GenesisNameCostCenter, 0),
-	insolar.GenesisNameFeeWallet + PrototypeSuffix:             *GenerateFromContractID(PrototypeType, insolar.GenesisNameWallet, 0),
-	insolar.GenesisNameFeeAccount + PrototypeSuffix:            *GenerateFromContractID(PrototypeType, insolar.GenesisNameAccount, 0),
-	insolar.GenesisNameDeposit + PrototypeSuffix:               *GenerateFromContractID(PrototypeType, insolar.GenesisNameDeposit, 0),
-	insolar.GenesisNameMember + PrototypeSuffix:                *GenerateFromContractID(PrototypeType, insolar.GenesisNameMember, 0),
-	insolar.GenesisNameMigrationAdminMember + PrototypeSuffix:  *GenerateFromContractID(PrototypeType, insolar.GenesisNameMember, 0),
-	insolar.GenesisNameMigrationAdmin + PrototypeSuffix:        *GenerateFromContractID(PrototypeType, insolar.GenesisNameMigrationAdmin, 0),
-	insolar.GenesisNameMigrationAdminWallet + PrototypeSuffix:  *GenerateFromContractID(PrototypeType, insolar.GenesisNameWallet, 0),
-	insolar.GenesisNameMigrationAdminAccount + PrototypeSuffix: *GenerateFromContractID(PrototypeType, insolar.GenesisNameAccount, 0),
-	insolar.GenesisNameWallet + PrototypeSuffix:                *GenerateFromContractID(PrototypeType, insolar.GenesisNameWallet, 0),
+	insolar.GenesisNameRootDomain + PrototypeSuffix:            *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameRootDomain, 0),
+	insolar.GenesisNameNodeDomain + PrototypeSuffix:            *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameNodeDomain, 0),
+	insolar.GenesisNameNodeRecord + PrototypeSuffix:            *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameNodeRecord, 0),
+	insolar.GenesisNameRootMember + PrototypeSuffix:            *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameMember, 0),
+	insolar.GenesisNameRootWallet + PrototypeSuffix:            *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameWallet, 0),
+	insolar.GenesisNameRootAccount + PrototypeSuffix:           *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameAccount, 0),
+	insolar.GenesisNameCostCenter + PrototypeSuffix:            *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameCostCenter, 0),
+	insolar.GenesisNameFeeWallet + PrototypeSuffix:             *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameWallet, 0),
+	insolar.GenesisNameFeeAccount + PrototypeSuffix:            *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameAccount, 0),
+	insolar.GenesisNameDeposit + PrototypeSuffix:               *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameDeposit, 0),
+	insolar.GenesisNameMember + PrototypeSuffix:                *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameMember, 0),
+	insolar.GenesisNameMigrationAdminMember + PrototypeSuffix:  *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameMember, 0),
+	insolar.GenesisNameMigrationAdmin + PrototypeSuffix:        *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameMigrationAdmin, 0),
+	insolar.GenesisNameMigrationAdminWallet + PrototypeSuffix:  *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameWallet, 0),
+	insolar.GenesisNameMigrationAdminAccount + PrototypeSuffix: *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameAccount, 0),
+	insolar.GenesisNameWallet + PrototypeSuffix:                *GenerateProtoReferenceFromContractID(PrototypeType, insolar.GenesisNameWallet, 0),
 }
 
 var (
@@ -110,16 +110,26 @@ var (
 )
 
 // Generate reference from hash code.
-func GenerateFromCode(pulse insolar.PulseNumber, code []byte) *insolar.Reference {
+func GenerateProtoReferenceFromCode(pulse insolar.PulseNumber, code []byte) *insolar.Reference {
 	hasher := platformpolicy.NewPlatformCryptographyScheme().ReferenceHasher()
 	codeHash := hasher.Hash(code)
-	return insolar.NewReference(*insolar.NewID(pulse, codeHash))
+	id := insolar.NewID(pulse, codeHash)
+	return insolar.NewReference(*id)
 }
 
-// Generate reference from contract id.
-func GenerateFromContractID(typeContractID string, name string, version int) *insolar.Reference {
+// Generate prototype reference from contract id.
+func GenerateProtoReferenceFromContractID(typeContractID string, name string, version int) *insolar.Reference {
 	contractID := fmt.Sprintf("%s::%s::v%02d", typeContractID, name, version)
-	return GenerateFromCode(pulse.BuiltinContract, []byte(contractID))
+	return GenerateProtoReferenceFromCode(pulse.BuiltinContract, []byte(contractID))
+}
+
+// Generate contract reference from contract id.
+func GenerateCodeReferenceFromContractID(typeContractID string, name string, version int) *insolar.Reference {
+	contractID := fmt.Sprintf("%s::%s::v%02d", typeContractID, name, version)
+	hasher := platformpolicy.NewPlatformCryptographyScheme().ReferenceHasher()
+	codeHash := hasher.Hash([]byte(contractID))
+	id := insolar.NewID(pulse.BuiltinContract, codeHash)
+	return insolar.NewRecordReference(*id)
 }
 
 // GenesisRef returns reference to any genesis records.

--- a/insolar/payload/payload.go
+++ b/insolar/payload/payload.go
@@ -20,6 +20,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	base58 "github.com/jbenet/go-base58"
 	"github.com/pkg/errors"
+
+	"github.com/insolar/insolar/insolar"
 )
 
 type Type uint32
@@ -137,6 +139,14 @@ func (h *MessageHash) IsZero() bool {
 		}
 	}
 	return true
+}
+
+func (m RequestInfo) RequestAsObjectReference() *insolar.Reference {
+	return insolar.NewReference(m.RequestID)
+}
+
+func (m RequestInfo) RequestReference() *insolar.Reference {
+	return insolar.NewRecordReference(m.RequestID)
 }
 
 // UnmarshalType decodes payload type from given binary.

--- a/insolar/payload/payload.go
+++ b/insolar/payload/payload.go
@@ -20,8 +20,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	base58 "github.com/jbenet/go-base58"
 	"github.com/pkg/errors"
-
-	"github.com/insolar/insolar/insolar"
 )
 
 type Type uint32
@@ -139,14 +137,6 @@ func (h *MessageHash) IsZero() bool {
 		}
 	}
 	return true
-}
-
-func (m RequestInfo) RequestAsObjectReference() *insolar.Reference {
-	return insolar.NewReference(m.RequestID)
-}
-
-func (m RequestInfo) RequestReference() *insolar.Reference {
-	return insolar.NewRecordReference(m.RequestID)
 }
 
 // UnmarshalType decodes payload type from given binary.

--- a/insolar/record.go
+++ b/insolar/record.go
@@ -49,6 +49,11 @@ func NewReference(id ID) *Reference {
 	return &global
 }
 
+func NewRecordReference(local ID) *Reference {
+	global := reference.NewRecordRef(local)
+	return &global
+}
+
 func NewGlobalReference(local ID, base ID) *Reference {
 	global := reference.NewGlobal(base, local)
 	return &global

--- a/insolar/rootdomain/rootdomain.go
+++ b/insolar/rootdomain/rootdomain.go
@@ -17,6 +17,8 @@
 package rootdomain
 
 import (
+	"sync"
+
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/genesisrefs"
 	"github.com/insolar/insolar/insolar/record"
@@ -25,7 +27,6 @@ import (
 	"github.com/insolar/insolar/logicrunner/builtin/proxy/migrationshard"
 	"github.com/insolar/insolar/logicrunner/builtin/proxy/pkshard"
 	"github.com/insolar/insolar/platformpolicy"
-	"github.com/insolar/insolar/pulse"
 )
 
 const (
@@ -44,6 +45,7 @@ func init() {
 	for _, el := range insolar.GenesisNamePublicKeyShards {
 		genesisrefs.PredefinedPrototypes[el+GenesisPrototypeSuffix] = *pkshard.PrototypeReference
 	}
+
 	for _, el := range insolar.GenesisNameMigrationAddressShards {
 		genesisrefs.PredefinedPrototypes[el+GenesisPrototypeSuffix] = *migrationshard.PrototypeReference
 	}
@@ -53,7 +55,10 @@ var genesisPulse = insolar.GenesisPulse.PulseNumber
 
 // Record provides methods to calculate root domain's identifiers.
 type Record struct {
-	PCS insolar.PlatformCryptographyScheme
+	once                sync.Once
+	rootDomainID        insolar.ID
+	rootDomainReference insolar.Reference
+	PCS                 insolar.PlatformCryptographyScheme
 }
 
 // RootDomain is the root domain instance.
@@ -61,34 +66,28 @@ var RootDomain = &Record{
 	PCS: platformpolicy.NewPlatformCryptographyScheme(),
 }
 
-// Ref returns insolar.Reference to root domain object.
-func (r Record) Ref() insolar.Reference {
-	return *insolar.NewReference(r.ID())
-}
-
-// ID returns insolar.ID  to root domain object.
-func (r Record) ID() insolar.ID {
-	req := record.IncomingRequest{
+func (r *Record) initialize() {
+	rootRecord := record.IncomingRequest{
 		CallType: record.CTGenesis,
 		Method:   insolar.GenesisNameRootDomain,
 	}
-	virtRec := record.Wrap(&req)
-	hash := record.HashVirtual(r.PCS.ReferenceHasher(), virtRec)
-	return *insolar.NewID(genesisPulse, hash)
+	virtualRec := record.Wrap(&rootRecord)
+	hash := record.HashVirtual(r.PCS.ReferenceHasher(), virtualRec)
+
+	r.rootDomainID = *insolar.NewID(genesisPulse, hash)
+	r.rootDomainReference = *insolar.NewReference(r.rootDomainID)
 }
 
-// GenesisRef returns reference to any genesis records based on the root domain.
-func GenesisRef(name string) insolar.Reference {
-	if ref, ok := genesisrefs.PredefinedPrototypes[name]; ok {
-		return ref
-	}
-	pcs := platformpolicy.NewPlatformCryptographyScheme()
-	req := record.IncomingRequest{
-		CallType: record.CTGenesis,
-		Method:   name,
-	}
-	virtRec := record.Wrap(&req)
-	hash := record.HashVirtual(pcs.ReferenceHasher(), virtRec)
-	id := insolar.NewID(pulse.MinTimePulse, hash)
-	return *insolar.NewReference(*id)
+// ID returns insolar.ID  to root domain object.
+func (r *Record) ID() insolar.ID {
+	r.once.Do(r.initialize)
+
+	return r.rootDomainID
+}
+
+// Reference returns insolar.Reference to root domain object
+func (r *Record) Reference() insolar.Reference {
+	r.once.Do(r.initialize)
+
+	return r.rootDomainReference
 }

--- a/insolar/rootdomain/rootdomain_test.go
+++ b/insolar/rootdomain/rootdomain_test.go
@@ -43,7 +43,7 @@ func TestReference(t *testing.T) {
 	rootRecord := &Record{
 		PCS: initPCS(),
 	}
-	require.Equal(t, refHex, hex.EncodeToString(rootRecord.Ref().Bytes()), "root domain Ref should always be the same")
+	require.Equal(t, refHex, hex.EncodeToString(rootRecord.Reference().Bytes()), "root domain Ref should always be the same")
 
 }
 

--- a/logicrunner/artifacts/client.go
+++ b/logicrunner/artifacts/client.go
@@ -152,8 +152,6 @@ func (m *client) calculateAffinityReference(ctx context.Context, requestRecord r
 		return nil, err
 	}
 	return record.CalculateRequestAffinityRef(requestRecord, pulseNumber, m.PCS), nil
-	// recID := *insolar.NewID(currentPN, h.Sum(nil))
-	// return insolar.NewReference(recID), nil
 }
 
 // RegisterIncomingRequest sends message for incoming request registration,
@@ -433,7 +431,7 @@ func (m *client) GetPendings(ctx context.Context, object insolar.Reference) ([]i
 	case *payload.IDs:
 		res := make([]insolar.Reference, len(concrete.IDs))
 		for i := range concrete.IDs {
-			res[i] = *insolar.NewReference(concrete.IDs[i])
+			res[i] = *insolar.NewRecordReference(concrete.IDs[i])
 		}
 		return res, nil
 	case *payload.Error:
@@ -535,7 +533,7 @@ func (m *client) DeployCode(
 
 	pl, err := m.sendToLight(
 		ctx, bus.NewRetrySender(m.sender, m.PulseAccessor, 1, 1),
-		psc, *insolar.NewReference(recID),
+		psc, *insolar.NewRecordReference(recID),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to send SetCode")

--- a/logicrunner/artifacts/client_test.go
+++ b/logicrunner/artifacts/client_test.go
@@ -163,7 +163,7 @@ func (s *amSuite) TestLedgerArtifactManager_GetPendings_Success() {
 	mc := minimock.NewController(s.T())
 	defer mc.Finish()
 	objectRef := gen.Reference()
-	requestRef := gen.Reference()
+	requestRef := gen.RecordReference()
 
 	jc := jet.NewCoordinatorMock(mc)
 

--- a/logicrunner/builtin/initialization.go
+++ b/logicrunner/builtin/initialization.go
@@ -69,19 +69,19 @@ func shouldLoadRef(strRef string) XXX_insolar.Reference {
 func InitializeCodeRefs() map[XXX_insolar.Reference]string {
 	rv := make(map[XXX_insolar.Reference]string, 0)
 
-	rv[shouldLoadRef("0111A7rimrANEAnwBT1kvAhHeHp9NPTFJMLKVng8GLH5")] = "account"
-	rv[shouldLoadRef("0111A7tUo1FeZ5DSoroiinMCKwzLacaYBAAcwAaNj6bc")] = "costcenter"
-	rv[shouldLoadRef("0111A79KGpeDUjYhRJP1n1AwYgwU9KEWmc2TNNc3KQjV")] = "deposit"
-	rv[shouldLoadRef("0111A5w1GcnTsht82duVrnWdVHVNyrxCUVcSPLtgQCPR")] = "helloworld"
-	rv[shouldLoadRef("0111A72gPKWyrF9c7yzDoccRoPQ62g1uQQDBecWJwAYr")] = "member"
-	rv[shouldLoadRef("0111A6516TVnMLh8DAzTWbtEJrgZkESeCpdn2viV6D61")] = "migrationadmin"
-	rv[shouldLoadRef("0111A7PzUnidJKg3DDo82FyyYFukEyKJYmLKoCFfQmoK")] = "migrationdaemon"
-	rv[shouldLoadRef("0111A66L3aoDPf2wedyRo2gyns8ghV9vdeJdJntVaGEf")] = "migrationshard"
-	rv[shouldLoadRef("0111A7Q5FK2ebPG9WnSiUc4iqF45w9oYkJkRjEtBohGe")] = "nodedomain"
-	rv[shouldLoadRef("0111A86xPKUQ1ZxSscgv5brbw93LkwiVhUWgGrYYsMar")] = "noderecord"
-	rv[shouldLoadRef("0111A5tzn16hnKGCZCyYA8Dv9FALvPYYQu4VA41SVx6s")] = "pkshard"
-	rv[shouldLoadRef("0111A63R5cAgGHC5DJffqF16vUkCuSVj3GExbMLy56cS")] = "rootdomain"
-	rv[shouldLoadRef("0111A5e49cJW6GKGegWBhtgrJs7nFh1kSWhBtT2VgK4t")] = "wallet"
+	rv[shouldLoadRef("0111A7rimrANEAnwBT1kvAhHeHp9NPTFJMLKVng8GLH5.record")] = "account"
+	rv[shouldLoadRef("0111A7tUo1FeZ5DSoroiinMCKwzLacaYBAAcwAaNj6bc.record")] = "costcenter"
+	rv[shouldLoadRef("0111A79KGpeDUjYhRJP1n1AwYgwU9KEWmc2TNNc3KQjV.record")] = "deposit"
+	rv[shouldLoadRef("0111A5w1GcnTsht82duVrnWdVHVNyrxCUVcSPLtgQCPR.record")] = "helloworld"
+	rv[shouldLoadRef("0111A72gPKWyrF9c7yzDoccRoPQ62g1uQQDBecWJwAYr.record")] = "member"
+	rv[shouldLoadRef("0111A6516TVnMLh8DAzTWbtEJrgZkESeCpdn2viV6D61.record")] = "migrationadmin"
+	rv[shouldLoadRef("0111A7PzUnidJKg3DDo82FyyYFukEyKJYmLKoCFfQmoK.record")] = "migrationdaemon"
+	rv[shouldLoadRef("0111A66L3aoDPf2wedyRo2gyns8ghV9vdeJdJntVaGEf.record")] = "migrationshard"
+	rv[shouldLoadRef("0111A7Q5FK2ebPG9WnSiUc4iqF45w9oYkJkRjEtBohGe.record")] = "nodedomain"
+	rv[shouldLoadRef("0111A86xPKUQ1ZxSscgv5brbw93LkwiVhUWgGrYYsMar.record")] = "noderecord"
+	rv[shouldLoadRef("0111A5tzn16hnKGCZCyYA8Dv9FALvPYYQu4VA41SVx6s.record")] = "pkshard"
+	rv[shouldLoadRef("0111A63R5cAgGHC5DJffqF16vUkCuSVj3GExbMLy56cS.record")] = "rootdomain"
+	rv[shouldLoadRef("0111A5e49cJW6GKGegWBhtgrJs7nFh1kSWhBtT2VgK4t.record")] = "wallet"
 
 	return rv
 }
@@ -93,79 +93,79 @@ func InitializeCodeDescriptors() []XXX_artifacts.CodeDescriptor {
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A7rimrANEAnwBT1kvAhHeHp9NPTFJMLKVng8GLH5"),
+		/* ref:         */ shouldLoadRef("0111A7rimrANEAnwBT1kvAhHeHp9NPTFJMLKVng8GLH5.record"),
 	))
 	// costcenter
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A7tUo1FeZ5DSoroiinMCKwzLacaYBAAcwAaNj6bc"),
+		/* ref:         */ shouldLoadRef("0111A7tUo1FeZ5DSoroiinMCKwzLacaYBAAcwAaNj6bc.record"),
 	))
 	// deposit
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A79KGpeDUjYhRJP1n1AwYgwU9KEWmc2TNNc3KQjV"),
+		/* ref:         */ shouldLoadRef("0111A79KGpeDUjYhRJP1n1AwYgwU9KEWmc2TNNc3KQjV.record"),
 	))
 	// helloworld
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A5w1GcnTsht82duVrnWdVHVNyrxCUVcSPLtgQCPR"),
+		/* ref:         */ shouldLoadRef("0111A5w1GcnTsht82duVrnWdVHVNyrxCUVcSPLtgQCPR.record"),
 	))
 	// member
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A72gPKWyrF9c7yzDoccRoPQ62g1uQQDBecWJwAYr"),
+		/* ref:         */ shouldLoadRef("0111A72gPKWyrF9c7yzDoccRoPQ62g1uQQDBecWJwAYr.record"),
 	))
 	// migrationadmin
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A6516TVnMLh8DAzTWbtEJrgZkESeCpdn2viV6D61"),
+		/* ref:         */ shouldLoadRef("0111A6516TVnMLh8DAzTWbtEJrgZkESeCpdn2viV6D61.record"),
 	))
 	// migrationdaemon
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A7PzUnidJKg3DDo82FyyYFukEyKJYmLKoCFfQmoK"),
+		/* ref:         */ shouldLoadRef("0111A7PzUnidJKg3DDo82FyyYFukEyKJYmLKoCFfQmoK.record"),
 	))
 	// migrationshard
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A66L3aoDPf2wedyRo2gyns8ghV9vdeJdJntVaGEf"),
+		/* ref:         */ shouldLoadRef("0111A66L3aoDPf2wedyRo2gyns8ghV9vdeJdJntVaGEf.record"),
 	))
 	// nodedomain
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A7Q5FK2ebPG9WnSiUc4iqF45w9oYkJkRjEtBohGe"),
+		/* ref:         */ shouldLoadRef("0111A7Q5FK2ebPG9WnSiUc4iqF45w9oYkJkRjEtBohGe.record"),
 	))
 	// noderecord
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A86xPKUQ1ZxSscgv5brbw93LkwiVhUWgGrYYsMar"),
+		/* ref:         */ shouldLoadRef("0111A86xPKUQ1ZxSscgv5brbw93LkwiVhUWgGrYYsMar.record"),
 	))
 	// pkshard
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A5tzn16hnKGCZCyYA8Dv9FALvPYYQu4VA41SVx6s"),
+		/* ref:         */ shouldLoadRef("0111A5tzn16hnKGCZCyYA8Dv9FALvPYYQu4VA41SVx6s.record"),
 	))
 	// rootdomain
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A63R5cAgGHC5DJffqF16vUkCuSVj3GExbMLy56cS"),
+		/* ref:         */ shouldLoadRef("0111A63R5cAgGHC5DJffqF16vUkCuSVj3GExbMLy56cS.record"),
 	))
 	// wallet
 	rv = append(rv, XXX_artifacts.NewCodeDescriptor(
 		/* code:        */ nil,
 		/* machineType: */ XXX_insolar.MachineTypeBuiltin,
-		/* ref:         */ shouldLoadRef("0111A5e49cJW6GKGegWBhtgrJs7nFh1kSWhBtT2VgK4t"),
+		/* ref:         */ shouldLoadRef("0111A5e49cJW6GKGegWBhtgrJs7nFh1kSWhBtT2VgK4t.record"),
 	))
 
 	return rv
@@ -176,7 +176,7 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 
 	{ // account
 		pRef := shouldLoadRef("0111A62X73fkPeY5vK6NjcXgmL9d37DgRRNtHNLGaEse")
-		cRef := shouldLoadRef("0111A7rimrANEAnwBT1kvAhHeHp9NPTFJMLKVng8GLH5")
+		cRef := shouldLoadRef("0111A7rimrANEAnwBT1kvAhHeHp9NPTFJMLKVng8GLH5.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -184,13 +184,13 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 
 	{ // costcenter
 		pRef := shouldLoadRef("0111A62HrJvAimG7M1r8XdeBVMw4X6ge8hGzVStfnn4e")
-		cRef := shouldLoadRef("0111A7tUo1FeZ5DSoroiinMCKwzLacaYBAAcwAaNj6bc")
+		cRef := shouldLoadRef("0111A7tUo1FeZ5DSoroiinMCKwzLacaYBAAcwAaNj6bc.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -198,13 +198,13 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 
 	{ // deposit
 		pRef := shouldLoadRef("0111A7ctasuNUug8BoK4VJNuAFJ73rnH8bH5zqd5HrDj")
-		cRef := shouldLoadRef("0111A79KGpeDUjYhRJP1n1AwYgwU9KEWmc2TNNc3KQjV")
+		cRef := shouldLoadRef("0111A79KGpeDUjYhRJP1n1AwYgwU9KEWmc2TNNc3KQjV.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -212,13 +212,13 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 
 	{ // helloworld
 		pRef := shouldLoadRef("0111A85JAZugtAkQErbDe3eAaTw56DPLku8QGymJUCt2")
-		cRef := shouldLoadRef("0111A5w1GcnTsht82duVrnWdVHVNyrxCUVcSPLtgQCPR")
+		cRef := shouldLoadRef("0111A5w1GcnTsht82duVrnWdVHVNyrxCUVcSPLtgQCPR.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -226,13 +226,13 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 
 	{ // member
 		pRef := shouldLoadRef("0111A7UqbgvFXj9vkCAaNYSAkWLapu62eU5AUSv3y4JY")
-		cRef := shouldLoadRef("0111A72gPKWyrF9c7yzDoccRoPQ62g1uQQDBecWJwAYr")
+		cRef := shouldLoadRef("0111A72gPKWyrF9c7yzDoccRoPQ62g1uQQDBecWJwAYr.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -240,13 +240,13 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 
 	{ // migrationadmin
 		pRef := shouldLoadRef("0111A8DhUhw5pzyvzVg1qXomNEHXs7kDtJRQGSD1PUpc")
-		cRef := shouldLoadRef("0111A6516TVnMLh8DAzTWbtEJrgZkESeCpdn2viV6D61")
+		cRef := shouldLoadRef("0111A6516TVnMLh8DAzTWbtEJrgZkESeCpdn2viV6D61.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -254,13 +254,13 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 
 	{ // migrationdaemon
 		pRef := shouldLoadRef("0111A7jZX41e1SpH9oW3F2dgUvVQdjSqXEAGQSxhbqmD")
-		cRef := shouldLoadRef("0111A7PzUnidJKg3DDo82FyyYFukEyKJYmLKoCFfQmoK")
+		cRef := shouldLoadRef("0111A7PzUnidJKg3DDo82FyyYFukEyKJYmLKoCFfQmoK.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -268,13 +268,13 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 
 	{ // migrationshard
 		pRef := shouldLoadRef("0111A7FNYLZLYXYWZPbkMhCAPwV9nYrWWE7L57CtdJCj")
-		cRef := shouldLoadRef("0111A66L3aoDPf2wedyRo2gyns8ghV9vdeJdJntVaGEf")
+		cRef := shouldLoadRef("0111A66L3aoDPf2wedyRo2gyns8ghV9vdeJdJntVaGEf.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -282,13 +282,13 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 
 	{ // nodedomain
 		pRef := shouldLoadRef("0111A6NKbCjpzFr9MttfcWV8vX8eFjiyGPPfSH1AMtwN")
-		cRef := shouldLoadRef("0111A7Q5FK2ebPG9WnSiUc4iqF45w9oYkJkRjEtBohGe")
+		cRef := shouldLoadRef("0111A7Q5FK2ebPG9WnSiUc4iqF45w9oYkJkRjEtBohGe.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -296,13 +296,13 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 
 	{ // noderecord
 		pRef := shouldLoadRef("0111A5fZeApbGhcsLrbfGy82kKLgapF93GhNPMLSYaPY")
-		cRef := shouldLoadRef("0111A86xPKUQ1ZxSscgv5brbw93LkwiVhUWgGrYYsMar")
+		cRef := shouldLoadRef("0111A86xPKUQ1ZxSscgv5brbw93LkwiVhUWgGrYYsMar.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -310,13 +310,13 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 
 	{ // pkshard
 		pRef := shouldLoadRef("0111A5x8N1VJTm7BKYgzSe6TWHcFi98QZgw3AnkYiKML")
-		cRef := shouldLoadRef("0111A5tzn16hnKGCZCyYA8Dv9FALvPYYQu4VA41SVx6s")
+		cRef := shouldLoadRef("0111A5tzn16hnKGCZCyYA8Dv9FALvPYYQu4VA41SVx6s.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -324,13 +324,13 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 
 	{ // rootdomain
 		pRef := shouldLoadRef("0111A84uiiTD1LXAHNP4GMA6YJFjbnCdkRia2pCqwBV5")
-		cRef := shouldLoadRef("0111A63R5cAgGHC5DJffqF16vUkCuSVj3GExbMLy56cS")
+		cRef := shouldLoadRef("0111A63R5cAgGHC5DJffqF16vUkCuSVj3GExbMLy56cS.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -338,13 +338,13 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 
 	{ // wallet
 		pRef := shouldLoadRef("0111A5gmRD1ZbHjQh7DgH9SrCK4a1qfwEUP5xAir6i8L")
-		cRef := shouldLoadRef("0111A5e49cJW6GKGegWBhtgrJs7nFh1kSWhBtT2VgK4t")
+		cRef := shouldLoadRef("0111A5e49cJW6GKGegWBhtgrJs7nFh1kSWhBtT2VgK4t.record")
 		rv = append(rv, XXX_artifacts.NewObjectDescriptor(
 			/* head:         */ pRef,
 			/* state:        */ *pRef.GetLocal(),
@@ -352,7 +352,7 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
 			/* isPrototype:  */ true,
 			/* childPointer: */ nil,
 			/* memory:       */ nil,
-			/* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+			/* parent:       */ XXX_rootdomain.RootDomain.Reference(),
 		))
 	}
 

--- a/logicrunner/builtin/proxy/account/account.go
+++ b/logicrunner/builtin/proxy/account/account.go
@@ -71,7 +71,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*Account,
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *Account) {
+func GetObject(ref insolar.Reference) *Account {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &Account{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxy/costcenter/costcenter.go
+++ b/logicrunner/builtin/proxy/costcenter/costcenter.go
@@ -67,7 +67,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*CostCent
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *CostCenter) {
+func GetObject(ref insolar.Reference) *CostCenter {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &CostCenter{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxy/deposit/deposit.go
+++ b/logicrunner/builtin/proxy/deposit/deposit.go
@@ -68,7 +68,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*Deposit,
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *Deposit) {
+func GetObject(ref insolar.Reference) *Deposit {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &Deposit{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxy/helloworld/helloworld.go
+++ b/logicrunner/builtin/proxy/helloworld/helloworld.go
@@ -88,7 +88,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*HelloWor
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *HelloWorld) {
+func GetObject(ref insolar.Reference) *HelloWorld {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &HelloWorld{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxy/member/member.go
+++ b/logicrunner/builtin/proxy/member/member.go
@@ -104,7 +104,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*Member, 
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *Member) {
+func GetObject(ref insolar.Reference) *Member {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &Member{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxy/migrationadmin/migrationadmin.go
+++ b/logicrunner/builtin/proxy/migrationadmin/migrationadmin.go
@@ -76,7 +76,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*Migratio
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *MigrationAdmin) {
+func GetObject(ref insolar.Reference) *MigrationAdmin {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &MigrationAdmin{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxy/migrationdaemon/migrationdaemon.go
+++ b/logicrunner/builtin/proxy/migrationdaemon/migrationdaemon.go
@@ -67,7 +67,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*Migratio
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *MigrationDaemon) {
+func GetObject(ref insolar.Reference) *MigrationDaemon {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &MigrationDaemon{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxy/migrationshard/migrationshard.go
+++ b/logicrunner/builtin/proxy/migrationshard/migrationshard.go
@@ -67,7 +67,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*Migratio
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *MigrationShard) {
+func GetObject(ref insolar.Reference) *MigrationShard {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &MigrationShard{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxy/nodedomain/nodedomain.go
+++ b/logicrunner/builtin/proxy/nodedomain/nodedomain.go
@@ -67,7 +67,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*NodeDoma
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *NodeDomain) {
+func GetObject(ref insolar.Reference) *NodeDomain {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &NodeDomain{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxy/noderecord/noderecord.go
+++ b/logicrunner/builtin/proxy/noderecord/noderecord.go
@@ -72,7 +72,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*NodeReco
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *NodeRecord) {
+func GetObject(ref insolar.Reference) *NodeRecord {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &NodeRecord{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxy/pkshard/pkshard.go
+++ b/logicrunner/builtin/proxy/pkshard/pkshard.go
@@ -67,7 +67,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*PKShard,
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *PKShard) {
+func GetObject(ref insolar.Reference) *PKShard {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &PKShard{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxy/rootdomain/rootdomain.go
+++ b/logicrunner/builtin/proxy/rootdomain/rootdomain.go
@@ -67,7 +67,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*RootDoma
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *RootDomain) {
+func GetObject(ref insolar.Reference) *RootDomain {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &RootDomain{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxy/wallet/wallet.go
+++ b/logicrunner/builtin/proxy/wallet/wallet.go
@@ -67,7 +67,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*Wallet, 
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *Wallet) {
+func GetObject(ref insolar.Reference) *Wallet {
+	if !ref.IsObjectReference() {
+		return nil
+	}
 	return &Wallet{Reference: ref}
 }
 

--- a/logicrunner/builtin/proxyhelper.go
+++ b/logicrunner/builtin/proxyhelper.go
@@ -19,6 +19,8 @@ package builtin
 import (
 	"reflect"
 
+	"github.com/pkg/errors"
+
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/logicrunner/builtin/foundation"
 	lrCommon "github.com/insolar/insolar/logicrunner/common"
@@ -85,6 +87,9 @@ func (h *ProxyHelper) SaveAsChild(
 ) (
 	*insolar.Reference, []byte, error,
 ) {
+	if !parentRef.IsObjectReference() {
+		return nil, nil, errors.Errorf("Failed to save AsChild: objRef should be ObjectReference; ref=%s", parentRef.String())
+	}
 
 	if h.GetSystemError() != nil {
 		// There was a system error during execution of the contract.

--- a/logicrunner/handle_additional_call_test.go
+++ b/logicrunner/handle_additional_call_test.go
@@ -106,8 +106,10 @@ func TestAdditionalCallFromPreviousExecutor_Proceed(t *testing.T) {
 		msg := &payload.AdditionalCallFromPreviousExecutor{
 			ObjectReference: obj,
 			RequestRef:      reqRef,
-			Request:         &record.IncomingRequest{},
-			Pending:         insolar.NotPending,
+			Request: &record.IncomingRequest{
+				Object: &obj,
+			},
+			Pending: insolar.NotPending,
 		}
 
 		stateStorage := NewStateStorageMock(t).
@@ -138,8 +140,10 @@ func TestAdditionalCallFromPreviousExecutor_Proceed(t *testing.T) {
 		msg := &payload.AdditionalCallFromPreviousExecutor{
 			ObjectReference: obj,
 			RequestRef:      reqRef,
-			Request:         &record.IncomingRequest{},
-			Pending:         insolar.InPending,
+			Request: &record.IncomingRequest{
+				Object: &obj,
+			},
+			Pending: insolar.InPending,
 		}
 
 		stateStorage := NewStateStorageMock(t).

--- a/logicrunner/handle_additional_call_test.go
+++ b/logicrunner/handle_additional_call_test.go
@@ -17,6 +17,8 @@
 package logicrunner
 
 import (
+	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,9 +31,42 @@ import (
 	"github.com/insolar/insolar/insolar/gen"
 	"github.com/insolar/insolar/insolar/payload"
 	"github.com/insolar/insolar/insolar/record"
+	"github.com/insolar/insolar/insolar/utils"
 	"github.com/insolar/insolar/instrumentation/inslogger"
 	"github.com/insolar/insolar/logicrunner/writecontroller"
 )
+
+func genAPIRequestID() string {
+	APIRequestID := utils.RandTraceID()
+	if strings.Contains(APIRequestID, "createRandomTraceIDFailed") {
+		panic("Failed to generate uuid: " + APIRequestID)
+	}
+	return APIRequestID
+}
+
+func genIncomingRequest() *record.IncomingRequest {
+	baseRef := gen.Reference()
+	objectRef := gen.Reference()
+	prototypeRef := gen.Reference()
+
+	return &record.IncomingRequest{
+		Polymorph:       rand.Int31(),
+		CallType:        record.CTMethod,
+		Caller:          gen.Reference(),
+		CallerPrototype: gen.Reference(),
+		Nonce:           0,
+		ReturnMode:      record.ReturnNoWait,
+		Immutable:       false,
+		Base:            &baseRef,
+		Object:          &objectRef,
+		Prototype:       &prototypeRef,
+		Method:          "Call",
+		Arguments:       []byte{},
+		APIRequestID:    genAPIRequestID(),
+		Reason:          gen.RecordReference(),
+		APINode:         insolar.Reference{},
+	}
+}
 
 func TestHandleAdditionalCallFromPreviousExecutor_Present(t *testing.T) {
 	table := []struct {
@@ -44,14 +79,13 @@ func TestHandleAdditionalCallFromPreviousExecutor_Present(t *testing.T) {
 		{
 			name: "Happy path",
 			mocks: func(t minimock.Tester) (*HandleAdditionalCallFromPreviousExecutor, flow.Flow) {
-				obj := gen.Reference()
-				reqRef := gen.Reference()
+				incoming := genIncomingRequest()
 
 				receivedPayload := &payload.AdditionalCallFromPreviousExecutor{
-					RequestRef:      reqRef,
+					RequestRef:      gen.RecordReference(),
 					Pending:         insolar.NotPending,
-					ObjectReference: obj,
-					Request:         &record.IncomingRequest{},
+					ObjectReference: *incoming.Object,
+					Request:         incoming,
 					ServiceData:     &payload.ServiceData{},
 				}
 
@@ -96,24 +130,20 @@ func TestAdditionalCallFromPreviousExecutor_Proceed(t *testing.T) {
 
 	t.Run("Proceed without pending", func(t *testing.T) {
 		t.Parallel()
-
 		mc := minimock.NewController(t)
 
 		ctx := inslogger.TestContext(t)
-		obj := gen.Reference()
-		reqRef := gen.Reference()
+		incoming := genIncomingRequest()
 
 		msg := &payload.AdditionalCallFromPreviousExecutor{
-			ObjectReference: obj,
-			RequestRef:      reqRef,
-			Request: &record.IncomingRequest{
-				Object: &obj,
-			},
-			Pending: insolar.NotPending,
+			ObjectReference: *incoming.Object,
+			RequestRef:      gen.RecordReference(),
+			Request:         incoming,
+			Pending:         insolar.NotPending,
 		}
 
 		stateStorage := NewStateStorageMock(t).
-			UpsertExecutionStateMock.Expect(obj).Return(
+			UpsertExecutionStateMock.Expect(*incoming.Object).Return(
 			NewExecutionBrokerIMock(t).
 				AddAdditionalRequestFromPrevExecutorMock.Return().
 				SetNotPendingMock.Return(),
@@ -134,20 +164,17 @@ func TestAdditionalCallFromPreviousExecutor_Proceed(t *testing.T) {
 		mc := minimock.NewController(t)
 
 		ctx := inslogger.TestContext(t)
-		obj := gen.Reference()
-		reqRef := gen.Reference()
+		incoming := genIncomingRequest()
 
 		msg := &payload.AdditionalCallFromPreviousExecutor{
-			ObjectReference: obj,
-			RequestRef:      reqRef,
-			Request: &record.IncomingRequest{
-				Object: &obj,
-			},
-			Pending: insolar.InPending,
+			ObjectReference: *incoming.Object,
+			RequestRef:      gen.RecordReference(),
+			Request:         incoming,
+			Pending:         insolar.InPending,
 		}
 
 		stateStorage := NewStateStorageMock(t).
-			UpsertExecutionStateMock.Expect(obj).Return(
+			UpsertExecutionStateMock.Expect(*incoming.Object).Return(
 			NewExecutionBrokerIMock(t).
 				AddAdditionalRequestFromPrevExecutorMock.Return(),
 		)

--- a/logicrunner/handle_calls.go
+++ b/logicrunner/handle_calls.go
@@ -164,19 +164,16 @@ func (h *HandleCall) handleActual(
 	}
 
 	reqInfo := procRegisterRequest.getResult()
-	requestRef := *reqInfo.RequestReference()
+	requestRef := *getRequestReference(reqInfo)
 
 	if request.CallType != record.CTMethod {
-		request.Object = reqInfo.RequestAsObjectReference()
+		request.Object = insolar.NewReference(reqInfo.RequestID)
 	}
 
 	objectRef := request.Object
 
-	if objectRef == nil {
+	if objectRef == nil || !objectRef.IsSelfScope() {
 		return nil, errors.New("can't get object reference")
-	} else if !objectRef.IsSelfScope() {
-		// TODO[bigbes]: temporary check, remove later
-		panic("objectRef is not in recordScope")
 	}
 
 	ctx, logger := inslogger.WithFields(

--- a/logicrunner/handle_calls.go
+++ b/logicrunner/handle_calls.go
@@ -36,6 +36,14 @@ import (
 	"github.com/insolar/insolar/logicrunner/common"
 )
 
+func checkPayloadCallMethod(ctx context.Context, callMethod payload.CallMethod) error {
+	if err := checkIncomingRequest(ctx, callMethod.Request); err != nil {
+		return errors.Wrap(err, "failed to verify callMethod.Request")
+	}
+
+	return nil
+}
+
 type HandleCall struct {
 	dep *Dependencies
 
@@ -244,6 +252,10 @@ func (h *HandleCall) Present(ctx context.Context, f flow.Flow) error {
 	err := message.Unmarshal(h.Message.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to unmarshal message")
+	}
+
+	if err := checkPayloadCallMethod(ctx, message); err != nil {
+		return err
 	}
 
 	rep, err := h.handleActual(ctx, message, f)

--- a/logicrunner/handle_calls_test.go
+++ b/logicrunner/handle_calls_test.go
@@ -502,7 +502,7 @@ func TestHandleCall_Present(t *testing.T) {
 		mc := minimock.NewController(t)
 
 		objRef := gen.Reference()
-		reqRef := gen.Reference()
+		reqRef := gen.RecordReference()
 
 		resRecord := &record.Result{Payload: []byte{3, 2, 1}}
 		virtResRecord := record.Wrap(resRecord)

--- a/logicrunner/handle_executorresults_test.go
+++ b/logicrunner/handle_executorresults_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 func TestHandleExecutorResults_Present(t *testing.T) {
+	objectRef1, objectRef2 := gen.Reference(), gen.Reference()
+
 	tests := []struct {
 		name  string
 		mocks func(t minimock.Tester) (*HandleExecutorResults, flow.Flow)
@@ -49,13 +51,13 @@ func TestHandleExecutorResults_Present(t *testing.T) {
 					LedgerHasMoreRequests: true,
 					Queue: []*payload.ExecutionQueueElement{
 						{
-							RequestRef: gen.Reference(),
-							Incoming: &record.IncomingRequest{},
+							RequestRef:  gen.Reference(),
+							Incoming:    &record.IncomingRequest{Object: &objectRef1},
 							ServiceData: &payload.ServiceData{},
 						},
 						{
-							RequestRef: gen.Reference(),
-							Incoming: &record.IncomingRequest{},
+							RequestRef:  gen.Reference(),
+							Incoming:    &record.IncomingRequest{Object: &objectRef2},
 							ServiceData: &payload.ServiceData{},
 						},
 					},
@@ -87,8 +89,8 @@ func TestHandleExecutorResults_Present(t *testing.T) {
 			mocks: func(t minimock.Tester) (*HandleExecutorResults, flow.Flow) {
 				obj := gen.Reference()
 				receivedPayload := &payload.ExecutorResults{
-					RecordRef:             obj,
-					Pending:               insolar.NotPending,
+					RecordRef: obj,
+					Pending:   insolar.NotPending,
 				}
 
 				buf, err := payload.Marshal(receivedPayload)
@@ -115,8 +117,8 @@ func TestHandleExecutorResults_Present(t *testing.T) {
 			mocks: func(t minimock.Tester) (*HandleExecutorResults, flow.Flow) {
 				obj := gen.Reference()
 				receivedPayload := &payload.ExecutorResults{
-					RecordRef:             obj,
-					Pending:               insolar.NotPending,
+					RecordRef: obj,
+					Pending:   insolar.NotPending,
 				}
 
 				buf, err := payload.Marshal(receivedPayload)
@@ -139,8 +141,8 @@ func TestHandleExecutorResults_Present(t *testing.T) {
 			mocks: func(t minimock.Tester) (*HandleExecutorResults, flow.Flow) {
 				obj := gen.Reference()
 				receivedPayload := &payload.ExecutorResults{
-					RecordRef:             obj,
-					Pending:               insolar.NotPending,
+					RecordRef: obj,
+					Pending:   insolar.NotPending,
 				}
 
 				buf, err := payload.Marshal(receivedPayload)
@@ -162,8 +164,8 @@ func TestHandleExecutorResults_Present(t *testing.T) {
 			name: "error, bad data",
 			mocks: func(t minimock.Tester) (*HandleExecutorResults, flow.Flow) {
 				h := &HandleExecutorResults{
-					dep: &Dependencies{},
-					meta: payload.Meta{Payload: []byte{3,2,1}},
+					dep:  &Dependencies{},
+					meta: payload.Meta{Payload: []byte{3, 2, 1}},
 				}
 				f := flow.NewFlowMock(t)
 				return h, f

--- a/logicrunner/handle_sagacallacceptnotification.go
+++ b/logicrunner/handle_sagacallacceptnotification.go
@@ -33,7 +33,7 @@ func (h *HandleSagaCallAcceptNotification) Present(ctx context.Context, f flow.F
 		return fmt.Errorf("unexpected request received %T", rec)
 	}
 
-	outgoingReqRef := insolar.NewReference(msg.DetachedRequestID)
+	outgoingReqRef := insolar.NewRecordReference(msg.DetachedRequestID)
 	_, _, _, err = h.dep.OutgoingSender.SendOutgoingRequest(ctx, *outgoingReqRef, outgoing)
 	return err
 }

--- a/logicrunner/handle_sagacallacceptnotification.go
+++ b/logicrunner/handle_sagacallacceptnotification.go
@@ -33,6 +33,10 @@ func (h *HandleSagaCallAcceptNotification) Present(ctx context.Context, f flow.F
 		return fmt.Errorf("unexpected request received %T", rec)
 	}
 
+	if err := checkOutgoingRequest(ctx, outgoing); err != nil {
+		return err
+	}
+
 	outgoingReqRef := insolar.NewRecordReference(msg.DetachedRequestID)
 	_, _, _, err = h.dep.OutgoingSender.SendOutgoingRequest(ctx, *outgoingReqRef, outgoing)
 	return err

--- a/logicrunner/handle_still_executing_test.go
+++ b/logicrunner/handle_still_executing_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gojuno/minimock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/flow"
 	"github.com/insolar/insolar/insolar/gen"
 	"github.com/insolar/insolar/insolar/payload"
@@ -40,7 +41,9 @@ func TestHandleStillExecuting_Present(t *testing.T) {
 			mocks: func(t minimock.Tester) (*HandleStillExecuting, flow.Flow) {
 				obj := gen.Reference()
 				receivedPayload := &payload.StillExecuting{
-					ObjectRef: obj,
+					ObjectRef:   obj,
+					Executor:    gen.Reference(),
+					RequestRefs: []insolar.Reference{gen.RecordReference()},
 				}
 
 				buf, err := payload.Marshal(receivedPayload)

--- a/logicrunner/logicexecutor/logicexecutor.go
+++ b/logicrunner/logicexecutor/logicexecutor.go
@@ -161,7 +161,7 @@ func (le *logicExecutor) ExecuteConstructor(
 		return nil, errors.New("return of constructor is empty")
 	}
 
-	res := requestresult.New(result, transcript.RequestRef)
+	res := requestresult.New(result, *transcript.Request.Object)
 	if newData != nil {
 		res.SetActivate(*request.Base, *request.Prototype, newData)
 	}
@@ -196,7 +196,7 @@ func (le *logicExecutor) genLogicCallContext(
 		// should be the same as request.Object
 		res.Callee = oDesc.HeadRef()
 	} else {
-		res.Callee = &reqRef
+		res.Callee = transcript.Request.Object
 	}
 
 	return res

--- a/logicrunner/logicexecutor/logicexecutor_test.go
+++ b/logicrunner/logicexecutor/logicexecutor_test.go
@@ -426,6 +426,7 @@ func TestLogicExecutor_ExecuteConstructor(t *testing.T) {
 	callerRef := gen.Reference()
 	codeRef := gen.Reference()
 	baseRef := gen.Reference()
+	objectRef := gen.Reference()
 
 	tests := []struct {
 		name  string
@@ -438,6 +439,7 @@ func TestLogicExecutor_ExecuteConstructor(t *testing.T) {
 			mocks: func(ctx context.Context, mc minimock.Tester) (LogicExecutor, *common.Transcript) {
 				tr := &common.Transcript{
 					Request: &record.IncomingRequest{
+						Object:    &objectRef,
 						Base:      &baseRef,
 						CallType:  record.CTSaveAsChild,
 						Caller:    callerRef,
@@ -464,11 +466,12 @@ func TestLogicExecutor_ExecuteConstructor(t *testing.T) {
 				return &logicExecutor{MachinesManager: mm, DescriptorsCache: dc}, tr
 			},
 			res: &requestresult.RequestResult{
-				SideEffectType:  artifacts.RequestSideEffectActivate,
-				RawResult:       []byte{3, 2, 1},
-				Memory:          []byte{1, 2, 3},
-				ParentReference: baseRef,
-				ObjectImage:     protoRef,
+				SideEffectType:     artifacts.RequestSideEffectActivate,
+				RawResult:          []byte{3, 2, 1},
+				Memory:             []byte{1, 2, 3},
+				ParentReference:    baseRef,
+				ObjectImage:        protoRef,
+				RawObjectReference: objectRef,
 			},
 		},
 		{
@@ -476,6 +479,7 @@ func TestLogicExecutor_ExecuteConstructor(t *testing.T) {
 			mocks: func(ctx context.Context, mc minimock.Tester) (LogicExecutor, *common.Transcript) {
 				tr := &common.Transcript{
 					Request: &record.IncomingRequest{
+						Object:    &objectRef,
 						Base:      &baseRef,
 						CallType:  record.CTSaveAsChild,
 						Caller:    callerRef,
@@ -502,7 +506,8 @@ func TestLogicExecutor_ExecuteConstructor(t *testing.T) {
 				return &logicExecutor{MachinesManager: mm, DescriptorsCache: dc}, tr
 			},
 			res: &requestresult.RequestResult{
-				RawResult:       []byte{3, 2, 1},
+				RawResult:          []byte{3, 2, 1},
+				RawObjectReference: objectRef,
 			},
 		},
 		{
@@ -510,6 +515,7 @@ func TestLogicExecutor_ExecuteConstructor(t *testing.T) {
 			mocks: func(ctx context.Context, mc minimock.Tester) (LogicExecutor, *common.Transcript) {
 				tr := &common.Transcript{
 					Request: &record.IncomingRequest{
+						Object:    &objectRef,
 						Base:      &baseRef,
 						CallType:  record.CTSaveAsChild,
 						Caller:    callerRef,
@@ -544,6 +550,7 @@ func TestLogicExecutor_ExecuteConstructor(t *testing.T) {
 			mocks: func(ctx context.Context, mc minimock.Tester) (LogicExecutor, *common.Transcript) {
 				tr := &common.Transcript{
 					Request: &record.IncomingRequest{
+						Object:    &objectRef,
 						Base:      &baseRef,
 						CallType:  record.CTSaveAsChild,
 						Caller:    callerRef,
@@ -578,6 +585,7 @@ func TestLogicExecutor_ExecuteConstructor(t *testing.T) {
 			mocks: func(ctx context.Context, mc minimock.Tester) (LogicExecutor, *common.Transcript) {
 				tr := &common.Transcript{
 					Request: &record.IncomingRequest{
+						Object:    &objectRef,
 						Base:      &baseRef,
 						CallType:  record.CTSaveAsChild,
 						Caller:    gen.Reference(),
@@ -604,6 +612,7 @@ func TestLogicExecutor_ExecuteConstructor(t *testing.T) {
 			mocks: func(ctx context.Context, mc minimock.Tester) (LogicExecutor, *common.Transcript) {
 				tr := &common.Transcript{
 					Request: &record.IncomingRequest{
+						Object:    &objectRef,
 						CallType:  record.CTSaveAsChild,
 						Caller:    gen.Reference(),
 						Prototype: &protoRef,
@@ -624,6 +633,7 @@ func TestLogicExecutor_ExecuteConstructor(t *testing.T) {
 			mocks: func(ctx context.Context, mc minimock.Tester) (LogicExecutor, *common.Transcript) {
 				tr := &common.Transcript{
 					Request: &record.IncomingRequest{
+						Object:    &objectRef,
 						CallType:  record.CTSaveAsChild,
 						Caller:    gen.Reference(),
 						Prototype: nil,

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -143,9 +143,11 @@ func (suite *LogicRunnerTestSuite) AfterTest(suiteName, testName string) {
 }
 
 func (suite *LogicRunnerTestSuite) TestSagaCallAcceptNotificationHandler() {
+	objectRef := gen.Reference()
 	outgoing := record.OutgoingRequest{
 		Caller:     gen.Reference(),
-		Reason:     gen.Reference(),
+		Reason:     gen.RecordReference(),
+		Object:     &objectRef,
 		ReturnMode: record.ReturnSaga,
 	}
 	virtual := record.Wrap(&outgoing)

--- a/logicrunner/outgoingsender_test.go
+++ b/logicrunner/outgoingsender_test.go
@@ -39,7 +39,7 @@ func randomOutgoingRequest() *record.OutgoingRequest {
 		Method:          "RandomMethodName",
 		Arguments:       arguments,
 		APIRequestID:    "dummy-api-request-id",
-		Reason:          gen.Reference(),
+		Reason:          gen.RecordReference(),
 	}
 	return outgoing
 }
@@ -146,7 +146,7 @@ func TestOutgoingSenderSendAbandonedOutgoing(t *testing.T) {
 	outgoing := randomOutgoingRequest()
 	msg := sendAbandonedOutgoingRequestMessage{
 		ctx:              context.Background(),
-		requestReference: gen.Reference(),
+		requestReference: gen.RecordReference(),
 		outgoingRequest:  outgoing,
 	}
 

--- a/logicrunner/preprocessor/main.go
+++ b/logicrunner/preprocessor/main.go
@@ -469,7 +469,7 @@ func (pf *ParsedFile) WriteProxy(classReference string, out io.Writer) error {
 	}
 
 	if classReference == "" {
-		classReference = genesisrefs.GenerateFromCode(0, pf.code).String()
+		classReference = genesisrefs.GenerateProtoReferenceFromCode(0, pf.code).String()
 	}
 
 	_, err = insolar.NewReferenceFromBase58(classReference)
@@ -943,8 +943,8 @@ func generateContractList(contracts ContractList) interface{} {
 			"Name":               contract.Name,
 			"ImportName":         contract.Name,
 			"ImportPath":         contract.ImportPath,
-			"CodeReference":      genesisrefs.GenerateFromContractID(CodeType, contract.Name, contract.Version).String(),
-			"PrototypeReference": genesisrefs.GenerateFromContractID(PrototypeType, contract.Name, contract.Version).String(),
+			"CodeReference":      genesisrefs.GenerateCodeReferenceFromContractID(CodeType, contract.Name, contract.Version).String(),
+			"PrototypeReference": genesisrefs.GenerateProtoReferenceFromContractID(PrototypeType, contract.Name, contract.Version).String(),
 		}
 		importList = append(importList, data)
 	}

--- a/logicrunner/preprocessor/templates/initialization.go.tpl
+++ b/logicrunner/preprocessor/templates/initialization.go.tpl
@@ -83,7 +83,7 @@ func InitializePrototypeDescriptors() []XXX_artifacts.ObjectDescriptor {
             /* isPrototype:  */ true,
             /* childPointer: */ nil,
             /* memory:       */ nil,
-            /* parent:       */ XXX_rootdomain.RootDomain.Ref(),
+            /* parent:       */ XXX_rootdomain.RootDomain.Reference(),
         ))
     }
     {{ end }}

--- a/logicrunner/preprocessor/templates/proxy.go.tpl
+++ b/logicrunner/preprocessor/templates/proxy.go.tpl
@@ -72,7 +72,10 @@ func (r *ContractConstructorHolder) AsChild(objRef insolar.Reference) (*{{ .Cont
 }
 
 // GetObject returns proxy object
-func GetObject(ref insolar.Reference) (r *{{ .ContractType }}) {
+func GetObject(ref insolar.Reference) *{{ .ContractType }} {
+    if !ref.IsObjectReference() {
+        return nil
+    }
 	return &{{ .ContractType }}{Reference: ref}
 }
 

--- a/logicrunner/requestresult/requestresult.go
+++ b/logicrunner/requestresult/requestresult.go
@@ -1,4 +1,4 @@
-///
+//
 // Copyright 2019 Insolar Technologies GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-///
+//
 
 package requestresult
 

--- a/logicrunner/requestsfetcher_test.go
+++ b/logicrunner/requestsfetcher_test.go
@@ -36,6 +36,8 @@ func TestRequestsFetcher_New(t *testing.T) {
 }
 
 func TestRequestsFetcher_FetchPendings(t *testing.T) {
+	objectRef := gen.Reference()
+
 	tests := []struct {
 		name  string
 		mocks func(t minimock.Tester) (insolar.Reference, artifacts.Client, ExecutionBrokerI)
@@ -47,7 +49,7 @@ func TestRequestsFetcher_FetchPendings(t *testing.T) {
 				reqRef := gen.Reference()
 				am := artifacts.NewClientMock(t).
 					GetPendingsMock.Return([]insolar.Reference{reqRef}, nil).
-					GetAbandonedRequestMock.Return(&record.IncomingRequest{}, nil)
+					GetAbandonedRequestMock.Return(&record.IncomingRequest{Object: &objectRef}, nil)
 				broker := NewExecutionBrokerIMock(t).
 					IsKnownRequestMock.Return(false).
 					AddRequestsFromLedgerMock.Return()

--- a/logicrunner/requestsfetcher_test.go
+++ b/logicrunner/requestsfetcher_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/gen"
-	"github.com/insolar/insolar/insolar/record"
 	"github.com/insolar/insolar/instrumentation/inslogger"
 	"github.com/insolar/insolar/logicrunner/artifacts"
 )
@@ -36,8 +35,6 @@ func TestRequestsFetcher_New(t *testing.T) {
 }
 
 func TestRequestsFetcher_FetchPendings(t *testing.T) {
-	objectRef := gen.Reference()
-
 	tests := []struct {
 		name  string
 		mocks func(t minimock.Tester) (insolar.Reference, artifacts.Client, ExecutionBrokerI)
@@ -45,16 +42,19 @@ func TestRequestsFetcher_FetchPendings(t *testing.T) {
 		{
 			name: "success",
 			mocks: func(t minimock.Tester) (insolar.Reference, artifacts.Client, ExecutionBrokerI) {
-				obj := gen.Reference()
-				reqRef := gen.Reference()
+
+				requestRef := gen.RecordReference()
+				incoming := genIncomingRequest()
+
 				am := artifacts.NewClientMock(t).
-					GetPendingsMock.Return([]insolar.Reference{reqRef}, nil).
-					GetAbandonedRequestMock.Return(&record.IncomingRequest{Object: &objectRef}, nil)
+					GetPendingsMock.Return([]insolar.Reference{requestRef}, nil).
+					GetAbandonedRequestMock.Return(incoming, nil)
+
 				broker := NewExecutionBrokerIMock(t).
 					IsKnownRequestMock.Return(false).
 					AddRequestsFromLedgerMock.Return()
 
-				return obj, am, broker
+				return *incoming.Object, am, broker
 			},
 		},
 	}

--- a/logicrunner/rpc_methods.go
+++ b/logicrunner/rpc_methods.go
@@ -189,10 +189,10 @@ func (m *executionProxyImplementation) RouteCall(
 
 	// Step 2. Send the request and register the result (both is done by outgoingSender)
 
-	outgoingReqRef := insolar.NewReference(outReqInfo.RequestID)
+	outgoingReqRef := *outReqInfo.RequestReference()
 
 	var incoming *record.IncomingRequest
-	_, rep.Result, incoming, err = m.outgoingSender.SendOutgoingRequest(ctx, *outgoingReqRef, outgoing)
+	_, rep.Result, incoming, err = m.outgoingSender.SendOutgoingRequest(ctx, outgoingReqRef, outgoing)
 	if incoming != nil {
 		current.AddOutgoingRequest(ctx, *incoming, rep.Result, nil, err)
 	}
@@ -219,9 +219,10 @@ func (m *executionProxyImplementation) SaveAsChild(
 	}
 
 	// Register result of the outgoing method
-	outgoingReqRef := insolar.NewReference(outReqInfo.RequestID)
+	outgoingReqRef := *outReqInfo.RequestReference()
+
 	var incoming *record.IncomingRequest
-	rep.Reference, rep.Result, incoming, err = m.outgoingSender.SendOutgoingRequest(ctx, *outgoingReqRef, outgoing)
+	rep.Reference, rep.Result, incoming, err = m.outgoingSender.SendOutgoingRequest(ctx, outgoingReqRef, outgoing)
 	if incoming != nil {
 		current.AddOutgoingRequest(ctx, *incoming, rep.Result, nil, err)
 	}

--- a/logicrunner/rpc_methods.go
+++ b/logicrunner/rpc_methods.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/insolar/insolar/insolar"
+	"github.com/insolar/insolar/insolar/payload"
 	"github.com/insolar/insolar/insolar/record"
 	"github.com/insolar/insolar/instrumentation/inslogger"
 	"github.com/insolar/insolar/instrumentation/instracer"
@@ -43,6 +44,10 @@ type RPCMethods struct {
 	ss         StateStorage
 	execution  ProxyImplementation
 	validation ProxyImplementation
+}
+
+func getRequestReference(info *payload.RequestInfo) *insolar.Reference {
+	return insolar.NewRecordReference(info.RequestID)
 }
 
 func NewRPCMethods(
@@ -189,7 +194,7 @@ func (m *executionProxyImplementation) RouteCall(
 
 	// Step 2. Send the request and register the result (both is done by outgoingSender)
 
-	outgoingReqRef := *outReqInfo.RequestReference()
+	outgoingReqRef := *getRequestReference(outReqInfo)
 
 	var incoming *record.IncomingRequest
 	_, rep.Result, incoming, err = m.outgoingSender.SendOutgoingRequest(ctx, outgoingReqRef, outgoing)
@@ -219,7 +224,7 @@ func (m *executionProxyImplementation) SaveAsChild(
 	}
 
 	// Register result of the outgoing method
-	outgoingReqRef := *outReqInfo.RequestReference()
+	outgoingReqRef := *getRequestReference(outReqInfo)
 
 	var incoming *record.IncomingRequest
 	rep.Reference, rep.Result, incoming, err = m.outgoingSender.SendOutgoingRequest(ctx, outgoingReqRef, outgoing)

--- a/reference/decoder.go
+++ b/reference/decoder.go
@@ -42,7 +42,7 @@ var defaultDecoder GlobalDecoder
 
 func DefaultDecoder() GlobalDecoder {
 	defaultDecoderOnce.Do(func() {
-		defaultDecoder = NewDefaultDecoder(AllowLegacy & AllowRecords)
+		defaultDecoder = NewDefaultDecoder(AllowLegacy | AllowRecords)
 	})
 	return defaultDecoder
 }

--- a/reference/decoder_test.go
+++ b/reference/decoder_test.go
@@ -319,3 +319,20 @@ func TestDecoder_Decode_aliases(t *testing.T) {
 		}
 	}
 }
+
+func TestCycle(t *testing.T) {
+	inp := "15qwjxArNbE36WiUvT3NRQ9JqyUdW3mCRMBHKY31dJh6"
+
+	var err error
+	dec := NewDefaultDecoder(0)
+	enc := NewBase58Encoder(0)
+
+	gl, err := dec.Decode(inp)
+	assert.NoError(t, err)
+
+	out, err := enc.Encode(&gl)
+	assert.NoError(t, err)
+
+	assert.Equal(t, inp, out)
+
+}

--- a/reference/global.go
+++ b/reference/global.go
@@ -100,6 +100,10 @@ func (v *Global) IsRecordScope() bool {
 	return v.addressBase.IsEmpty() && !v.addressLocal.IsEmpty() && v.addressLocal.getScope() == baseScopeLifeline
 }
 
+func (v *Global) IsObjectReference() bool {
+	return !v.addressBase.IsEmpty() && !v.addressLocal.IsEmpty() && v.addressLocal.getScope() == baseScopeLifeline
+}
+
 func (v *Global) IsSelfScope() bool {
 	return v.addressBase == v.addressLocal
 }


### PR DESCRIPTION
-- Record References are references with zeroed base part (and ends with .record in textual repr)
-- Object References (Local) have left and right part duplicated (and starts with 1 in textual repr)

* Replace Code/Reason/Request references with RecordReferences (all other references should be ObjectReferences)
* Add checks for ObjectReferences/RecordReferences in incoming messages
* Actualize unit+func tests
