### PR TITLE
INS-3293 / INS-3371: stop OutgoingRequestSender

### DIFF
--- a/logicrunner/outgoingsender.go
+++ b/logicrunner/outgoingsender.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/insolar/go-actors/actor"
+	aerr "github.com/insolar/go-actors/actor/errors"
 
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/payload"
@@ -64,6 +65,10 @@ type sendAbandonedOutgoingRequestMessage struct {
 	outgoingRequest  *record.OutgoingRequest // outgoing request body
 }
 
+type stopOutgoingRequestSenderMessage struct {
+	resultChan chan struct{}
+}
+
 func NewOutgoingRequestSender(as actor.System, cr insolar.ContractRequester, am artifacts.Client, pa pulse.Accessor) OutgoingRequestSender {
 	pid := as.Spawn(func(system actor.System, pid actor.Pid) (actor.Actor, int) {
 		state := newOutgoingSenderActorState(cr, am, pa)
@@ -109,9 +114,19 @@ func (rs *outgoingRequestSender) SendAbandonedOutgoingRequest(ctx context.Contex
 	}
 }
 
-func (rs *outgoingRequestSender) Stop(_ context.Context) {
-	// not implemented yet, see INS-3293, INS-3371
-	// rs.as.CloseAll()
+func (rs *outgoingRequestSender) Stop(ctx context.Context) {
+	resultChan := make(chan struct{}, 1)
+	msg := stopOutgoingRequestSenderMessage{
+		resultChan: resultChan,
+	}
+	err := rs.as.SendPriority(rs.senderPid, msg)
+	if err != nil { // this is unlikely to happen
+		inslogger.FromContext(ctx).Errorf("OutgoingRequestSender.Stop failed: %v", err)
+		return
+	}
+
+	// wait for a termination
+	<-resultChan
 }
 
 func newOutgoingSenderActorState(cr insolar.ContractRequester, am artifacts.Client, pa pulse.Accessor) actor.Actor {
@@ -151,6 +166,9 @@ func (a *outgoingSenderActorState) Receive(message actor.Message) (actor.Actor, 
 			inslogger.FromContext(context.Background()).Errorf("OutgoingRequestActor: sendOutgoingRequest failed %v", err)
 		}
 		return a, nil
+	case stopOutgoingRequestSenderMessage:
+		v.resultChan <- struct{}{}
+		return a, aerr.Terminate
 	default:
 		inslogger.FromContext(context.Background()).Errorf("OutgoingRequestActor: unexpected message %v", v)
 		return a, nil

--- a/logicrunner/outgoingsender_test.go
+++ b/logicrunner/outgoingsender_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/insolar/go-actors/actor/errors"
+
 	"github.com/gojuno/minimock"
 
 	"github.com/insolar/insolar/insolar"
@@ -155,4 +157,24 @@ func TestOutgoingSenderSendAbandonedOutgoing(t *testing.T) {
 
 	_, err := sender.Receive(msg)
 	require.NoError(t, err)
+}
+
+func TestOutgoingSenderStop(t *testing.T) {
+	t.Parallel()
+
+	mc := minimock.NewController(t)
+	defer mc.Wait(2 * time.Minute)
+
+	cr := testutils.NewContractRequesterMock(mc)
+	am := artifacts.NewClientMock(mc)
+	pa := pulse.NewAccessorMock(mc)
+
+	sender := newOutgoingSenderActorState(cr, am, pa)
+	resultChan := make(chan struct{}, 1)
+	msg := stopOutgoingRequestSenderMessage{
+		resultChan: resultChan,
+	}
+	_, err := sender.Receive(msg)
+	<-resultChan
+	require.Equal(t, errors.Terminate, err)
 }

--- a/logicrunner/rpc_methods_test.go
+++ b/logicrunner/rpc_methods_test.go
@@ -354,8 +354,9 @@ func TestRouteCallRegistersOutgoingRequestWithValidReason(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, outreq)
 	require.Equal(t, requestRef, outreq.Reason)
-	// not implemented yet, see INS-3293 / INS-3371 AALEKSEEV
-	// as.CloseAll()
+
+	os.Stop(ctx)
+	as.AwaitTermination()
 }
 
 func TestRouteCallRegistersSaga(t *testing.T) {

--- a/logicrunner/rpc_methods_test.go
+++ b/logicrunner/rpc_methods_test.go
@@ -354,7 +354,7 @@ func TestRouteCallRegistersOutgoingRequestWithValidReason(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, outreq)
 	require.Equal(t, requestRef, outreq.Reason)
-	// not implemented yet, see INS-3293 / INS-3371
+	// not implemented yet, see INS-3293 / INS-3371 AALEKSEEV
 	// as.CloseAll()
 }
 


### PR DESCRIPTION
How to  test:

```
$ INSOLAR_LOG_LEVEL=warn go test ./logicrunner -run '^TestLogicRunner/TestConcurrency$' -count=10000 -race -v &>2
$ cat 2 | grep 'go-actors/actor/mailbox/mailbox.go' | wc -l
0
```