### PR TITLE
NOISSUE: fix Gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -808,6 +808,7 @@
     "github.com/grpc-ecosystem/grpc-gateway/runtime",
     "github.com/grpc-ecosystem/grpc-gateway/utilities",
     "github.com/insolar/go-actors/actor",
+    "github.com/insolar/go-actors/actor/errors",
     "github.com/insolar/go-actors/actor/system",
     "github.com/insolar/rpc/v2",
     "github.com/insolar/rpc/v2/json2",


### PR DESCRIPTION
`dep ensure` adds this single line to Gopkg.lock which is a little annoying. 