### PR TITLE
INS-3468: add `nil` checks in TestChangeLogLevelOk / TestChangeLogLev…

### DIFF
--- a/functest/change_loglevel_test.go
+++ b/functest/change_loglevel_test.go
@@ -31,12 +31,8 @@ import (
 func TestChangeLogLevelOk(t *testing.T) {
 	url := launchnet.HostDebug + "/debug/loglevel?level=debug"
 	resp, err := http.Get(url)
-	defer func() {
-		if resp != nil {
-			resp.Body.Close() //nolint: errcheck
-		}
-	}()
 	require.NoError(t, err)
+	defer resp.Body.Close() //nolint: errcheck
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	resBody, err := ioutil.ReadAll(resp.Body)
 	require.Nil(t, err)
@@ -46,11 +42,7 @@ func TestChangeLogLevelOk(t *testing.T) {
 func TestChangeLogLevelFail(t *testing.T) {
 	url := launchnet.HostDebug + "/debug/loglevel?level=ololo"
 	resp, err := http.Get(url)
-	defer func() {
-		if resp != nil {
-			resp.Body.Close() //nolint: errcheck
-		}
-	}()
 	require.NoError(t, err)
+	defer resp.Body.Close() //nolint: errcheck
 	require.NotEqual(t, http.StatusOK, resp.StatusCode)
 }

--- a/functest/change_loglevel_test.go
+++ b/functest/change_loglevel_test.go
@@ -31,7 +31,11 @@ import (
 func TestChangeLogLevelOk(t *testing.T) {
 	url := launchnet.HostDebug + "/debug/loglevel?level=debug"
 	resp, err := http.Get(url)
-	defer resp.Body.Close()
+	defer func() {
+		if resp != nil {
+			resp.Body.Close() //nolint: errcheck
+		}
+	}()
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	resBody, err := ioutil.ReadAll(resp.Body)
@@ -42,7 +46,11 @@ func TestChangeLogLevelOk(t *testing.T) {
 func TestChangeLogLevelFail(t *testing.T) {
 	url := launchnet.HostDebug + "/debug/loglevel?level=ololo"
 	resp, err := http.Get(url)
-	defer resp.Body.Close()
+	defer func() {
+		if resp != nil {
+			resp.Body.Close() //nolint: errcheck
+		}
+	}()
 	require.NoError(t, err)
 	require.NotEqual(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
Sometimes `http.Get(url)` can return an error and `nil` response. This patch makes tests more robust, preventing zero pointer dereference.