### PR TITLE
INS-3449: Reason and APINode are mutually exclusive, now

### DIFF
--- a/api/call_test.go
+++ b/api/call_test.go
@@ -122,7 +122,7 @@ func TestTimeoutSuite(t *testing.T) {
 	timeoutSuite.api.timeout = 1 * time.Second
 
 	cr := testutils.NewContractRequesterMock(timeoutSuite.mc)
-	cr.SendRequestMock.Set(func(p context.Context, p1 *insolar.Reference, method string, p3 []interface{}, p4 insolar.PulseNumber) (insolar.Reply, *insolar.Reference, error) {
+	cr.CallMock.Set(func(p context.Context, p1 *insolar.Reference, method string, p3 []interface{}, p4 insolar.PulseNumber) (insolar.Reply, *insolar.Reference, error) {
 		requestReference, _ := insolar.NewReferenceFromBase58("14K3NiGuqYGqKPnYp6XeGd2kdN4P9veL6rYcWkLKWXZCu.14FFB8zfQoGznSmzDxwv4njX1aR9ioL8GHSH17QXH2AFa")
 		switch method {
 		case "GetPublicKey":

--- a/api/contract.go
+++ b/api/contract.go
@@ -75,7 +75,7 @@ func (ar *Runner) checkSeed(paramsSeed string) (insolar.PulseNumber, error) {
 }
 
 func (ar *Runner) makeCall(ctx context.Context, method string, params requester.Params, rawBody []byte, signature string, seedPulse insolar.PulseNumber) (interface{}, *insolar.Reference, error) {
-	ctx, span := instracer.StartSpan(ctx, "SendRequest "+method)
+	ctx, span := instracer.StartSpan(ctx, "Call "+method)
 	defer span.End()
 
 	reference, err := insolar.NewReferenceFromBase58(params.Reference)
@@ -88,7 +88,7 @@ func (ar *Runner) makeCall(ctx context.Context, method string, params requester.
 		return nil, nil, errors.Wrap(err, "failed to marshal arguments")
 	}
 
-	res, ref, err := ar.ContractRequester.SendRequest(
+	res, ref, err := ar.ContractRequester.Call(
 		ctx,
 		reference,
 		"Call",

--- a/contractrequester/contractrequester_test.go
+++ b/contractrequester/contractrequester_test.go
@@ -164,7 +164,7 @@ func TestContractRequester_SendRequest(t *testing.T) {
 					}
 				})
 
-			result, _, err := cReq.SendRequest(ctx, &ref, "TestMethod", []interface{}{}, insolar.GenesisPulse.PulseNumber)
+			result, _, err := cReq.Call(ctx, &ref, "TestMethod", []interface{}{}, insolar.GenesisPulse.PulseNumber)
 			require.NoError(t, err)
 			require.Equal(t, &reply.CallMethod{}, result)
 		})
@@ -228,7 +228,7 @@ func TestContractRequester_Call_Timeout(t *testing.T) {
 		Request: request,
 	}
 
-	_, _, err = cReq.Call(ctx, msg)
+	_, _, err = cReq.SendRequest(ctx, msg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "canceled")
 	require.Contains(t, err.Error(), "timeout")

--- a/functest/logicrunner_test.go
+++ b/functest/logicrunner_test.go
@@ -1783,7 +1783,8 @@ func (r *Two) NoWaitGet(OneRef insolar.Reference) (int, error) {
 	contractTwoRef := uploadContractOnce(t, "second_nowait_contract", contractTwoCode)
 
 	anon := func() api.CallMethodReply { return callMethod(t, firstObjRef, "Get") }
-	firstResultAfterWait, _ := waitUntilRequestProcessed(anon, time.Second+10, time.Millisecond+50, 10)
+	firstResultAfterWait, err := waitUntilRequestProcessed(anon, time.Second+10, time.Millisecond+50, 10)
+	require.NoError(t, err)
 	require.Equal(t, float64(n), firstResultAfterWait.ExtractedReply)
 
 	t.Run("one object, sequential calls", func(t *testing.T) {

--- a/insolar/contractrequester.go
+++ b/insolar/contractrequester.go
@@ -29,6 +29,6 @@ type Payload interface {
 
 // ContractRequester is the global contract requester handler. Other system parts communicate with contract requester through it.
 type ContractRequester interface {
-	Call(ctx context.Context, msg Payload) (Reply, *Reference, error)
-	SendRequest(ctx context.Context, ref *Reference, method string, argsIn []interface{}, pulse PulseNumber) (Reply, *Reference, error)
+	SendRequest(ctx context.Context, msg Payload) (Reply, *Reference, error)
+	Call(ctx context.Context, ref *Reference, method string, argsIn []interface{}, pulse PulseNumber) (Reply, *Reference, error)
 }

--- a/ledger/light/proc/set_request_test.go
+++ b/ledger/light/proc/set_request_test.go
@@ -75,7 +75,6 @@ func TestSetRequest_Proceed(t *testing.T) {
 	request := record.IncomingRequest{
 		Object:   &ref,
 		CallType: record.CTMethod,
-		// APINode:  gen.Reference(),
 	}
 	virtual := record.Virtual{
 		Union: &record.Virtual_IncomingRequest{

--- a/logicrunner/goplugin/goplugintestutils/utils.go
+++ b/logicrunner/goplugin/goplugintestutils/utils.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/insolar/insolar/insolar"
-	"github.com/insolar/insolar/insolar/api"
 	"github.com/insolar/insolar/insolar/flow"
 	"github.com/insolar/insolar/insolar/gen"
 	"github.com/insolar/insolar/insolar/jet"
@@ -113,15 +112,11 @@ func (cb *ContractsBuilder) Build(ctx context.Context, contracts map[string]stri
 
 	for name := range contracts {
 		nonce := gen.Reference()
-		pulse, err := cb.pulseAccessor.Latest(ctx)
-		if err != nil {
-			return errors.Wrap(err, "can't get current pulse")
-		}
 		request := record.IncomingRequest{
 			CallType:  record.CTDeployPrototype,
 			Prototype: &nonce,
-			Reason:    api.MakeReason(pulse.PulseNumber, []byte(name)),
-			APINode:   cb.jetCoordinator.Me(),
+
+			APINode: cb.jetCoordinator.Me(),
 		}
 		protoID, err := cb.registerRequest(ctx, &request)
 

--- a/logicrunner/handle_init.go
+++ b/logicrunner/handle_init.go
@@ -216,8 +216,6 @@ func checkOutgoingRequest(ctx context.Context, request *record.OutgoingRequest) 
 }
 
 func checkIncomingRequest(ctx context.Context, request *record.IncomingRequest) error {
-	logger := inslogger.FromContext(ctx)
-
 	if !request.Caller.IsEmpty() && !request.Caller.IsObjectReference() {
 		return errors.Errorf("request.Caller should be ObjectReference; ref=%s", request.Caller.String())
 	}
@@ -244,12 +242,7 @@ func checkIncomingRequest(ctx context.Context, request *record.IncomingRequest) 
 			aStr = "APINode is not empty"
 		}
 
-		msg := fmt.Sprintf("failed to check request reason: one should be set, but %s and %s", rStr, aStr)
-		if !rEmpty && !aEmpty {
-			logger.Warn(msg)
-		} else {
-			return errors.Errorf(msg)
-		}
+		return errors.Errorf("failed to check request reason: one should be set, but %s and %s", rStr, aStr)
 	}
 
 	if !request.Reason.IsEmpty() && !request.Reason.IsRecordScope() {

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -180,7 +180,7 @@ func (suite *LogicRunnerTestSuite) TestSagaCallAcceptNotificationHandler() {
 	var usedReason insolar.Reference
 	var usedReturnMode record.ReturnMode
 
-	suite.cr.CallMock.Set(func(ctx context.Context, msg insolar.Payload) (insolar.Reply, *insolar.Reference, error) {
+	suite.cr.SendRequestMock.Set(func(ctx context.Context, msg insolar.Payload) (insolar.Reply, *insolar.Reference, error) {
 		_, ok := msg.(*payload.CallMethod)
 		suite.Require().True(ok, "message should be payload.CallMethod")
 		cm := msg.(*payload.CallMethod)

--- a/logicrunner/outgoingsender.go
+++ b/logicrunner/outgoingsender.go
@@ -187,7 +187,7 @@ func (a *outgoingSenderActorState) sendOutgoingRequest(ctx context.Context, outg
 	}
 	// Actually make a call.
 	callMsg := &payload.CallMethod{Request: incoming, PulseNumber: latestPulse.PulseNumber}
-	res, _, err := a.cr.Call(ctx, callMsg)
+	res, _, err := a.cr.SendRequest(ctx, callMsg)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/logicrunner/outgoingsender_test.go
+++ b/logicrunner/outgoingsender_test.go
@@ -81,7 +81,7 @@ func TestOutgoingSenderSendRegularOutgoing(t *testing.T) {
 		resultChan:       resultChan,
 	}
 
-	cr.CallMock.Return(&reply.CallMethod{}, insolar.NewEmptyReference(), nil)
+	cr.SendRequestMock.Return(&reply.CallMethod{}, insolar.NewEmptyReference(), nil)
 	am.RegisterResultMock.Return(nil)
 
 	_, err := sender.Receive(msg)
@@ -120,7 +120,7 @@ func TestOutgoingSenderSendSagaOutgoing(t *testing.T) {
 		resultChan:       resultChan,
 	}
 
-	cr.CallMock.Return(&reply.CallMethod{}, insolar.NewEmptyReference(), nil)
+	cr.SendRequestMock.Return(&reply.CallMethod{}, insolar.NewEmptyReference(), nil)
 	am.RegisterResultMock.Return(nil)
 
 	_, err := sender.Receive(msg)
@@ -152,7 +152,7 @@ func TestOutgoingSenderSendAbandonedOutgoing(t *testing.T) {
 		outgoingRequest:  outgoing,
 	}
 
-	cr.CallMock.Return(&reply.CallMethod{}, insolar.NewEmptyReference(), nil)
+	cr.SendRequestMock.Return(&reply.CallMethod{}, insolar.NewEmptyReference(), nil)
 	am.RegisterResultMock.Return(nil)
 
 	_, err := sender.Receive(msg)

--- a/logicrunner/rpc_methods_test.go
+++ b/logicrunner/rpc_methods_test.go
@@ -346,7 +346,7 @@ func TestRouteCallRegistersOutgoingRequestWithValidReason(t *testing.T) {
 	})
 
 	ref := gen.Reference()
-	cr.CallMock.Return(&reply.CallMethod{}, &ref, nil)
+	cr.SendRequestMock.Return(&reply.CallMethod{}, &ref, nil)
 	// Make sure the result of the outgoing request is registered as well
 	am.RegisterResultMock.Set(func(ctx context.Context, reqref insolar.Reference, result artifacts.RequestResult) (r error) {
 		if outgoingReqRef != reqref {

--- a/network/gateway/complete.go
+++ b/network/gateway/complete.go
@@ -165,7 +165,7 @@ func (g *Complete) getNodeInfo(ctx context.Context, nodeRef *insolar.Reference) 
 		return "", "", errors.Wrap(err, "[ GetCert ] Can't get latest pulse")
 	}
 
-	res, _, err := g.ContractRequester.SendRequest(
+	res, _, err := g.ContractRequester.Call(
 		ctx, nodeRef, "GetNodeInfo", []interface{}{}, latest.PulseNumber,
 	)
 	if err != nil {

--- a/network/gateway/complete_test.go
+++ b/network/gateway/complete_test.go
@@ -123,7 +123,7 @@ func mockReply(t *testing.T) []byte {
 
 func mockContractRequester(t *testing.T, nodeRef insolar.Reference, ok bool, r []byte) insolar.ContractRequester {
 	cr := testutils.NewContractRequesterMock(t)
-	cr.SendRequestMock.Set(func(ctx context.Context, ref *insolar.Reference, method string, argsIn []interface{}, p insolar.PulseNumber) (r1 insolar.Reply, r2 *insolar.Reference, err error) {
+	cr.CallMock.Set(func(ctx context.Context, ref *insolar.Reference, method string, argsIn []interface{}, p insolar.PulseNumber) (r1 insolar.Reply, r2 *insolar.Reference, err error) {
 		require.Equal(t, nodeRef, *ref)
 		require.Equal(t, "GetNodeInfo", method)
 		require.Equal(t, 0, len(argsIn))

--- a/network/gateway/gateway_test.go
+++ b/network/gateway/gateway_test.go
@@ -162,7 +162,7 @@ func TestDumbComplete_GetCert(t *testing.T) {
 
 	cref := gen.Reference()
 
-	CR.SendRequestMock.Set(func(ctx context.Context, ref *insolar.Reference, method string, argsIn []interface{}, p insolar.PulseNumber,
+	CR.CallMock.Set(func(ctx context.Context, ref *insolar.Reference, method string, argsIn []interface{}, p insolar.PulseNumber,
 	) (r insolar.Reply, r2 *insolar.Reference, r1 error) {
 		require.Equal(t, &cref, ref)
 		require.Equal(t, "GetNodeInfo", method)


### PR DESCRIPTION
* ContractRequester methods are renamed: Call -> SendRequest,
  SendRequest -> Call
* Returned back check for Reason/APINode