### PR TITLE
INS-3465: return err.Error() in json2.Error.Message

### DIFF
--- a/api/call_wrapper.go
+++ b/api/call_wrapper.go
@@ -134,7 +134,7 @@ func wrapCall(runner *Runner, allowedMethods map[string]bool, req *http.Request,
 
 		return &json2.Error{
 			Code:    ExecutionError,
-			Message: ExecutionErrorMessage,
+			Message: ExecutionErrorMessage + "; ERROR: " + err.Error(),
 			Data: requester.Data{
 				Trace:            strings.Split(err.Error(), ": "),
 				TraceID:          traceID,


### PR DESCRIPTION
Return err.Error() in json2.Error.Message, otherwise the real failure is hidden during execution of tests.