### PR TITLE
NOISSUE: fix bug re bad PendingFinished and StillExecution messages

### DIFF
--- a/logicrunner/artifacts/client.go
+++ b/logicrunner/artifacts/client.go
@@ -264,7 +264,7 @@ func (m *client) GetObject(
 		instrumenter.end()
 	}()
 
-	logger := inslogger.FromContext(ctx).WithField("object", head.GetLocal().DebugString())
+	logger := inslogger.FromContext(ctx).WithField("object", head.GetLocal().String())
 
 	msg, err := payload.NewMessage(&payload.GetObject{
 		ObjectID: *head.GetLocal(),

--- a/logicrunner/common/queue.go
+++ b/logicrunner/common/queue.go
@@ -8,19 +8,25 @@ import (
 )
 
 func ConvertQueueToMessageQueue(ctx context.Context, queue []*Transcript) []*payload.ExecutionQueueElement {
+	logger := inslogger.FromContext(ctx)
+
 	mq := make([]*payload.ExecutionQueueElement, 0)
 	var traces string
-	for _, elem := range queue {
-		mq = append(mq, &payload.ExecutionQueueElement{
-			RequestRef:  elem.RequestRef,
-			Incoming:    elem.Request,
-			ServiceData: ServiceDataFromContext(elem.Context),
-		})
+	if len(queue) > 0 {
+		for _, elem := range queue {
+			mq = append(mq, &payload.ExecutionQueueElement{
+				RequestRef:  elem.RequestRef,
+				Incoming:    elem.Request,
+				ServiceData: ServiceDataFromContext(elem.Context),
+			})
 
-		traces += inslogger.TraceID(elem.Context) + ", "
+			traces += inslogger.TraceID(elem.Context) + ", "
+		}
+
+		logger.Debug("ConvertQueueToMessageQueue: ", traces)
+	} else {
+		logger.Debug("ConvertQueueToMessageQueue: empty queue ")
 	}
-
-	inslogger.FromContext(ctx).Debug("ConvertQueueToMessageQueue: ", traces)
 
 	return mq
 }

--- a/logicrunner/common/transcript.go
+++ b/logicrunner/common/transcript.go
@@ -24,7 +24,6 @@ type Transcript struct {
 	Nonce            uint64
 	Deactivate       bool
 	OutgoingRequests []OutgoingRequest
-	FromLedger       bool
 }
 
 func NewTranscript(
@@ -39,8 +38,6 @@ func NewTranscript(
 		RequestRef: requestRef,
 		Nonce:      0,
 		Deactivate: false,
-
-		FromLedger: false,
 	}
 }
 

--- a/logicrunner/executionregistry/execution_registry.go
+++ b/logicrunner/executionregistry/execution_registry.go
@@ -118,7 +118,7 @@ func (r *executionRegistry) OnPulse(_ context.Context) []payload.Payload {
 	messages := make([]payload.Payload, 0)
 	if len(r.registry) != 0 {
 		requestRefs := make([]insolar.Reference, 0, len(r.registry))
-		for requestRef, _ := range r.registry {
+		for requestRef := range r.registry {
 			requestRefs = append(requestRefs, requestRef)
 		}
 

--- a/logicrunner/executionregistry/execution_registry.go
+++ b/logicrunner/executionregistry/execution_registry.go
@@ -118,7 +118,7 @@ func (r *executionRegistry) OnPulse(_ context.Context) []payload.Payload {
 	messages := make([]payload.Payload, 0)
 	if len(r.registry) != 0 {
 		requestRefs := make([]insolar.Reference, 0, len(r.registry))
-		for requestRef := range r.registry {
+		for requestRef, _ := range r.registry {
 			requestRefs = append(requestRefs, requestRef)
 		}
 

--- a/logicrunner/handle_still_executing.go
+++ b/logicrunner/handle_still_executing.go
@@ -64,8 +64,11 @@ func (h *HandleStillExecuting) Present(ctx context.Context, f flow.Flow) error {
 		return errors.Wrap(err, "failed to unmarshal message")
 	}
 
-	ctx, logger := inslogger.WithField(ctx, "object", message.ObjectRef.String())
-	logger.Debug("handling still executing message")
+	ctx, logger := inslogger.WithFields(ctx, map[string]interface{}{
+		"object": message.ObjectRef.String(),
+		"sender": h.Message.Sender.String(),
+	})
+	logger.Debug("handle StillExecuting message")
 
 	if err := checkPayloadStillExecuting(message); err != nil {
 		return nil
@@ -73,7 +76,7 @@ func (h *HandleStillExecuting) Present(ctx context.Context, f flow.Flow) error {
 
 	done, err := h.dep.WriteAccessor.Begin(ctx, flow.Pulse(ctx))
 	if err != nil {
-		logger.Warn("late still executing message, ignoring: ", err.Error())
+		logger.Warn("late StillExecuting message, ignoring: ", err.Error())
 		return nil
 	}
 	defer done()

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -533,13 +533,18 @@ func TestLogicRunner_OnPulse_Order(t *testing.T) {
 }
 
 func (suite *LogicRunnerTestSuite) TestImmutableOrder() {
+	pa := insolarPulse.NewAccessorMock(suite.mc).LatestMock.Return(
+		insolar.Pulse{PulseNumber: pulse.MinTimePulse},
+		nil,
+	)
+
 	er := executionregistry.NewExecutionRegistryMock(suite.mc).
 		RegisterMock.Return(nil).
 		DoneMock.Return(true)
 
 	// prepare default object and execution state
 	objectRef := gen.Reference()
-	broker := NewExecutionBroker(objectRef, nil, suite.re, nil, nil, er, nil, nil)
+	broker := NewExecutionBroker(objectRef, nil, suite.re, nil, nil, er, nil, pa)
 	broker.pending = insolar.NotPending
 
 	// prepare request objects
@@ -596,7 +601,6 @@ func (suite *LogicRunnerTestSuite) TestImmutableOrder() {
 			log.Debug("mutableChan 1")
 			select {
 			case _ = <-mutableChan:
-
 				log.Info("mutable got notifications")
 				return &reply.CallMethod{Result: []byte{1, 2, 3}}, nil
 			case <-time.After(2 * time.Minute):

--- a/logicrunner/requestsqueue/requests_queue_mock.go
+++ b/logicrunner/requestsqueue/requests_queue_mock.go
@@ -28,6 +28,12 @@ type RequestsQueueMock struct {
 	beforeCleanCounter uint64
 	CleanMock          mRequestsQueueMockClean
 
+	funcLength          func() (i1 int)
+	inspectFuncLength   func()
+	afterLengthCounter  uint64
+	beforeLengthCounter uint64
+	LengthMock          mRequestsQueueMockLength
+
 	funcNumberOfOld          func(ctx context.Context) (i1 int)
 	inspectFuncNumberOfOld   func(ctx context.Context)
 	afterNumberOfOldCounter  uint64
@@ -59,6 +65,8 @@ func NewRequestsQueueMock(t minimock.Tester) *RequestsQueueMock {
 
 	m.CleanMock = mRequestsQueueMockClean{mock: m}
 	m.CleanMock.callArgs = []*RequestsQueueMockCleanParams{}
+
+	m.LengthMock = mRequestsQueueMockLength{mock: m}
 
 	m.NumberOfOldMock = mRequestsQueueMockNumberOfOld{mock: m}
 	m.NumberOfOldMock.callArgs = []*RequestsQueueMockNumberOfOldParams{}
@@ -445,6 +453,149 @@ func (m *RequestsQueueMock) MinimockCleanInspect() {
 	// if func was set then invocations count should be greater than zero
 	if m.funcClean != nil && mm_atomic.LoadUint64(&m.afterCleanCounter) < 1 {
 		m.t.Error("Expected call to RequestsQueueMock.Clean")
+	}
+}
+
+type mRequestsQueueMockLength struct {
+	mock               *RequestsQueueMock
+	defaultExpectation *RequestsQueueMockLengthExpectation
+	expectations       []*RequestsQueueMockLengthExpectation
+}
+
+// RequestsQueueMockLengthExpectation specifies expectation struct of the RequestsQueue.Length
+type RequestsQueueMockLengthExpectation struct {
+	mock *RequestsQueueMock
+
+	results *RequestsQueueMockLengthResults
+	Counter uint64
+}
+
+// RequestsQueueMockLengthResults contains results of the RequestsQueue.Length
+type RequestsQueueMockLengthResults struct {
+	i1 int
+}
+
+// Expect sets up expected params for RequestsQueue.Length
+func (mmLength *mRequestsQueueMockLength) Expect() *mRequestsQueueMockLength {
+	if mmLength.mock.funcLength != nil {
+		mmLength.mock.t.Fatalf("RequestsQueueMock.Length mock is already set by Set")
+	}
+
+	if mmLength.defaultExpectation == nil {
+		mmLength.defaultExpectation = &RequestsQueueMockLengthExpectation{}
+	}
+
+	return mmLength
+}
+
+// Inspect accepts an inspector function that has same arguments as the RequestsQueue.Length
+func (mmLength *mRequestsQueueMockLength) Inspect(f func()) *mRequestsQueueMockLength {
+	if mmLength.mock.inspectFuncLength != nil {
+		mmLength.mock.t.Fatalf("Inspect function is already set for RequestsQueueMock.Length")
+	}
+
+	mmLength.mock.inspectFuncLength = f
+
+	return mmLength
+}
+
+// Return sets up results that will be returned by RequestsQueue.Length
+func (mmLength *mRequestsQueueMockLength) Return(i1 int) *RequestsQueueMock {
+	if mmLength.mock.funcLength != nil {
+		mmLength.mock.t.Fatalf("RequestsQueueMock.Length mock is already set by Set")
+	}
+
+	if mmLength.defaultExpectation == nil {
+		mmLength.defaultExpectation = &RequestsQueueMockLengthExpectation{mock: mmLength.mock}
+	}
+	mmLength.defaultExpectation.results = &RequestsQueueMockLengthResults{i1}
+	return mmLength.mock
+}
+
+//Set uses given function f to mock the RequestsQueue.Length method
+func (mmLength *mRequestsQueueMockLength) Set(f func() (i1 int)) *RequestsQueueMock {
+	if mmLength.defaultExpectation != nil {
+		mmLength.mock.t.Fatalf("Default expectation is already set for the RequestsQueue.Length method")
+	}
+
+	if len(mmLength.expectations) > 0 {
+		mmLength.mock.t.Fatalf("Some expectations are already set for the RequestsQueue.Length method")
+	}
+
+	mmLength.mock.funcLength = f
+	return mmLength.mock
+}
+
+// Length implements RequestsQueue
+func (mmLength *RequestsQueueMock) Length() (i1 int) {
+	mm_atomic.AddUint64(&mmLength.beforeLengthCounter, 1)
+	defer mm_atomic.AddUint64(&mmLength.afterLengthCounter, 1)
+
+	if mmLength.inspectFuncLength != nil {
+		mmLength.inspectFuncLength()
+	}
+
+	if mmLength.LengthMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmLength.LengthMock.defaultExpectation.Counter, 1)
+
+		results := mmLength.LengthMock.defaultExpectation.results
+		if results == nil {
+			mmLength.t.Fatal("No results are set for the RequestsQueueMock.Length")
+		}
+		return (*results).i1
+	}
+	if mmLength.funcLength != nil {
+		return mmLength.funcLength()
+	}
+	mmLength.t.Fatalf("Unexpected call to RequestsQueueMock.Length.")
+	return
+}
+
+// LengthAfterCounter returns a count of finished RequestsQueueMock.Length invocations
+func (mmLength *RequestsQueueMock) LengthAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmLength.afterLengthCounter)
+}
+
+// LengthBeforeCounter returns a count of RequestsQueueMock.Length invocations
+func (mmLength *RequestsQueueMock) LengthBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmLength.beforeLengthCounter)
+}
+
+// MinimockLengthDone returns true if the count of the Length invocations corresponds
+// the number of defined expectations
+func (m *RequestsQueueMock) MinimockLengthDone() bool {
+	for _, e := range m.LengthMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	// if default expectation was set then invocations count should be greater than zero
+	if m.LengthMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterLengthCounter) < 1 {
+		return false
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcLength != nil && mm_atomic.LoadUint64(&m.afterLengthCounter) < 1 {
+		return false
+	}
+	return true
+}
+
+// MinimockLengthInspect logs each unmet expectation
+func (m *RequestsQueueMock) MinimockLengthInspect() {
+	for _, e := range m.LengthMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Error("Expected call to RequestsQueueMock.Length")
+		}
+	}
+
+	// if default expectation was set then invocations count should be greater than zero
+	if m.LengthMock.defaultExpectation != nil && mm_atomic.LoadUint64(&m.afterLengthCounter) < 1 {
+		m.t.Error("Expected call to RequestsQueueMock.Length")
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcLength != nil && mm_atomic.LoadUint64(&m.afterLengthCounter) < 1 {
+		m.t.Error("Expected call to RequestsQueueMock.Length")
 	}
 }
 
@@ -1101,6 +1252,8 @@ func (m *RequestsQueueMock) MinimockFinish() {
 
 		m.MinimockCleanInspect()
 
+		m.MinimockLengthInspect()
+
 		m.MinimockNumberOfOldInspect()
 
 		m.MinimockTakeAllOriginatedFromInspect()
@@ -1131,6 +1284,7 @@ func (m *RequestsQueueMock) minimockDone() bool {
 	return done &&
 		m.MinimockAppendDone() &&
 		m.MinimockCleanDone() &&
+		m.MinimockLengthDone() &&
 		m.MinimockNumberOfOldDone() &&
 		m.MinimockTakeAllOriginatedFromDone() &&
 		m.MinimockTakeFirstDone()

--- a/logicrunner/requestsqueue/requestsqueue.go
+++ b/logicrunner/requestsqueue/requestsqueue.go
@@ -45,6 +45,8 @@ type RequestsQueue interface {
 	// NumberOfOld returns quantity of requests from ledger and previous executor
 	// (e.g not fresh, aka old)
 	NumberOfOld(ctx context.Context) int
+	// Number of elements in queue
+	Length() int
 	// Clean cleans queue
 	Clean(ctx context.Context)
 }
@@ -105,4 +107,11 @@ func (q *queue) Clean(_ context.Context) {
 	for i := 0; i < int(numberOfSources); i++ {
 		q.lists[i] = nil
 	}
+}
+
+func (q *queue) Length() int {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	return len(q.lists[FromLedger]) + len(q.lists[FromPreviousExecutor]) + len(q.lists[FromThisPulse])
 }


### PR DESCRIPTION
* when we first send PendingFinished we won't move our state (in some
  situations) to InPending
* when OnPulse happens, sometime, we won't move our state to InPending,
  too
* Added some more verbose logging