### PR TITLE
fix flow log level

### DIFF
--- a/insolar/flow/dispatcher/dispatcher.go
+++ b/insolar/flow/dispatcher/dispatcher.go
@@ -139,7 +139,7 @@ func (d *dispatcher) Process(msg *message.Message) error {
 		procDuration := time.Since(processStart)
 		result := "ok"
 		if err != nil {
-			if err == flow.ErrCancelled {
+			if errors.Cause(err) == flow.ErrCancelled {
 				result = "cancelled"
 				logger.Info(errors.Wrap(err, "flow handling failed"))
 			} else {


### PR DESCRIPTION
**- What I did**
fixed flow log level fix for FlowCancelled

**- How I did it**
with test (but only for manual testing, because it is really hard to get into dispatcher interface)

**- How to verify it**
run 
`go test ./insolar/flow/dispatcher -run TestDispatcher_Process_ReplyFlowCancelled -v`
 and see only unfo message
