### PR TITLE
NOISSUE: make virtual integration test to support go1.13

### DIFF
--- a/virtual/integration/main_test.go
+++ b/virtual/integration/main_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -118,7 +119,6 @@ var verboseWM bool
 
 func init() {
 	flag.BoolVar(&verboseWM, "verbose-wm", false, "flag to enable watermill logging")
-	flag.Parse()
 }
 
 func NewServer(
@@ -457,4 +457,9 @@ func getIncomingTopic(msg *message.Message) string {
 		topic = bus.TopicIncomingRequestResults
 	}
 	return topic
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
Before that patch result of running virtual integration test was:
```
[ 09/23/19 | 14:09:20 ] $ go test -timeout 1200s -tags slowtest ./virtual/integration
flag provided but not defined: -test.testlogfile
Usage of /var/folders/9g/lwhn2csx7rn66b_rg_905wq00000gn/T/go-build606332186/b001/integration.test:
  -verbose-wm
        flag to enable watermill logging
FAIL    github.com/insolar/insolar/virtual/integration  0.021s
FAIL
```

Bug was re order of loading modules:
1) virtual functest (added `verbose-wm` and running `Parse` function), error was here due to absence of `test.testlogfile` command line argument
2) test.testlogfile and other arguments were added later in testing module