### PR TITLE
INS-3628_outgoing_deduplication no more double call of outgoing

### DIFF
--- a/logicrunner/rpc_methods.go
+++ b/logicrunner/rpc_methods.go
@@ -189,18 +189,21 @@ func (m *executionProxyImplementation) RouteCall(
 	if req.Saga {
 		// Saga methods are not executed right away. LME will send a method
 		// to the VE when current object finishes the execution and validation.
+		if outReqInfo.Result != nil {
+			return errors.New("RegisterOutgoingRequest returns Result for Saga Call")
+		}
+		return nil
+	}
+
+	// if we replay abandoned request after node was down we can already have Result
+	if outReqInfo.Result != nil {
+		rep.Result = outReqInfo.Result
 		return nil
 	}
 
 	// Step 2. Send the request and register the result (both is done by outgoingSender)
+	_, rep.Result, _, err = m.outgoingSender.SendOutgoingRequest(ctx, *getRequestReference(outReqInfo), outgoing)
 
-	outgoingReqRef := *getRequestReference(outReqInfo)
-
-	var incoming *record.IncomingRequest
-	_, rep.Result, incoming, err = m.outgoingSender.SendOutgoingRequest(ctx, outgoingReqRef, outgoing)
-	if incoming != nil {
-		current.AddOutgoingRequest(ctx, *incoming, rep.Result, nil, err)
-	}
 	return err
 }
 


### PR DESCRIPTION
**- What I did**
1) remove some useless code
2) add check for already processed outgoing requests
3) add check for Saga's outgoing requests with results (it must never happen)

**- How I did it**
write code and tests
**- How to verify it**
run tests