### PR TITLE
INS-3639: return existed result as virtual record

### DIFF
--- a/logicrunner/rpc_methods.go
+++ b/logicrunner/rpc_methods.go
@@ -18,6 +18,7 @@ package logicrunner
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -197,7 +198,17 @@ func (m *executionProxyImplementation) RouteCall(
 
 	// if we replay abandoned request after node was down we can already have Result
 	if outReqInfo.Result != nil {
-		rep.Result = outReqInfo.Result
+		rec := record.Material{}
+		err := rec.Unmarshal(outReqInfo.Result)
+		if err != nil {
+			return errors.Wrap(err, "failed to unmarshal existing result")
+		}
+		virtual := record.Unwrap(&rec.Virtual)
+		resultRecord, ok := virtual.(*record.Result)
+		if !ok {
+			return fmt.Errorf("unexpected record %T", virtual)
+		}
+		rep.Result = resultRecord.Payload
 		return nil
 	}
 

--- a/logicrunner/rpc_methods_test.go
+++ b/logicrunner/rpc_methods_test.go
@@ -23,9 +23,6 @@ import (
 
 	"github.com/gojuno/minimock"
 	"github.com/insolar/go-actors/actor/system"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
-
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/gen"
 	"github.com/insolar/insolar/insolar/payload"
@@ -38,6 +35,8 @@ import (
 	"github.com/insolar/insolar/logicrunner/executionregistry"
 	"github.com/insolar/insolar/logicrunner/goplugin/rpctypes"
 	"github.com/insolar/insolar/testutils"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRPCMethods_New(t *testing.T) {
@@ -397,8 +396,13 @@ func TestRouteCallRegistersOutgoingRequestAlreadyHasResult(t *testing.T) {
 		require.Equal(t, record.ReturnResult, r.ReturnMode)
 		outreq = r
 		id := *outgoingReqRef.GetLocal()
-		result := append(make([]byte, 1),1)
-		return &payload.RequestInfo{RequestID: id, Result: result}, nil
+		result := append(make([]byte, 1), 1)
+		resRecord := &record.Result{Payload: result}
+		virtResRecord := record.Wrap(resRecord)
+		matRecord := record.Material{Virtual: virtResRecord}
+		matRecordSerialized, err := matRecord.Marshal()
+		require.NoError(t, err)
+		return &payload.RequestInfo{RequestID: id, Result: matRecordSerialized}, nil
 	})
 
 	err := rpcm.RouteCall(ctx, transcript, req, resp)


### PR DESCRIPTION
**- What I did**
If result for request already exist, we get virtual record from it and set it as result.

**- How to verify it**
Run Jepsen test with kill_under_load case.
