### PR TITLE
INS-3633: fix in executionbroker tests leaking goroutines

### DIFF
--- a/logicrunner/executionbroker.go
+++ b/logicrunner/executionbroker.go
@@ -281,7 +281,7 @@ func (q *ExecutionBroker) processTranscript(ctx context.Context, transcript *com
 		q.finishTranscript(ctx, transcript)
 
 		if sendReply {
-			go q.requestsExecutor.SendReply(ctx, transcript.RequestRef, *transcript.Request, replyData, err)
+			q.requestsExecutor.SendReply(ctx, transcript.RequestRef, *transcript.Request, replyData, err)
 		}
 
 		// we're checking here that pulse was changed and we should send

--- a/logicrunner/executionbroker_test.go
+++ b/logicrunner/executionbroker_test.go
@@ -110,7 +110,7 @@ func TestExecutionBroker_AddFreshRequest(t *testing.T) {
 				wg.Add(1)
 				er := executionregistry.NewExecutionRegistryMock(t).
 					RegisterMock.Return(nil).
-					DoneMock.Return(true).IsEmptyMock.Return(true)
+					DoneMock.Return(true)
 				count := 0
 				am := artifacts.NewClientMock(t).
 					HasPendingsMock.Return(false, nil).
@@ -139,7 +139,7 @@ func TestExecutionBroker_AddFreshRequest(t *testing.T) {
 					return &requestresult.RequestResult{}, nil
 				})
 				broker := NewExecutionBroker(objectRef,
-					nil, re, senderOKMock(t, nil), am, er, nil, pa)
+					nil, re, nil, am, er, nil, pa)
 				return broker, wg
 			},
 		},
@@ -155,8 +155,8 @@ func TestExecutionBroker_AddFreshRequest(t *testing.T) {
 			broker.HasMoreRequests(ctx)
 
 			wg.Wait()
-			// we need to call onpulse to stop broker/fetcher
-			broker.OnPulse(ctx)
+			// we need to stop broker to stop fetcher
+			close(broker.closed)
 
 			mc.Wait(1 * time.Minute)
 			mc.Finish()

--- a/logicrunner/executionbroker_test.go
+++ b/logicrunner/executionbroker_test.go
@@ -19,11 +19,14 @@ package logicrunner
 import (
 	"context"
 	"math"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
 	wmMessage "github.com/ThreeDotsLabs/watermill/message"
+	"github.com/fortytw2/leaktest"
 	"github.com/gojuno/minimock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,6 +37,7 @@ import (
 	"github.com/insolar/insolar/insolar/payload"
 	insolarPulse "github.com/insolar/insolar/insolar/pulse"
 	"github.com/insolar/insolar/insolar/record"
+	"github.com/insolar/insolar/insolar/reply"
 	"github.com/insolar/insolar/insolar/utils"
 	"github.com/insolar/insolar/instrumentation/inslogger"
 	"github.com/insolar/insolar/logicrunner/artifacts"
@@ -84,6 +88,8 @@ func finishedCount(args ...interface{}) bool {
 }
 
 func TestExecutionBroker_AddFreshRequest(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	objectRef := gen.Reference()
 
 	reqRef := gen.RecordReference()
@@ -95,14 +101,16 @@ func TestExecutionBroker_AddFreshRequest(t *testing.T) {
 
 	table := []struct {
 		name  string
-		mocks func(ctx context.Context, t minimock.Tester) *ExecutionBroker
+		mocks func(ctx context.Context, t minimock.Tester) (broker *ExecutionBroker, finishedCase *sync.WaitGroup)
 	}{
 		{
 			name: "happy path",
-			mocks: func(ctx context.Context, t minimock.Tester) *ExecutionBroker {
+			mocks: func(ctx context.Context, t minimock.Tester) (*ExecutionBroker, *sync.WaitGroup) {
+				wg := &sync.WaitGroup{}
+				wg.Add(1)
 				er := executionregistry.NewExecutionRegistryMock(t).
 					RegisterMock.Return(nil).
-					DoneMock.Return(true)
+					DoneMock.Return(true).IsEmptyMock.Return(true)
 				count := 0
 				am := artifacts.NewClientMock(t).
 					HasPendingsMock.Return(false, nil).
@@ -125,13 +133,14 @@ func TestExecutionBroker_AddFreshRequest(t *testing.T) {
 					}, nil)
 				re := NewRequestsExecutorMock(t).
 					SendReplyMock.Set(func(ctx context.Context, reqRef insolar.Reference, req record.IncomingRequest, re insolar.Reply, err error) {
+					wg.Done()
 					require.NoError(t, err)
 				}).ExecuteAndSaveMock.Set(func(ctx context.Context, tr *common.Transcript) (artifacts.RequestResult, error) {
 					return &requestresult.RequestResult{}, nil
 				})
 				broker := NewExecutionBroker(objectRef,
-					nil, re, nil, am, er, nil, pa)
-				return broker
+					nil, re, senderOKMock(t, nil), am, er, nil, pa)
+				return broker, wg
 			},
 		},
 	}
@@ -142,8 +151,12 @@ func TestExecutionBroker_AddFreshRequest(t *testing.T) {
 			ctx := inslogger.TestContext(t)
 			mc := minimock.NewController(t)
 
-			broker := test.mocks(ctx, mc)
+			broker, wg := test.mocks(ctx, mc)
 			broker.HasMoreRequests(ctx)
+
+			wg.Wait()
+			// we need to call onpulse to stop broker/fetcher
+			broker.OnPulse(ctx)
 
 			mc.Wait(1 * time.Minute)
 			mc.Finish()
@@ -151,7 +164,33 @@ func TestExecutionBroker_AddFreshRequest(t *testing.T) {
 	}
 }
 
+func senderOKMock(t minimock.Tester, callback func()) *bus.SenderMock {
+	innerReps := make(chan *message.Message)
+	sender := bus.NewSenderMock(t).SendRoleMock.Set(func(ctx context.Context, msg *wmMessage.Message, role insolar.DynamicRole, object insolar.Reference) (ch1 <-chan *wmMessage.Message, f1 func()) {
+		go sendOK(innerReps)
+		return innerReps, func() {
+			close(innerReps)
+			if callback != nil {
+				callback()
+			}
+		}
+	})
+	return sender
+}
+
+func sendOK(ch chan<- *message.Message) {
+	msg := bus.ReplyAsMessage(context.Background(), &reply.OK{})
+	meta := payload.Meta{
+		Payload: msg.Payload,
+	}
+	buf, _ := meta.Marshal()
+	msg.Payload = buf
+	ch <- msg
+}
+
 func TestExecutionBroker_PendingFinishedIfNeed(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	mc := minimock.NewController(t)
 
 	tests := []struct {
@@ -251,6 +290,11 @@ func TestExecutionBroker_PendingFinishedIfNeed(t *testing.T) {
 }
 
 func TestExecutionBroker_ExecuteImmutable(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
 	ctx := inslogger.TestContext(t)
 	mc := minimock.NewController(t)
 	defer mc.Finish()
@@ -258,7 +302,7 @@ func TestExecutionBroker_ExecuteImmutable(t *testing.T) {
 
 	er := executionregistry.NewExecutionRegistryMock(mc).
 		RegisterMock.Return(nil).
-		DoneMock.Return(true)
+		DoneMock.Return(true).IsEmptyMock.Return(true)
 
 	pa := insolarPulse.NewAccessorMock(t).LatestMock.Return(
 		insolar.Pulse{PulseNumber: pulse.MinTimePulse},
@@ -267,13 +311,14 @@ func TestExecutionBroker_ExecuteImmutable(t *testing.T) {
 
 	am := artifacts.NewClientMock(t).GetObjectMock.Set(func(ctx context.Context, head insolar.Reference, request *insolar.Reference) (o1 artifacts.ObjectDescriptor, err error) {
 		return artifacts.NewObjectDescriptorMock(t), nil
+	}).HasPendingsMock.Set(func(ctx context.Context, object insolar.Reference) (b1 bool, err error) {
+		return false, nil
 	})
 
 	// prepare default object and execution state
 	objectRef := gen.Reference()
 	re := NewRequestsExecutorMock(mc)
-	broker := NewExecutionBroker(objectRef, nil, re, nil, am, er, nil, pa)
-	broker.pending = insolar.NotPending
+	broker := NewExecutionBroker(objectRef, nil, re, senderOKMock(t, nil), am, er, nil, pa)
 
 	immutableRequestRef1 := gen.RecordReference()
 	immutableRequest1 := record.IncomingRequest{
@@ -295,12 +340,20 @@ func TestExecutionBroker_ExecuteImmutable(t *testing.T) {
 	}).GetRequestMock.Return(&immutableRequest1, nil)
 
 	re.ExecuteAndSaveMock.Return(requestresult.New([]byte{1, 2, 3}, gen.Reference()), nil)
-	re.SendReplyMock.Return()
+	re.SendReplyMock.Set(func(ctx context.Context, reqRef insolar.Reference, req record.IncomingRequest, re insolar.Reply, err error) {
+		t.Log("sendreply called")
+		wg.Done()
+	})
 
 	broker.HasMoreRequests(ctx)
+
+	wg.Wait()
+	broker.OnPulse(ctx)
 }
 
 func TestExecutionBroker_OnPulse(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	randTranscript := func(ctx context.Context) *common.Transcript {
 		reqRef := gen.RecordReference()
 		return common.NewTranscript(ctx, reqRef, record.IncomingRequest{})
@@ -399,12 +452,14 @@ func TestExecutionBroker_OnPulse(t *testing.T) {
 			assert.Equal(t, test.pendingConfirmed, broker.PendingConfirmed)
 			assert.Equal(t, test.end, !broker.isActive())
 			assert.Equal(t, test.ledgerHasMore, broker.ledgerHasMoreRequests)
-			assert.Len(t, messages, test.numberOfMessages)
+			assert.Len(t, messages, test.numberOfMessages, "result %+v", messages)
 		})
 	}
 }
 
-func TestExecutionBroker_AddFreshRequestWithOnPulse(t *testing.T) {
+func TestExecutionBroker_HasMoreRequestsWithOnPulse(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	objectRef := gen.Reference()
 
 	// ctx := inslogger.TestContext(t)
@@ -418,12 +473,12 @@ func TestExecutionBroker_AddFreshRequestWithOnPulse(t *testing.T) {
 
 	table := []struct {
 		name   string
-		mocks  func(ctx context.Context, t minimock.Tester) (*ExecutionBroker, *[]payload.Payload)
+		mocks  func(ctx context.Context, t minimock.Tester) (*ExecutionBroker, *[]payload.Payload, *sync.WaitGroup)
 		checks func(ctx context.Context, t *testing.T, msgs []payload.Payload)
 	}{
 		{
 			name: "pulse change in HasPendings",
-			mocks: func(ctx context.Context, t minimock.Tester) (*ExecutionBroker, *[]payload.Payload) {
+			mocks: func(ctx context.Context, t minimock.Tester) (*ExecutionBroker, *[]payload.Payload, *sync.WaitGroup) {
 				am := artifacts.NewClientMock(t)
 
 				er := executionregistry.NewExecutionRegistryMock(t).
@@ -435,7 +490,7 @@ func TestExecutionBroker_AddFreshRequestWithOnPulse(t *testing.T) {
 					msgs = broker.OnPulse(ctx)
 					return false, nil
 				})
-				return broker, &msgs
+				return broker, &msgs, &sync.WaitGroup{}
 			},
 			checks: func(ctx context.Context, t *testing.T, msgs []payload.Payload) {
 				require.Len(t, msgs, 1)
@@ -448,7 +503,9 @@ func TestExecutionBroker_AddFreshRequestWithOnPulse(t *testing.T) {
 		},
 		{
 			name: "pulse change in Execute",
-			mocks: func(ctx context.Context, t minimock.Tester) (*ExecutionBroker, *[]payload.Payload) {
+			mocks: func(ctx context.Context, t minimock.Tester) (*ExecutionBroker, *[]payload.Payload, *sync.WaitGroup) {
+				wg := &sync.WaitGroup{}
+				wg.Add(1)
 				doneCalled := false
 				er := executionregistry.NewExecutionRegistryMock(t).
 					IsEmptyMock.Set(func() bool { return doneCalled }).
@@ -472,8 +529,10 @@ func TestExecutionBroker_AddFreshRequestWithOnPulse(t *testing.T) {
 					Caller:       gen.Reference(),
 				}, nil)
 				re := NewRequestsExecutorMock(t).
-					SendReplyMock.Return()
-				sender := bus.NewSenderMock(t).SendRoleMock.Return(nil, func() { return })
+					SendReplyMock.Set(func(ctx context.Context, reqRef insolar.Reference, req record.IncomingRequest, re insolar.Reply, err error) {
+					wg.Done()
+				})
+				sender := senderOKMock(t, nil)
 				pulseMock := insolarPulse.NewAccessorMock(t).LatestMock.Set(func(p context.Context) (r insolar.Pulse, r1 error) {
 					return insolar.Pulse{
 						PulseNumber:     insolar.PulseNumber(pulse.MinTimePulse),
@@ -487,15 +546,15 @@ func TestExecutionBroker_AddFreshRequestWithOnPulse(t *testing.T) {
 					msgs = broker.OnPulse(ctx)
 					return &requestresult.RequestResult{}, nil
 				})
-				return broker, &msgs
+				return broker, &msgs, wg
 			},
 			checks: func(ctx context.Context, t *testing.T, msgs []payload.Payload) {
 				require.Len(t, msgs, 1)
 
 				results, ok := msgs[0].(*payload.ExecutorResults)
-				require.True(t, ok)
-				require.False(t, results.LedgerHasMoreRequests)
-				require.Equal(t, insolar.InPending, results.Pending)
+				assert.True(t, ok)
+				assert.False(t, results.LedgerHasMoreRequests)
+				assert.Equal(t, insolar.InPending, results.Pending)
 			},
 		},
 		// TODO: need more test cases, for example Pulse in GetPendings, Pulse in GetObject
@@ -507,8 +566,10 @@ func TestExecutionBroker_AddFreshRequestWithOnPulse(t *testing.T) {
 			ctx := inslogger.TestContext(t)
 			mc := minimock.NewController(t)
 
-			broker, msgs := test.mocks(ctx, mc)
+			broker, msgs, wg := test.mocks(ctx, mc)
 			broker.HasMoreRequests(ctx)
+
+			wg.Wait()
 
 			mc.Wait(1 * time.Minute)
 			mc.Finish()
@@ -519,6 +580,8 @@ func TestExecutionBroker_AddFreshRequestWithOnPulse(t *testing.T) {
 }
 
 func TestExecutionBroker_NoMoreRequestsOnLedger(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	ctx := inslogger.TestContext(t)
 	mc := minimock.NewController(t)
 	defer mc.Finish()
@@ -558,6 +621,8 @@ func TestExecutionBroker_AbandonedRequestsOnLedger(t *testing.T) {
 }
 
 func TestExecutionBroker_AbandonedRequestsOnLedger_Integration(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	mc := minimock.NewController(t)
 
 	objectRef := gen.Reference()
@@ -624,6 +689,8 @@ func TestExecutionBroker_AbandonedRequestsOnLedger_Integration(t *testing.T) {
 }
 
 func TestExecutionBroker_PrevExecutorPendingResult(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	objectRef := gen.Reference()
 
 	pa := insolarPulse.NewAccessorMock(t).LatestMock.Return(

--- a/logicrunner/handle_init.go
+++ b/logicrunner/handle_init.go
@@ -253,7 +253,7 @@ func checkOutgoingRequest(ctx context.Context, request *record.OutgoingRequest) 
 	return checkIncomingRequest(ctx, (*record.IncomingRequest)(request))
 }
 
-func checkIncomingRequest(ctx context.Context, request *record.IncomingRequest) error {
+func checkIncomingRequest(_ context.Context, request *record.IncomingRequest) error {
 	if !request.CallerPrototype.IsEmpty() && !request.CallerPrototype.IsObjectReference() {
 		return errors.Errorf("request.CallerPrototype should be ObjectReference; ref=%s", request.CallerPrototype.String())
 	}

--- a/logicrunner/requestsexecutor.go
+++ b/logicrunner/requestsexecutor.go
@@ -142,11 +142,11 @@ func (e *requestsExecutor) SendReply(
 	}
 
 	if req.APINode.IsEmpty() {
-		e.sendToCaller(ctx, reqRef, req, replyBytes, errStr)
+		go e.sendToCaller(ctx, reqRef, req, replyBytes, errStr)
 		return
 	}
 
-	e.sendToAPINode(ctx, reqRef, req, replyBytes, errStr)
+	go e.sendToAPINode(ctx, reqRef, req, replyBytes, errStr)
 }
 
 func (e *requestsExecutor) sendToCaller(


### PR DESCRIPTION
**- What I did**
fixed leaking goroutines in executionbroker tests

**- How I did it**
with leaktest

**- How to verify it**
run tests
