### PR TITLE
INS-2921: fixed leak in ImmutableOrder and fixed OnPulse tests behaviour

### DIFF
--- a/logicrunner/executionbroker.go
+++ b/logicrunner/executionbroker.go
@@ -181,10 +181,10 @@ func (q *ExecutionBroker) startProcessor(ctx context.Context) {
 
 	q.processorActive = true
 
+	// Clear flag if there were more requests before fetching started
 	select {
 	case <-q.probablyMoreSinceLastFetch:
 	default:
-		logger.Warn("no record in probablyMoreSinceLastFetch channel during processor activation, impossible situation")
 	}
 
 	logger.Debug("starting requests processor")
@@ -418,7 +418,7 @@ func (q *ExecutionBroker) OnPulse(ctx context.Context) []payload.Payload {
 		q.PendingConfirmed = true
 	}()
 
-	close(q.closed)
+	q.close()
 
 	sendExecResults := false
 
@@ -574,6 +574,12 @@ func (q *ExecutionBroker) isClosed() bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func (q *ExecutionBroker) close() {
+	if !q.isClosed() {
+		close(q.closed)
 	}
 }
 

--- a/logicrunner/logicrunner_unit_test.go
+++ b/logicrunner/logicrunner_unit_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	message2 "github.com/ThreeDotsLabs/watermill/message"
+	"github.com/fortytw2/leaktest"
 	"github.com/gojuno/minimock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -428,6 +429,7 @@ func TestLogicRunner_OnPulse_Order(t *testing.T) {
 
 func (suite *LogicRunnerTestSuite) TestImmutableOrder() {
 	syncT := &testutils.SyncT{T: suite.T()}
+	defer leaktest.Check(syncT)()
 
 	wg := &sync.WaitGroup{}
 
@@ -582,5 +584,5 @@ func (suite *LogicRunnerTestSuite) TestImmutableOrder() {
 
 	wg.Wait()
 
-	suite.True(wait(finishedCount, broker, 3))
+	broker.close()
 }

--- a/logicrunner/request_fetcher_test.go
+++ b/logicrunner/request_fetcher_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/gojuno/minimock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,6 +40,8 @@ func TestRequestsFetcher_New(t *testing.T) {
 }
 
 func TestRequestsFetcher_FetchPendings(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	tests := []struct {
 		name  string
 		mocks func(t minimock.Tester) (insolar.Reference, artifacts.Client)


### PR DESCRIPTION
**- What I did**
- fixed goroutine test leak
- fixed TestExecutionBroker_AddFreshRequestWithOnPulse logic
