### PR TITLE
increase number of shards we create by default

### DIFF
--- a/scripts/insolard/bootstrap_template.yaml
+++ b/scripts/insolard/bootstrap_template.yaml
@@ -12,8 +12,8 @@ root_balance: "0"
 fee: "1000000000"
 md_balance: "50000000000000000000"
 lockup_pulse_period: 20
-pk_shard_count: 10
-ma_shard_count: 10
+pk_shard_count: 10000
+ma_shard_count: 1000
 vesting_pulse_period: 10
 vesting_pulse_step: 10
 majority_rule: 5


### PR DESCRIPTION
10k shards should take 10GB of space for 1M users, way better
than 10TB with 10 shards
