### PR TITLE
WLT-1243: reference refactoring

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -86,7 +86,7 @@ func (ar *Runner) makeCall(ctx context.Context, method string, params requester.
 	ctx, span := instracer.StartSpan(ctx, "Call "+method)
 	defer span.End()
 
-	reference, err := insolar.NewReferenceFromBase58(params.Reference)
+	reference, err := insolar.NewReferenceFromString(params.Reference)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to parse params.Reference")
 	}

--- a/api/contract_test.go
+++ b/api/contract_test.go
@@ -64,7 +64,7 @@ func TestTimeoutSuite(t *testing.T) {
 
 	cr := testutils.NewContractRequesterMock(mc)
 	cr.CallMock.Set(func(p context.Context, p1 *insolar.Reference, method string, p3 []interface{}, p4 insolar.PulseNumber) (insolar.Reply, *insolar.Reference, error) {
-		requestReference, _ := insolar.NewReferenceFromBase58("14K3NiGuqYGqKPnYp6XeGd2kdN4P9veL6rYcWkLKWXZCu.14FFB8zfQoGznSmzDxwv4njX1aR9ioL8GHSH17QXH2AFa")
+		requestReference, _ := insolar.NewReferenceFromString("14K3NiGuqYGqKPnYp6XeGd2kdN4P9veL6rYcWkLKWXZCu.14FFB8zfQoGznSmzDxwv4njX1aR9ioL8GHSH17QXH2AFa")
 		switch method {
 		case "Call":
 			var result = "OK"

--- a/api/functest_contract.go
+++ b/api/functest_contract.go
@@ -119,7 +119,7 @@ func (s *FuncTestContractService) CallConstructor(r *http.Request, args *CallCon
 		return errors.New("params.PrototypeRefString is missing")
 	}
 
-	protoRef, err := insolar.NewReferenceFromBase58(args.PrototypeRefString)
+	protoRef, err := insolar.NewReferenceFromString(args.PrototypeRefString)
 	if err != nil {
 		return errors.Wrap(err, "can't get protoRef")
 	}
@@ -180,7 +180,7 @@ func (s *FuncTestContractService) CallMethod(r *http.Request, args *CallMethodAr
 		return errors.New("params.ObjectRefString is missing")
 	}
 
-	objectRef, err := insolar.NewReferenceFromBase58(args.ObjectRefString)
+	objectRef, err := insolar.NewReferenceFromString(args.ObjectRefString)
 	if err != nil {
 		return errors.Wrap(err, "can't get objectRef")
 	}

--- a/api/node_cert.go
+++ b/api/node_cert.go
@@ -52,7 +52,7 @@ func NewNodeCertService(runner *Runner) *NodeCertService {
 
 // Get returns certificate for node with given reference.
 func (s *NodeCertService) get(ctx context.Context, _ *http.Request, args *NodeCertArgs, _ *rpc.RequestBody, reply *NodeCertReply) error {
-	nodeRef, err := insolar.NewReferenceFromBase58(args.Ref)
+	nodeRef, err := insolar.NewReferenceFromString(args.Ref)
 	if err != nil {
 		return errors.Wrap(err, "failed to parse args.Ref")
 	}

--- a/certificate/authorization.go
+++ b/certificate/authorization.go
@@ -41,7 +41,7 @@ func (authCert *AuthorizationCertificate) GetPublicKey() crypto.PublicKey {
 
 // GetNodeRef returns reference from node certificate
 func (authCert *AuthorizationCertificate) GetNodeRef() *insolar.Reference {
-	ref, err := insolar.NewReferenceFromBase58(authCert.Reference)
+	ref, err := insolar.NewReferenceFromString(authCert.Reference)
 	if err != nil {
 		log.Errorf("Invalid node reference in auth cert: %s\n", authCert.Reference)
 		return nil

--- a/certificate/certificate.go
+++ b/certificate/certificate.go
@@ -56,7 +56,7 @@ func NewBootstrapNode(pubKey crypto.PublicKey, publicKey, host, noderef, role st
 
 // GetNodeRef returns reference of bootstrap node
 func (bn *BootstrapNode) GetNodeRef() *insolar.Reference {
-	ref, err := insolar.NewReferenceFromBase58(bn.NodeRef)
+	ref, err := insolar.NewReferenceFromString(bn.NodeRef)
 	if err != nil {
 		log.Errorf("Invalid bootstrap node reference: %s\n", bn.NodeRef)
 		return nil
@@ -188,7 +188,7 @@ func (cert *Certificate) fillExtraFields(keyProcessor insolar.KeyProcessor) erro
 
 // GetRootDomainReference returns RootDomain reference
 func (cert *Certificate) GetRootDomainReference() *insolar.Reference {
-	ref, err := insolar.NewReferenceFromBase58(cert.RootDomainReference)
+	ref, err := insolar.NewReferenceFromString(cert.RootDomainReference)
 	if err != nil {
 		log.Errorf("Invalid domain reference in cert: %s\n", cert.Reference)
 		return nil

--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -46,7 +46,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	ref, err := insolar.NewReferenceFromBase58(*refString)
+	ref, err := insolar.NewReferenceFromString(*refString)
 	if err != nil {
 		log.Errorf("Failed to parse healthcheck contract ref: %s", err.Error())
 		os.Exit(2)

--- a/cmd/insgorund/insgorund.go
+++ b/cmd/insgorund/insgorund.go
@@ -73,7 +73,7 @@ func main() {
 			log.Fatal("code param format is <ref>:</path/to/plugin.so>")
 			os.Exit(1)
 		}
-		ref, err := insolar.NewReferenceFromBase58(codeSlice[0])
+		ref, err := insolar.NewReferenceFromString(codeSlice[0])
 		if err != nil {
 			log.Fatalf("Couldn't parse ref: %s", err.Error())
 			os.Exit(1)

--- a/cmd/insolar/certgen.go
+++ b/cmd/insolar/certgen.go
@@ -67,7 +67,7 @@ func extractReference(response []byte, requestTypeMsg string) insolar.Reference 
 		os.Exit(1)
 	}
 
-	ref, err := insolar.NewReferenceFromBase58(r.Result.CallResult.(string))
+	ref, err := insolar.NewReferenceFromString(r.Result.CallResult.(string))
 	checkError(fmt.Sprintf("Failed to construct ref from '%s' node response", requestTypeMsg), err)
 
 	return *ref

--- a/cmd/insolar/main.go
+++ b/cmd/insolar/main.go
@@ -369,7 +369,7 @@ func sendRequest(sendURL string, adminURL, rootKeysFile string, paramsPath strin
 	reqCfg, err := requester.ReadRequestParamsFromFile(pPath)
 	check("[ sendRequest ]", err)
 
-	if !insolar.IsReferenceInBase58(userCfg.Caller) && insolar.IsReferenceInBase58(reqCfg.Reference) {
+	if !insolar.IsObjectReferenceString(userCfg.Caller) && insolar.IsObjectReferenceString(reqCfg.Reference) {
 		userCfg.Caller = reqCfg.Reference
 	}
 

--- a/functest/helloworld_test.go
+++ b/functest/helloworld_test.go
@@ -67,7 +67,7 @@ func NewHelloWorld(ctx context.Context) (*HelloWorldInstance, error) {
 	}
 
 	i := HelloWorldInstance{}
-	i.Ref, err = insolar.NewReferenceFromBase58(rv)
+	i.Ref, err = insolar.NewReferenceFromString(rv)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (i *HelloWorldInstance) CreateChild(ctx context.Context) (*HelloWorldInstan
 	}
 
 	child := HelloWorldInstance{}
-	child.Ref, err = insolar.NewReferenceFromBase58(rv)
+	child.Ref, err = insolar.NewReferenceFromString(rv)
 	if err != nil {
 		return nil, err
 	}

--- a/functest/logicrunner_test.go
+++ b/functest/logicrunner_test.go
@@ -234,7 +234,7 @@ func (r *Two) GetPayloadString() (string, error) {
 	resp = callMethod(t, objectRef, "GetFriend")
 	require.Empty(t, resp.Error)
 
-	two, err2 := insolar.NewReferenceFromBase58(resp.ExtractedReply.(string))
+	two, err2 := insolar.NewReferenceFromString(resp.ExtractedReply.(string))
 	require.NoError(t, err2)
 
 	for i := 6; i <= 9; i++ {
@@ -320,7 +320,7 @@ func (w *TestSagaSimpleCallContract) Rollback(amount int) error {
 	resp := callMethod(t, firstWalletRef, "Transfer", int(amount))
 	require.Empty(t, resp.Error)
 
-	secondWalletRef, err := insolar.NewReferenceFromBase58(resp.ExtractedReply.(string))
+	secondWalletRef, err := insolar.NewReferenceFromString(resp.ExtractedReply.(string))
 	require.NoError(t, err)
 
 	checkPassed := false
@@ -429,7 +429,7 @@ func (w *TestSagaCallFromAcceptMethodContract) RollbackStepTwo(amount int) error
 	resp := callMethod(t, firstWalletRef, "Transfer", int(amount))
 	require.Empty(t, resp.Error)
 
-	secondWalletRef, err := insolar.NewReferenceFromBase58(resp.ExtractedReply.(string))
+	secondWalletRef, err := insolar.NewReferenceFromString(resp.ExtractedReply.(string))
 	require.NoError(t, err)
 
 	checkPassed := false
@@ -528,7 +528,7 @@ func (w *TestSagaMultipleCallsContract) Rollback(amount int) error {
 	resp := callMethod(t, firstWalletRef, "Transfer", int(amount))
 	require.Empty(t, resp.Error)
 
-	secondWalletRef, err := insolar.NewReferenceFromBase58(resp.ExtractedReply.(string))
+	secondWalletRef, err := insolar.NewReferenceFromString(resp.ExtractedReply.(string))
 	require.NoError(t, err)
 
 	checkPassed := false
@@ -633,7 +633,7 @@ func (w *SagaMagicFlagTwo) Accept(amount int) error {
 	resp := callMethod(t, firstWalletRef, "Transfer", int(amount))
 	require.Empty(t, resp.Error)
 
-	secondWalletRef, err := insolar.NewReferenceFromBase58(resp.ExtractedReply.(string))
+	secondWalletRef, err := insolar.NewReferenceFromString(resp.ExtractedReply.(string))
 	require.NoError(t, err)
 
 	checkPassed := false

--- a/functest/test_utils.go
+++ b/functest/test_utils.go
@@ -327,7 +327,7 @@ func signedRequest(t *testing.T, URL string, user *launchnet.User, method string
 	require.NotEqual(t, "", refStr, "request ref is empty: %s", errMsg)
 	require.NotEqual(t, insolar.NewEmptyReference().String(), refStr, "request ref is zero: %s", errMsg)
 
-	_, err = insolar.NewReferenceFromBase58(refStr)
+	_, err = insolar.NewReferenceFromString(refStr)
 	require.Nil(t, err)
 
 	return res, err
@@ -457,7 +457,7 @@ func uploadContract(t testing.TB, contractName string, contractCode string) *ins
 	require.NoError(t, err)
 	require.Empty(t, uploadRes.Error)
 
-	prototypeRef, err := insolar.NewReferenceFromBase58(uploadRes.Result.PrototypeRef)
+	prototypeRef, err := insolar.NewReferenceFromString(uploadRes.Result.PrototypeRef)
 	require.NoError(t, err)
 	require.False(t, prototypeRef.IsEmpty())
 
@@ -493,7 +493,7 @@ func callConstructor(t testing.TB, prototypeRef *insolar.Reference, method strin
 
 	require.NotEmpty(t, callConstructorRes.Result.Object)
 
-	objectRef, err := insolar.NewReferenceFromBase58(callConstructorRes.Result.Object)
+	objectRef, err := insolar.NewReferenceFromString(callConstructorRes.Result.Object)
 	require.NoError(t, err)
 
 	require.NotEqual(t, insolar.NewReferenceFromBytes(make([]byte, insolar.RecordRefSize)), objectRef)

--- a/insolar/record.go
+++ b/insolar/record.go
@@ -60,9 +60,9 @@ func NewGlobalReference(local ID, base ID) *Reference {
 	return &global
 }
 
-// NewObjectReferenceFromBase58 deserializes reference from base58 encoded string and checks if it object reference
-func NewObjectReferenceFromBase58(input string) (*Reference, error) {
-	global, err := NewReferenceFromBase58(input)
+// NewObjectReferenceFromString deserializes reference from base58 encoded string and checks if it object reference
+func NewObjectReferenceFromString(input string) (*Reference, error) {
+	global, err := NewReferenceFromString(input)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +75,8 @@ func NewObjectReferenceFromBase58(input string) (*Reference, error) {
 	return global, nil
 }
 
-// NewReferenceFromBase58 deserializes reference from base58 encoded string
-func NewReferenceFromBase58(input string) (*Reference, error) {
+// NewReferenceFromString deserializes reference from base58 encoded string
+func NewReferenceFromString(input string) (*Reference, error) {
 	global, err := reference.DefaultDecoder().Decode(input)
 	if err != nil {
 		return nil, err
@@ -84,9 +84,9 @@ func NewReferenceFromBase58(input string) (*Reference, error) {
 	return &global, nil
 }
 
-// IsReferenceInBase58 checks the validity of the reference
-func IsReferenceInBase58(input string) bool {
-	_, err := NewObjectReferenceFromBase58(input)
+// IsObjectReferenceString checks the validity of the reference
+func IsObjectReferenceString(input string) bool {
+	_, err := NewObjectReferenceFromString(input)
 	return err == nil
 }
 
@@ -113,8 +113,8 @@ func NewID(p PulseNumber, hash []byte) *ID {
 	return &local
 }
 
-// NewIDFromBase58 deserializes ID from base58 encoded string
-func NewIDFromBase58(input string) (*ID, error) {
+// NewIDFromString deserializes ID from base58 encoded string
+func NewIDFromString(input string) (*ID, error) {
 	global, err := reference.DefaultDecoder().Decode(input)
 	if err != nil {
 		return nil, err

--- a/insolar/record_test.go
+++ b/insolar/record_test.go
@@ -37,10 +37,10 @@ func TestNewIDFromBytes(t *testing.T) {
 	insolar.NewIDFromBytes(nil)
 }
 
-func TestNewIDFromBase58(t *testing.T) {
+func TestNewIDFromString(t *testing.T) {
 	id := gen.ID()
 	idStr := "1" + base58.Encode(id.Bytes())
-	id2, err := insolar.NewIDFromBase58(idStr)
+	id2, err := insolar.NewIDFromString(idStr)
 	require.NoError(t, err)
 
 	assert.Equal(t, id, *id2)
@@ -53,13 +53,13 @@ func TestRecordID_String(t *testing.T) {
 	assert.Equal(t, idStr, id.String())
 }
 
-func TestNewRefFromBase58(t *testing.T) {
+func TestNewRefFromString(t *testing.T) {
 	recordID := gen.ID()
 	domainID := gen.ID()
 	refStr := "1" + base58.Encode(recordID.Bytes()) + insolar.RecordRefIDSeparator + "1" + base58.Encode(domainID.Bytes())
 
 	expectedRef := insolar.NewGlobalReference(recordID, domainID)
-	actualRef, err := insolar.NewReferenceFromBase58(refStr)
+	actualRef, err := insolar.NewReferenceFromString(refStr)
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedRef, actualRef)
@@ -108,9 +108,9 @@ func BenchmarkRecordID_DebugString_Depth5(b *testing.B) {
 	}
 }
 
-func TestNewReferenceFromBase58(t *testing.T) {
+func TestNewReferenceFromString(t *testing.T) {
 	origin := gen.Reference()
-	decoded, err := insolar.NewReferenceFromBase58(origin.String())
+	decoded, err := insolar.NewReferenceFromString(origin.String())
 	require.NoError(t, err)
 	assert.Equal(t, origin, *decoded)
 }

--- a/logicrunner/artifacts/client_test.go
+++ b/logicrunner/artifacts/client_test.go
@@ -387,7 +387,7 @@ func (s *ArtifactsMangerClientSuite) TestGetPendings() {
 			)
 
 			// Act
-			references, err := s.amClient.GetPendings(s.ctx, objectRef, make([] insolar.ID, 0))
+			references, err := s.amClient.GetPendings(s.ctx, objectRef, make([]insolar.ID, 0))
 
 			// Assert
 			test.check(references, err)
@@ -405,7 +405,7 @@ func (s *ArtifactsMangerClientSuite) TestGetPendings_FailedToSend() {
 	s.busSender.SendRoleMock.Return(ch, func() {})
 
 	// Act
-	_, err := s.amClient.GetPendings(s.ctx, *request.Object, make([] insolar.ID, 0))
+	_, err := s.amClient.GetPendings(s.ctx, *request.Object, make([]insolar.ID, 0))
 
 	// Assert
 	s.Error(err)

--- a/logicrunner/artifacts/client_test.go
+++ b/logicrunner/artifacts/client_test.go
@@ -1523,7 +1523,7 @@ func (s *ArtifactsMangerClientSuite) TestGetObject() {
 }
 
 func shouldLoadRef(strRef string) insolar.Reference {
-	ref, err := insolar.NewReferenceFromBase58(strRef)
+	ref, err := insolar.NewReferenceFromString(strRef)
 	if err != nil {
 		panic(errors.Wrap(err, "Unexpected error, bailing out"))
 	}

--- a/logicrunner/builtin/contract/deposit/deposit.go
+++ b/logicrunner/builtin/contract/deposit/deposit.go
@@ -191,7 +191,7 @@ func (d *Deposit) checkConfirm(migrationDaemonRef string, amountStr string) erro
 	var activateDaemons []string
 
 	for ref := range d.MigrationDaemonConfirms {
-		migrationDaemonMemberRef, err := insolar.NewObjectReferenceFromBase58(ref)
+		migrationDaemonMemberRef, err := insolar.NewObjectReferenceFromString(ref)
 		if err != nil {
 			return fmt.Errorf(" failed to parse params.Reference")
 		}

--- a/logicrunner/builtin/contract/member/member.go
+++ b/logicrunner/builtin/contract/member/member.go
@@ -227,7 +227,7 @@ func (m *Member) getBalanceCall(params map[string]interface{}) (interface{}, err
 		return nil, fmt.Errorf("failed to get 'reference' param")
 	}
 
-	reference, err := insolar.NewObjectReferenceFromBase58(referenceStr)
+	reference, err := insolar.NewObjectReferenceFromString(referenceStr)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse 'reference': %s", err.Error())
 	}
@@ -278,7 +278,7 @@ func (m *Member) transferCall(params map[string]interface{}) (interface{}, error
 		asset = XNS // set to default asset
 	}
 
-	recipientReference, err := insolar.NewObjectReferenceFromBase58(recipientReferenceStr)
+	recipientReference, err := insolar.NewObjectReferenceFromString(recipientReferenceStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse 'toMemberReference' param: %s", err.Error())
 	}

--- a/logicrunner/builtin/contract/migrationadmin/migrationadmin.go
+++ b/logicrunner/builtin/contract/migrationadmin/migrationadmin.go
@@ -219,7 +219,7 @@ func (mA *MigrationAdmin) GetDepositParameters() (*VestingParams, error) {
 // ins:immutable
 func (mA *MigrationAdmin) GetMigrationDaemonByMemberRef(memberRef string) (insolar.Reference, error) {
 
-	migrationDaemonMemberRef, err := insolar.NewObjectReferenceFromBase58(memberRef)
+	migrationDaemonMemberRef, err := insolar.NewObjectReferenceFromString(memberRef)
 	if err != nil {
 		return insolar.Reference{}, fmt.Errorf(" failed to parse params.Reference")
 	}
@@ -247,7 +247,7 @@ func (mA *MigrationAdmin) GetMemberByMigrationAddress(migrationAddress string) (
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get reference in shard")
 	}
-	ref, err := insolar.NewObjectReferenceFromBase58(refStr)
+	ref, err := insolar.NewObjectReferenceFromString(refStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "bad member reference for this migration address")
 	}

--- a/logicrunner/builtin/contract/rootdomain/rootdomain.go
+++ b/logicrunner/builtin/contract/rootdomain/rootdomain.go
@@ -47,7 +47,7 @@ func (rd *RootDomain) GetMemberByPublicKey(publicKey string) (*insolar.Reference
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get reference in shard")
 	}
-	ref, err := insolar.NewObjectReferenceFromBase58(refStr)
+	ref, err := insolar.NewObjectReferenceFromString(refStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "bad member reference for this public key")
 	}

--- a/logicrunner/builtin/contract/wallet/wallet.go
+++ b/logicrunner/builtin/contract/wallet/wallet.go
@@ -54,7 +54,7 @@ func (w *Wallet) GetAccount(assetName string) (*insolar.Reference, error) {
 	if !ok {
 		return nil, fmt.Errorf("asset not found: %s", assetName)
 	}
-	return insolar.NewObjectReferenceFromBase58(accountReference)
+	return insolar.NewObjectReferenceFromString(accountReference)
 }
 
 // Transfer transfers money to given wallet.
@@ -93,7 +93,7 @@ func (w *Wallet) GetDeposits() ([]interface{}, error) {
 	result := []interface{}{}
 	for _, dRef := range w.Deposits {
 
-		reference, err := insolar.NewObjectReferenceFromBase58(dRef)
+		reference, err := insolar.NewObjectReferenceFromString(dRef)
 		if err != nil {
 			return nil, err
 		}
@@ -113,7 +113,7 @@ func (w *Wallet) GetDeposits() ([]interface{}, error) {
 // ins:immutable
 func (w *Wallet) FindDeposit(transactionHash string) (bool, *insolar.Reference, error) {
 	if depositReferenceStr, ok := w.Deposits[transactionHash]; ok {
-		depositReference, _ := insolar.NewObjectReferenceFromBase58(depositReferenceStr)
+		depositReference, _ := insolar.NewObjectReferenceFromString(depositReferenceStr)
 		return true, depositReference, nil
 	}
 

--- a/logicrunner/builtin/initialization.go
+++ b/logicrunner/builtin/initialization.go
@@ -59,7 +59,7 @@ func InitializeContractMethods() map[string]XXX_insolar.ContractWrapper {
 }
 
 func shouldLoadRef(strRef string) XXX_insolar.Reference {
-	ref, err := XXX_insolar.NewReferenceFromBase58(strRef)
+	ref, err := XXX_insolar.NewReferenceFromString(strRef)
 	if err != nil {
 		panic(errors.Wrap(err, "Unexpected error, bailing out"))
 	}

--- a/logicrunner/builtin/proxy/account/account.go
+++ b/logicrunner/builtin/proxy/account/account.go
@@ -31,7 +31,7 @@ type destination interface {
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A62X73fkPeY5vK6NjcXgmL9d37DgRRNtHNLGaEse")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A62X73fkPeY5vK6NjcXgmL9d37DgRRNtHNLGaEse")
 
 // Account holds proxy type
 type Account struct {

--- a/logicrunner/builtin/proxy/costcenter/costcenter.go
+++ b/logicrunner/builtin/proxy/costcenter/costcenter.go
@@ -27,7 +27,7 @@ import (
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A62HrJvAimG7M1r8XdeBVMw4X6ge8hGzVStfnn4e")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A62HrJvAimG7M1r8XdeBVMw4X6ge8hGzVStfnn4e")
 
 // CostCenter holds proxy type
 type CostCenter struct {

--- a/logicrunner/builtin/proxy/deposit/deposit.go
+++ b/logicrunner/builtin/proxy/deposit/deposit.go
@@ -44,7 +44,7 @@ type DepositOut struct {
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A7ctasuNUug8BoK4VJNuAFJ73rnH8bH5zqd5HrDj")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A7ctasuNUug8BoK4VJNuAFJ73rnH8bH5zqd5HrDj")
 
 // Deposit holds proxy type
 type Deposit struct {

--- a/logicrunner/builtin/proxy/helloworld/helloworld.go
+++ b/logicrunner/builtin/proxy/helloworld/helloworld.go
@@ -48,7 +48,7 @@ type Text struct {
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A85JAZugtAkQErbDe3eAaTw56DPLku8QGymJUCt2")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A85JAZugtAkQErbDe3eAaTw56DPLku8QGymJUCt2")
 
 // HelloWorld holds proxy type
 type HelloWorld struct {

--- a/logicrunner/builtin/proxy/member/member.go
+++ b/logicrunner/builtin/proxy/member/member.go
@@ -61,7 +61,7 @@ type TransferResponse struct {
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A7UqbgvFXj9vkCAaNYSAkWLapu62eU5AUSv3y4JY")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A7UqbgvFXj9vkCAaNYSAkWLapu62eU5AUSv3y4JY")
 
 // Member holds proxy type
 type Member struct {

--- a/logicrunner/builtin/proxy/migrationadmin/migrationadmin.go
+++ b/logicrunner/builtin/proxy/migrationadmin/migrationadmin.go
@@ -43,7 +43,7 @@ type VestingParams struct {
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A8DhUhw5pzyvzVg1qXomNEHXs7kDtJRQGSD1PUpc")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A8DhUhw5pzyvzVg1qXomNEHXs7kDtJRQGSD1PUpc")
 
 // MigrationAdmin holds proxy type
 type MigrationAdmin struct {

--- a/logicrunner/builtin/proxy/migrationdaemon/migrationdaemon.go
+++ b/logicrunner/builtin/proxy/migrationdaemon/migrationdaemon.go
@@ -31,7 +31,7 @@ type DepositMigrationResult struct {
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A7jZX41e1SpH9oW3F2dgUvVQdjSqXEAGQSxhbqmD")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A7jZX41e1SpH9oW3F2dgUvVQdjSqXEAGQSxhbqmD")
 
 // MigrationDaemon holds proxy type
 type MigrationDaemon struct {

--- a/logicrunner/builtin/proxy/migrationshard/migrationshard.go
+++ b/logicrunner/builtin/proxy/migrationshard/migrationshard.go
@@ -27,7 +27,7 @@ import (
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A7FNYLZLYXYWZPbkMhCAPwV9nYrWWE7L57CtdJCj")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A7FNYLZLYXYWZPbkMhCAPwV9nYrWWE7L57CtdJCj")
 
 // MigrationShard holds proxy type
 type MigrationShard struct {

--- a/logicrunner/builtin/proxy/nodedomain/nodedomain.go
+++ b/logicrunner/builtin/proxy/nodedomain/nodedomain.go
@@ -27,7 +27,7 @@ import (
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A6NKbCjpzFr9MttfcWV8vX8eFjiyGPPfSH1AMtwN")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A6NKbCjpzFr9MttfcWV8vX8eFjiyGPPfSH1AMtwN")
 
 // NodeDomain holds proxy type
 type NodeDomain struct {

--- a/logicrunner/builtin/proxy/noderecord/noderecord.go
+++ b/logicrunner/builtin/proxy/noderecord/noderecord.go
@@ -32,7 +32,7 @@ type RecordInfo struct {
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A5fZeApbGhcsLrbfGy82kKLgapF93GhNPMLSYaPY")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A5fZeApbGhcsLrbfGy82kKLgapF93GhNPMLSYaPY")
 
 // NodeRecord holds proxy type
 type NodeRecord struct {

--- a/logicrunner/builtin/proxy/pkshard/pkshard.go
+++ b/logicrunner/builtin/proxy/pkshard/pkshard.go
@@ -27,7 +27,7 @@ import (
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A5x8N1VJTm7BKYgzSe6TWHcFi98QZgw3AnkYiKML")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A5x8N1VJTm7BKYgzSe6TWHcFi98QZgw3AnkYiKML")
 
 // PKShard holds proxy type
 type PKShard struct {

--- a/logicrunner/builtin/proxy/rootdomain/rootdomain.go
+++ b/logicrunner/builtin/proxy/rootdomain/rootdomain.go
@@ -27,7 +27,7 @@ import (
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A84uiiTD1LXAHNP4GMA6YJFjbnCdkRia2pCqwBV5")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A84uiiTD1LXAHNP4GMA6YJFjbnCdkRia2pCqwBV5")
 
 // RootDomain holds proxy type
 type RootDomain struct {

--- a/logicrunner/builtin/proxy/wallet/wallet.go
+++ b/logicrunner/builtin/proxy/wallet/wallet.go
@@ -27,7 +27,7 @@ import (
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("0111A5gmRD1ZbHjQh7DgH9SrCK4a1qfwEUP5xAir6i8L")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("0111A5gmRD1ZbHjQh7DgH9SrCK4a1qfwEUP5xAir6i8L")
 
 // Wallet holds proxy type
 type Wallet struct {

--- a/logicrunner/goplugin/ginsider/ginsider_test.go
+++ b/logicrunner/goplugin/ginsider/ginsider_test.go
@@ -84,7 +84,7 @@ func (s *HealthCheckSuite) TestHealthCheck() {
 	gi := NewGoInsider(tmpDir, protocol, socket)
 
 	refString := "14K3NiGuqYGqKPnYp6XeGd2kdN4P9veL6rYcWkLKWXZCu.17ZQboaH24PH42sqZKUvoa7UBrpuuubRtShp6CKNuWGZa"
-	ref, err := insolar.NewReferenceFromBase58(refString)
+	ref, err := insolar.NewReferenceFromString(refString)
 	s.Require().NoError(err)
 
 	healthcheckSoFile := path.Join(tmpDir, "healthcheck.so")

--- a/logicrunner/preprocessor/main.go
+++ b/logicrunner/preprocessor/main.go
@@ -472,7 +472,7 @@ func (pf *ParsedFile) WriteProxy(classReference string, out io.Writer) error {
 		classReference = genesisrefs.GenerateProtoReferenceFromCode(0, pf.code).String()
 	}
 
-	_, err = insolar.NewReferenceFromBase58(classReference)
+	_, err = insolar.NewReferenceFromString(classReference)
 	if err != nil {
 		return errors.Wrap(err, "can't write proxy: ")
 	}

--- a/logicrunner/preprocessor/main_test.go
+++ b/logicrunner/preprocessor/main_test.go
@@ -259,7 +259,7 @@ import (
 )
 
 func main() {
-	ref, _ := insolar.NewReferenceFromBase58("14K3NiGuqYGqKPnYp6XeGd2kdN4P9veL6rYcWkLKWXZCu.17ZQboaH24PH42sqZKUvoa7UBrpuuubRtShp6CKNuWGZa")
+	ref, _ := insolar.NewReferenceFromString("14K3NiGuqYGqKPnYp6XeGd2kdN4P9veL6rYcWkLKWXZCu.17ZQboaH24PH42sqZKUvoa7UBrpuuubRtShp6CKNuWGZa")
 	_ = secondary.GetObject(*ref)
 }
 	`)

--- a/logicrunner/preprocessor/templates/initialization.go.tpl
+++ b/logicrunner/preprocessor/templates/initialization.go.tpl
@@ -38,7 +38,7 @@ func InitializeContractMethods() map[string]XXX_insolar.ContractWrapper {
 }
 
 func shouldLoadRef(strRef string) XXX_insolar.Reference {
-    ref, err := XXX_insolar.NewReferenceFromBase58(strRef)
+    ref, err := XXX_insolar.NewReferenceFromString(strRef)
     if err != nil {
         panic(errors.Wrap(err, "Unexpected error, bailing out"))
     }

--- a/logicrunner/preprocessor/templates/proxy.go.tpl
+++ b/logicrunner/preprocessor/templates/proxy.go.tpl
@@ -31,7 +31,7 @@ import (
 
 // PrototypeReference to prototype of this contract
 // error checking hides in generator
-var PrototypeReference, _ = insolar.NewObjectReferenceFromBase58("{{ .ClassReference }}")
+var PrototypeReference, _ = insolar.NewObjectReferenceFromString("{{ .ClassReference }}")
 
 
 // {{ .ContractType }} holds proxy type

--- a/network/hostnetwork/hostnetwork.go
+++ b/network/hostnetwork/hostnetwork.go
@@ -75,7 +75,7 @@ import (
 // NewHostNetwork constructor creates new NewHostNetwork component
 func NewHostNetwork(nodeRef string) (network.HostNetwork, error) {
 
-	id, err := insolar.NewReferenceFromBase58(nodeRef)
+	id, err := insolar.NewReferenceFromString(nodeRef)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid nodeRef")
 	}

--- a/network/hostnetwork/hostnetwork_test.go
+++ b/network/hostnetwork/hostnetwork_test.go
@@ -117,7 +117,7 @@ func (m *MockResolver) AddToKnownHosts(h *host.Host)      {}
 func (m *MockResolver) Rebalance(network.PartitionPolicy) {}
 
 func (m *MockResolver) addMapping(key, value string) error {
-	k, err := insolar.NewReferenceFromBase58(key)
+	k, err := insolar.NewReferenceFromString(key)
 	if err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func TestNewHostNetwork(t *testing.T) {
 	s.Start()
 
 	for i := 0; i < count; i++ {
-		ref, err := insolar.NewReferenceFromBase58(ID2 + DOMAIN)
+		ref, err := insolar.NewReferenceFromString(ID2 + DOMAIN)
 		require.NoError(t, err)
 		f, err := s.n1.SendRequest(s.ctx1, types.RPC, &packet.RPCRequest{}, *ref)
 		require.NoError(t, err)
@@ -266,7 +266,7 @@ func TestHostNetwork_SendRequestPacket(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	unknownID, err := insolar.NewReferenceFromBase58(IDUNKNOWN + DOMAIN)
+	unknownID, err := insolar.NewReferenceFromString(IDUNKNOWN + DOMAIN)
 	require.NoError(t, err)
 
 	// should return error because cannot resolve NodeID -> Address
@@ -279,7 +279,7 @@ func TestHostNetwork_SendRequestPacket(t *testing.T) {
 	err = m.addMapping(ID3+DOMAIN, "127.0.0.1:7654")
 	require.NoError(t, err)
 
-	ref, err := insolar.NewReferenceFromBase58(ID2 + DOMAIN)
+	ref, err := insolar.NewReferenceFromString(ID2 + DOMAIN)
 	require.NoError(t, err)
 	// should return error because resolved address is invalid
 	f, err = n1.SendRequest(ctx, types.Pulse, &packet.PulseRequest{}, *ref)
@@ -297,7 +297,7 @@ func TestHostNetwork_SendRequestPacket2(t *testing.T) {
 
 	handler := func(ctx context.Context, r network.ReceivedPacket) (network.Packet, error) {
 		inslogger.FromContext(ctx).Info("handler triggered")
-		ref, err := insolar.NewReferenceFromBase58(ID1 + DOMAIN)
+		ref, err := insolar.NewReferenceFromString(ID1 + DOMAIN)
 		require.NoError(t, err)
 		require.Equal(t, *ref, r.GetSender())
 		require.Equal(t, s.n1.PublicAddress(), r.GetSenderHost().Address.String())
@@ -309,7 +309,7 @@ func TestHostNetwork_SendRequestPacket2(t *testing.T) {
 
 	s.Start()
 
-	ref, err := insolar.NewReferenceFromBase58(ID2 + DOMAIN)
+	ref, err := insolar.NewReferenceFromString(ID2 + DOMAIN)
 	require.NoError(t, err)
 	f, err := s.n1.SendRequest(s.ctx1, types.RPC, &packet.RPCRequest{}, *ref)
 	require.NoError(t, err)
@@ -331,7 +331,7 @@ func TestHostNetwork_SendRequestPacket3(t *testing.T) {
 	s.Start()
 
 	request := &packet.PulseRequest{}
-	ref, err := insolar.NewReferenceFromBase58(ID2 + DOMAIN)
+	ref, err := insolar.NewReferenceFromString(ID2 + DOMAIN)
 	require.NoError(t, err)
 	f, err := s.n1.SendRequest(s.ctx1, types.Pulse, request, *ref)
 	require.NoError(t, err)
@@ -365,7 +365,7 @@ func TestHostNetwork_SendRequestPacket_errors(t *testing.T) {
 
 	s.Start()
 
-	ref, err := insolar.NewReferenceFromBase58(ID2 + DOMAIN)
+	ref, err := insolar.NewReferenceFromString(ID2 + DOMAIN)
 	require.NoError(t, err)
 	f, err := s.n1.SendRequest(s.ctx1, types.RPC, &packet.RPCRequest{}, *ref)
 	require.NoError(t, err)
@@ -397,7 +397,7 @@ func TestHostNetwork_WrongHandler(t *testing.T) {
 
 	s.Start()
 
-	ref, err := insolar.NewReferenceFromBase58(ID2 + DOMAIN)
+	ref, err := insolar.NewReferenceFromString(ID2 + DOMAIN)
 	require.NoError(t, err)
 	f, err := s.n1.SendRequest(s.ctx1, types.Pulse, &packet.PulseRequest{}, *ref)
 	require.NoError(t, err)
@@ -427,7 +427,7 @@ func TestStartStopSend(t *testing.T) {
 	s.Start()
 
 	send := func() {
-		ref, err := insolar.NewReferenceFromBase58(ID2 + DOMAIN)
+		ref, err := insolar.NewReferenceFromString(ID2 + DOMAIN)
 		require.NoError(t, err)
 		f, err := s.n1.SendRequest(s.ctx1, types.RPC, &packet.RPCRequest{}, *ref)
 		require.NoError(t, err)

--- a/network/merkle/calculator_test.go
+++ b/network/merkle/calculator_test.go
@@ -71,7 +71,7 @@ import (
 )
 
 func createOrigin() insolar.NetworkNode {
-	ref, _ := insolar.NewReferenceFromBase58("14K3NiGuqYGqKPnYp6XeGd2kdN4P9veL6rYcWkLKWXZCu.17ZQboaH24PH42sqZKUvoa7UBrpuuubRtShp6CKNuWGZa")
+	ref, _ := insolar.NewReferenceFromString("14K3NiGuqYGqKPnYp6XeGd2kdN4P9veL6rYcWkLKWXZCu.17ZQboaH24PH42sqZKUvoa7UBrpuuubRtShp6CKNuWGZa")
 	return node.NewNode(*ref, insolar.StaticRoleVirtual, nil, "127.0.0.1:5432", "")
 }
 

--- a/reference/bytedecoder.go
+++ b/reference/bytedecoder.go
@@ -50,7 +50,7 @@ func byteDecodeBase58(s string, target io.ByteWriter) (stringRead int, err error
 }
 
 func byteDecodeBase64(s string, target io.ByteWriter) (stringRead int, err error) {
-	bytes, err := base64.URLEncoding.DecodeString(s)
+	bytes, err := base64.RawURLEncoding.DecodeString(s)
 	if err != nil {
 		return 0, err
 	}

--- a/reference/bytedecoder.go
+++ b/reference/bytedecoder.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"io"
 
-	"github.com/jbenet/go-base58"
+	base58 "github.com/jbenet/go-base58"
 	"github.com/pkg/errors"
 )
 

--- a/reference/decoder.go
+++ b/reference/decoder.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 )
 
 type ByteDecodeFunc func(s string, target io.ByteWriter) (stringRead int, err error)
@@ -37,14 +36,8 @@ const (
 	IgnoreParity
 )
 
-var defaultDecoderOnce sync.Once
-var defaultDecoder GlobalDecoder
-
 func DefaultDecoder() GlobalDecoder {
-	defaultDecoderOnce.Do(func() {
-		defaultDecoder = NewDefaultDecoder(AllowLegacy | AllowRecords)
-	})
-	return defaultDecoder
+	return NewDefaultDecoder(AllowLegacy | AllowRecords)
 }
 
 type GlobalDecoder interface {

--- a/reference/encoder.go
+++ b/reference/encoder.go
@@ -19,7 +19,6 @@ package reference
 import (
 	"bytes"
 	"strings"
-	"sync"
 
 	"github.com/pkg/errors"
 )
@@ -43,24 +42,12 @@ type Encoder interface {
 	EncodeRecord(rec *Local) (string, error)
 }
 
-var defaultEncoderOnce sync.Once
-var defaultEncoder Encoder
-
-var base64EncoderOnce sync.Once
-var base64Encoder Encoder
-
 func DefaultEncoder() Encoder {
-	defaultEncoderOnce.Do(func() {
-		defaultEncoder = NewBase58Encoder(0)
-	})
-	return defaultEncoder
+	return NewBase58Encoder(0)
 }
 
 func Base64Encoder() Encoder {
-	base64EncoderOnce.Do(func() {
-		base64Encoder = NewBase64Encoder(0)
-	})
-	return base64Encoder
+	return NewBase64Encoder(0)
 }
 
 type encoder struct {

--- a/virtual/integration/virtual_test.go
+++ b/virtual/integration/virtual_test.go
@@ -205,7 +205,7 @@ func TestVirtual_BasicOperations(t *testing.T) {
 var walletRef = shouldLoadRef("0111A5e49cJW6GKGegWBhtgrJs7nFh1kSWhBtT2VgK4t.record")
 
 func shouldLoadRef(strRef string) insolar.Reference {
-	ref, err := insolar.NewReferenceFromBase58(strRef)
+	ref, err := insolar.NewReferenceFromString(strRef)
 	if err != nil {
 		panic(errors.Wrap(err, "Unexpected error, bailing out"))
 	}


### PR DESCRIPTION
* Renamed `...Base58` methods to `...String`
* Removed `sync.Once` from encoder and decoder constructors
* Switched base64 decoder to `RawUrlEncoding`