### PR TITLE
INS-3691: increase wait timeout of network start up to 270 seconds

### DIFF
--- a/testutils/launchnet/launchnet.go
+++ b/testutils/launchnet/launchnet.go
@@ -262,7 +262,7 @@ func stopInsolard() error {
 }
 
 func waitForNet() error {
-	numAttempts := 90
+	numAttempts := 270
 	// TODO: read ports from bootstrap config
 	ports := []string{
 		"19001",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
increase wait timeout of network start up to 270 seconds
It's fast fix of tests

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
