### PR TITLE
INS-3709: fix-logic-in-getAddressCount-with-startWithIndex

### DIFF
--- a/functest/migration_shard_test.go
+++ b/functest/migration_shard_test.go
@@ -78,6 +78,12 @@ func TestGetFreeAddressCount_ChangesAfterMigration(t *testing.T) {
 	require.True(t, isFound)
 }
 
+func TestGetFreeAddressCount_WithIndex_NotAllRange(t *testing.T) {
+	numLeftShards := 2
+	var migrationShards = getAddressCount(t, numShards-numLeftShards)
+	require.Len(t, migrationShards, numLeftShards)
+}
+
 func TestGetFreeAddressCount_StartIndexTooBig(t *testing.T) {
 	_, _, err := makeSignedRequest(launchnet.TestRPCUrl, &launchnet.MigrationAdmin, "migration.getAddressCount",
 		map[string]interface{}{"startWithIndex": numShards + 2})

--- a/logicrunner/builtin/contract/migrationadmin/migrationadmin.go
+++ b/logicrunner/builtin/contract/migrationadmin/migrationadmin.go
@@ -174,14 +174,21 @@ func (mA *MigrationAdmin) getAddressCount(params map[string]interface{}, memberR
 		return nil, fmt.Errorf("only migration daemon admin can call this method")
 	}
 
-	const maxNumberOfElements = 10
-	if len(mA.MigrationAddressShards) < startWithIndex+maxNumberOfElements {
+	if startWithIndex >= len(mA.MigrationAddressShards) {
 		return nil, fmt.Errorf("incorrect start shard index: too big")
 	}
 
+	lastIndex := 0
 	var res []*GetAddressCountResponse
+	const maxNumberOfElements = 10
 
-	for i := startWithIndex; i < startWithIndex+maxNumberOfElements; i++ {
+	if startWithIndex+maxNumberOfElements > len(mA.MigrationAddressShards) {
+		lastIndex = len(mA.MigrationAddressShards)
+	} else {
+		lastIndex = startWithIndex + maxNumberOfElements
+	}
+
+	for i := startWithIndex; i < lastIndex; i++ {
 		s := migrationshard.GetObject(mA.MigrationAddressShards[i])
 		count, err := s.GetMigrationAddressesAmount()
 		if err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
correct logic in getAddressCount with startWithIndex: now it return the rest of shard starting from startWithIndex

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
