### PR TITLE
INS-3845: add retry on ServiceUnavailable in benchmark

### DIFF
--- a/application/api/requester/requester.go
+++ b/application/api/requester/requester.go
@@ -26,7 +26,6 @@ import (
 	"encoding/asn1"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"math/big"
 	mathrand "math/rand"
@@ -141,7 +140,7 @@ func MakeContractRequest(url string, postP ContractRequest, signature string) (*
 	return req, nil
 }
 
-// GetResponseBodyContract makes request to platform and extracts body
+// GetResponseBodyPlatform makes request to platform and extracts body
 func GetResponseBodyPlatform(url string, method string, params interface{}) ([]byte, error) {
 	request := PlatformRequest{
 		Request: Request{
@@ -212,7 +211,7 @@ func GetSeed(url string) (string, error) {
 		return "", errors.Wrap(err, "[ GetSeed ] Can't unmarshal")
 	}
 	if seedResp.Error != nil {
-		return "", errors.New("[ GetSeed ] Field 'error' is not nil: " + fmt.Sprint(seedResp.Error))
+		return "", seedResp.Error
 	}
 	if len(seedResp.Result.Seed) == 0 {
 		return "", errors.New("[ GetSeed ] Field seed is empty")
@@ -320,7 +319,7 @@ func Info(url string) (*InfoResponse, error) {
 		return nil, errors.Wrap(err, "[ Info ] Can't unmarshal")
 	}
 	if infoResp.Error != nil {
-		return nil, errors.New("[ Info ] Field 'error' is not nil: " + fmt.Sprint(infoResp.Error))
+		return nil, infoResp.Error
 	}
 
 	return &infoResp.Result, nil
@@ -340,7 +339,7 @@ func Status(url string) (*StatusResponse, error) {
 		return nil, errors.Wrap(err, "[ Status ] Can't unmarshal")
 	}
 	if statusResp.Error != nil {
-		return nil, errors.New("[ Status ] Field 'error' is not nil: " + fmt.Sprint(statusResp.Error))
+		return nil, statusResp.Error
 	}
 
 	return &statusResp.Result, nil

--- a/application/cmd/benchmark/README.md
+++ b/application/cmd/benchmark/README.md
@@ -76,3 +76,9 @@ or you can run benchmark with
 
         --discovery-nodes-logs-dir
                 Launchnet logs dir for checking errors
+
+        -R --retries
+                Number of request retries if ServiceUnavailable error received
+
+        -P --retry-period
+                Time to wait between retries (accepts go duration format: 0.5s, 500ms, 1m30s etc.)

--- a/application/cmd/benchmark/main.go
+++ b/application/cmd/benchmark/main.go
@@ -68,6 +68,8 @@ var (
 	checkTotalBalance   bool
 	scenarioName        string
 	discoveryNodesLogs  string
+	maxRetries          int
+	retryPeriod         time.Duration
 )
 
 func parseInputParams() {
@@ -88,6 +90,8 @@ func parseInputParams() {
 	pflag.BoolVarP(&checkTotalBalance, "check-total-balance", "", false, "check total balance of members from file, don't run any scenario")
 	pflag.StringVarP(&scenarioName, "scenarioname", "t", "", "name of scenario")
 	pflag.StringVarP(&discoveryNodesLogs, "discovery-nodes-logs-dir", "", defaultDiscoveryNodesLogs, "launchnet logs dir for checking errors")
+	pflag.IntVarP(&maxRetries, "retries", "R", 0, "number of request attempts after getting -31429 error. -1 retries infinitely")
+	pflag.DurationVarP(&retryPeriod, "retry-period", "P", 0, "delay between retries")
 	pflag.Parse()
 }
 
@@ -366,7 +370,10 @@ func main() {
 	out, err := chooseOutput(output)
 	check("Problems with output file:", err)
 
-	insSDK, err := sdk.NewSDK(adminAPIURLs, publicAPIURLs, memberKeys)
+	insSDK, err := sdk.NewSDK(adminAPIURLs, publicAPIURLs, memberKeys, sdk.Options{
+		RetryPeriod: retryPeriod,
+		MaxRetries:  maxRetries,
+	})
 	check("SDK is not initialized: ", err)
 
 	err = insSDK.SetLogLevel(logLevelServer)

--- a/application/cmd/insolar/add_migration_addresses.go
+++ b/application/cmd/insolar/add_migration_addresses.go
@@ -28,7 +28,7 @@ import (
 )
 
 func addMigrationAddresses(adminUrls []string, publicUrls []string, memberKeysDirPath string, addressesPath string, shardsCount int) {
-	insSDK, err := sdk.NewSDK(adminUrls, publicUrls, memberKeysDirPath)
+	insSDK, err := sdk.NewSDK(adminUrls, publicUrls, memberKeysDirPath, sdk.DefaultOptions)
 	check("SDK is not initialized: ", err)
 	var filename string
 	// method AddMigrationAddresses in contract use only 10 shards in one call

--- a/application/cmd/insolar/free_migration_addresses.go
+++ b/application/cmd/insolar/free_migration_addresses.go
@@ -27,7 +27,7 @@ import (
 var shardsAtOneTime = 10
 
 func getfreeMigrationCount(adminUrls []string, publicUrls []string, memberKeysDirPath string, shardsCount int, alertCount int) {
-	insSDK, err := sdk.NewSDK(adminUrls, publicUrls, memberKeysDirPath)
+	insSDK, err := sdk.NewSDK(adminUrls, publicUrls, memberKeysDirPath, sdk.DefaultOptions)
 	check("SDK is not initialized: ", err)
 
 	shoudAlert := map[int]int{}

--- a/cmd/apirequester/main.go
+++ b/cmd/apirequester/main.go
@@ -55,7 +55,7 @@ func main() {
 	err := log.SetLevel("error")
 	check("can't set 'error' level on logger: ", err)
 
-	insSDK, err := sdk.NewSDK([]string{apiAdminURL}, []string{apiPublicURL}, memberKeys)
+	insSDK, err := sdk.NewSDK([]string{apiAdminURL}, []string{apiPublicURL}, memberKeys, sdk.DefaultOptions)
 	check("can't create SDK: ", err)
 
 	// you can modify this manual tests by commenting any of this functions or/and add some new functions if necessary


### PR DESCRIPTION
**- What I did**
Added new keys to benchmark:
 * `-R`: number of request retries if `ServiceUnavailable` error received
 * `-P`: time to wait between retries (accepts go duration format: `0.5s`, `500ms`, `1m30s` etc.)

**- How to verify it**
Run launchnet, kill `keeperd`, and run benchmark: `bin/benchmark -c=1 -r=1 -k=.artifacts/launchnet/configs/ -R=5 -P=0.5s`