### PR TITLE
NOISSUE: fix TestSingleContract test

### DIFF
--- a/logicrunner/goplugin/goplugintestutils/build.go
+++ b/logicrunner/goplugin/goplugintestutils/build.go
@@ -32,7 +32,7 @@ func buildCLI(name string) (string, error) {
 	binPath := filepath.Join(testdataDir, name)
 
 	out, err := exec.Command(
-		"go", "build",
+		"go", "build", "-mod=vendor",
 		"-o", binPath,
 		filepath.Join(insolarImportPath, name),
 	).CombinedOutput()


### PR DESCRIPTION
Fix test.

```
------- Stdout: -------
=== RUN   TestSingleContract
--- FAIL: TestSingleContract (31.61s)
    test_utils.go:489: 
        	Error Trace:	test_utils.go:489
        	            				test_utils.go:455
        	            				logicrunner_test.go:64
        	Error:      	Should be empty, but was {-32000 can't build preprocessor: can't build preprocessor. buildPrototypes output: go: finding github.com/spf13/pflag v1.0.3
        	            	go: finding github.com/opentracing/opentracing-go v1.1.0
        	            	go: finding github.com/spf13/afero v1.2.2
        	            	go: finding github.com/dustin/go-humanize v1.0.0
        	            	go: finding github.com/uber/jaeger-lib v2.2.0+incompatible
        	            	go: finding github.com/fortytw2/leaktest v1.3.
...
```