### PR TITLE
INS-3838: parametrization for functests

### DIFF
--- a/application/functest/bloat_test.go
+++ b/application/functest/bloat_test.go
@@ -23,12 +23,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/insolar/insolar/application/testutils/launchnet"
 	"github.com/stretchr/testify/require"
 )
 
 // Make sure that panic() in a contract causes a system error and that this error
 // is returned by API.
 func TestPanic(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var panicContractCode = `
 package main
 
@@ -56,6 +58,7 @@ func (r *One) Panic() error {
 }
 
 func TestRecursiveCallError(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractOneCode = `
 package main
 
@@ -100,6 +103,7 @@ func (r *One) Recursive() (error) {
 }
 
 func TestPrototypeMismatch(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	testContract := `
 package main
 
@@ -173,6 +177,7 @@ func (c *First) GetName() (string, error) {
 }
 
 func TestContractWithEmbeddedConstructor(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractOneCode = `
 package main
 

--- a/application/functest/change_loglevel_test.go
+++ b/application/functest/change_loglevel_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestChangeLogLevelOk(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	url := launchnet.HostDebug + "/debug/loglevel?level=debug"
 	resp, err := http.Get(url)
 	require.NoError(t, err)
@@ -40,6 +41,7 @@ func TestChangeLogLevelOk(t *testing.T) {
 }
 
 func TestChangeLogLevelFail(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	url := launchnet.HostDebug + "/debug/loglevel?level=ololo"
 	resp, err := http.Get(url)
 	require.NoError(t, err)

--- a/application/functest/common_test.go
+++ b/application/functest/common_test.go
@@ -40,7 +40,7 @@ func TestGetRequest(t *testing.T) {
 
 func TestWrongUrl(t *testing.T) {
 	jsonValue, _ := json.Marshal(postParams{})
-	testURL := launchnet.HOST + launchnet.AdminPort + "/not_api"
+	testURL := launchnet.AdminHostPort + "/not_api"
 	postResp, err := http.Post(testURL, "application/json", bytes.NewBuffer(jsonValue))
 	defer postResp.Body.Close()
 	require.NoError(t, err)

--- a/application/functest/deposit_transfer_test.go
+++ b/application/functest/deposit_transfer_test.go
@@ -76,7 +76,7 @@ func TestDepositTransferBeforeUnhold(t *testing.T) {
 	_, err := signedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, member,
 		"deposit.transfer", map[string]interface{}{"amount": "100", "ethTxHash": "Eth_TxHash_test"})
 	data := checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "hold period didn't end")
+	require.Contains(t, data.Trace, "hold period didn't end", "check lockup_pulse_period param at bootstrap.yaml: it maybe too low")
 }
 
 func TestDepositTransferBiggerAmount(t *testing.T) {

--- a/application/functest/logicrunner_test.go
+++ b/application/functest/logicrunner_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/insolar/insolar/application/testutils/launchnet"
 	"github.com/stretchr/testify/require"
 
 	"github.com/insolar/insolar/insolar"
@@ -30,6 +31,7 @@ import (
 )
 
 func TestSingleContract(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractCode = `
 package main
 
@@ -86,6 +88,7 @@ func (c *One) Dec() (int, error) {
 }
 
 func TestContractCallingContract(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractOneCode = `
 package main
 
@@ -261,6 +264,7 @@ func (r *Two) GetPayloadString() (string, error) {
 
 // Make sure a contract can make a saga call to another contract
 func TestSagaSimpleCall(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	balance := float64(100)
 	amount := float64(10)
 	var contractCode = `
@@ -348,6 +352,7 @@ func (w *TestSagaSimpleCallContract) Rollback(amount int) error {
 
 // Make sure a contract can make a saga call from a saga accept method
 func TestSagaCallFromSagaAcceptMethod(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	balance := float64(100)
 	amount := float64(10)
 	var contractCode = `
@@ -460,6 +465,7 @@ func (w *TestSagaCallFromAcceptMethodContract) RollbackStepTwo(amount int) error
 
 // Make sure a contract can make multiple saga calls in one method
 func TestSagaMultipleCalls(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	balance := float64(100)
 	amount := float64(10)
 	var contractCode = `
@@ -557,6 +563,7 @@ func (w *TestSagaMultipleCallsContract) Rollback(amount int) error {
 // Make sure a contract can make a saga call to another _type_ of contract
 // without a rollback method using a special flag.
 func TestSagaCallBetweenContractsWithoutRollback(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	balance := float64(100)
 	amount := float64(10)
 	var contractOneCode = `
@@ -661,6 +668,7 @@ func (w *SagaMagicFlagTwo) Accept(amount int) error {
 
 // Make sure a contract can make a saga call to itself
 func TestSagaSelfCall(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractCode = `
 package main
 
@@ -732,6 +740,7 @@ func (c *TestSagaSelfCallContract) Rollback(delta int) error {
 }
 
 func TestContextPassing(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractOneCode = `
 package main
 
@@ -759,6 +768,7 @@ func (r *One) Hello() (string, error) {
 }
 
 func TestDeactivation(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractOneCode = `
 package main
 
@@ -786,6 +796,7 @@ func (r *One) Kill() error {
 }
 
 func TestErrorInterface(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractOneCode = `
 package main
 
@@ -863,6 +874,7 @@ func (r *Two) NoError() error {
 }
 
 func TestNilResult(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractOneCode = `
 package main
 
@@ -921,6 +933,7 @@ func (r *Two) Hello() (*string, error) {
 // If a contract constructor returns `nil, nil` it's considered a logical error,
 // which is returned to the calling contract and/or API.
 func TestConstructorReturnNil(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractOneCode = `
 package main
 
@@ -976,6 +989,7 @@ func New() (*Two, error) {
 // If a contract constructor fails it's considered a logical error,
 // which is returned to the calling contract and/or API.
 func TestConstructorReturnError(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractOneCode = `
 package main
 
@@ -1029,6 +1043,7 @@ func New() (*Two, error) {
 }
 
 func TestGetParent(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractOneCode = `
  package main
 
@@ -1092,6 +1107,7 @@ func TestGinsiderMustDieAfterInsolardError(t *testing.T) {
 }
 
 func TestGetRemoteData(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractOneCode = `
 package main
 
@@ -1144,6 +1160,7 @@ func New() (*Two, error) {
 }
 
 func TestImmutableAnnotation(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractOneCode = `
 package main
 
@@ -1248,6 +1265,7 @@ func (r *Three) DoNothing() (error) {
 }
 
 func TestMultipleConstructorsCall(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractCode = `
 package main
 

--- a/application/functest/migration_shard_test.go
+++ b/application/functest/migration_shard_test.go
@@ -35,7 +35,7 @@ func TestGetFreeAddressCount(t *testing.T) {
 	}
 }
 
-const numShards = 1000
+var numShards = launchnet.GetNumShards()
 
 func TestGetFreeAddressCount_ChangesAfterMigration(t *testing.T) {
 

--- a/application/functest/migration_shard_test.go
+++ b/application/functest/migration_shard_test.go
@@ -35,14 +35,14 @@ func TestGetFreeAddressCount(t *testing.T) {
 	}
 }
 
-var numShards = launchnet.GetNumShards()
-
 func TestGetFreeAddressCount_ChangesAfterMigration(t *testing.T) {
 
 	member, err := newUserWithKeys()
 	require.NoError(t, err)
 
 	trimmedPublicKey := foundation.TrimPublicKey(member.PubKey)
+	numShards, err := launchnet.GetNumShards()
+	require.NoError(t, err)
 	shardIndex := foundation.GetShardIndex(trimmedPublicKey, numShards)
 
 	var migrationShardsMapBefore = getAddressCount(t, shardIndex)
@@ -80,12 +80,16 @@ func TestGetFreeAddressCount_ChangesAfterMigration(t *testing.T) {
 
 func TestGetFreeAddressCount_WithIndex_NotAllRange(t *testing.T) {
 	numLeftShards := 2
+	numShards, err := launchnet.GetNumShards()
+	require.NoError(t, err)
 	var migrationShards = getAddressCount(t, numShards-numLeftShards)
 	require.Len(t, migrationShards, numLeftShards)
 }
 
 func TestGetFreeAddressCount_StartIndexTooBig(t *testing.T) {
-	_, _, err := makeSignedRequest(launchnet.TestRPCUrl, &launchnet.MigrationAdmin, "migration.getAddressCount",
+	numShards, err := launchnet.GetNumShards()
+	require.NoError(t, err)
+	_, _, err = makeSignedRequest(launchnet.TestRPCUrl, &launchnet.MigrationAdmin, "migration.getAddressCount",
 		map[string]interface{}{"startWithIndex": numShards + 2})
 	data := checkConvertRequesterError(t, err).Data
 	require.Contains(t, data.Trace, "incorrect start shard index")

--- a/application/functest/pressure_test.go
+++ b/application/functest/pressure_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/insolar/insolar/application/testutils/launchnet"
 	"github.com/stretchr/testify/require"
 
 	"github.com/insolar/insolar/insolar"
@@ -31,6 +32,7 @@ import (
 )
 
 func TestPressureOnSystem(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractCode = `
 package main
 
@@ -140,6 +142,7 @@ func (c *One) Dec() (int, error) {
 }
 
 func TestCoinPassing(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	var contractCode = `
 package main
 

--- a/application/functest/upload_contract_test.go
+++ b/application/functest/upload_contract_test.go
@@ -21,10 +21,12 @@ package functest
 import (
 	"testing"
 
+	"github.com/insolar/insolar/application/testutils/launchnet"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCallUploadedContract(t *testing.T) {
+	launchnet.RunOnlyWithLaunchnet(t)
 	contractCode := `
 		package main
 		import "github.com/insolar/insolar/logicrunner/builtin/foundation"

--- a/application/testutils/launchnet/launchnet.go
+++ b/application/testutils/launchnet/launchnet.go
@@ -182,7 +182,7 @@ func GetNodesCount() (int, error) {
 	return len(conf.DiscoverNodes) + len(conf.Nodes), nil
 }
 
-func GetNumShards() int {
+func GetNumShards() (int, error) {
 	type bootstrapConf struct {
 		PKShardCount int `yaml:"ma_shard_count"`
 	}
@@ -191,19 +191,19 @@ func GetNumShards() int {
 
 	path, err := launchnetPath("bootstrap.yaml")
 	if err != nil {
-		return 0
+		return 0, err
 	}
 	buff, err := ioutil.ReadFile(path)
 	if err != nil {
-		return 0
+		return 0, errors.Wrap(err, "[ GetNumShards ] Can't read bootstrap config")
 	}
 
 	err = yaml.Unmarshal(buff, &conf)
 	if err != nil {
-		return 0
+		return 0, errors.Wrap(err, "[ GetNumShards ] Can't parse bootstrap config")
 	}
 
-	return conf.PKShardCount
+	return conf.PKShardCount, nil
 }
 
 func loadMemberKeys(keysPath string, member *User) error {

--- a/application/testutils/launchnet/launchnet.go
+++ b/application/testutils/launchnet/launchnet.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"testing"
 	"time"
 
 	yaml "gopkg.in/yaml.v2"
@@ -49,8 +50,14 @@ const AdminPort = "19002"
 const PublicPort = "19102"
 const HostDebug = "http://localhost:8001"
 const TestAdminRPCUrl = "/admin-api/rpc"
-const TestRPCUrl = HOST + AdminPort + TestAdminRPCUrl
-const TestRPCUrlPublic = HOST + PublicPort + "/api/rpc"
+
+var AdminHostPort = HOST + AdminPort
+var TestRPCUrl = HOST + AdminPort + TestAdminRPCUrl
+var TestRPCUrlPublic = HOST + PublicPort + "/api/rpc"
+var disableLaunchnet = false
+var testRPCUrlVar = "INSOLAR_FUNC_RPC_URL"
+var testRPCUrlPublicVar = "INSOLAR_FUNC_RPC_URL_PUBLIC"
+var keysPathVar = "INSOLAR_FUNC_KEYS_PATH"
 
 const insolarRootMemberKeys = "root_member_keys.json"
 const insolarMigrationAdminMemberKeys = "migration_admin_member_keys.json"
@@ -118,6 +125,12 @@ type User struct {
 }
 
 func launchnetPath(a ...string) (string, error) {
+	keysPath := os.Getenv(keysPathVar)
+	if keysPath != "" {
+		p := []string{keysPath}
+		p = append(p, a[len(a)-1])
+		return filepath.Join(p...), nil
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", errors.Wrap(err, "[ startNet ] Can't get current working directory")
@@ -167,6 +180,30 @@ func GetNodesCount() (int, error) {
 	}
 
 	return len(conf.DiscoverNodes) + len(conf.Nodes), nil
+}
+
+func GetNumShards() int {
+	type bootstrapConf struct {
+		PKShardCount int `yaml:"ma_shard_count"`
+	}
+
+	var conf bootstrapConf
+
+	path, err := launchnetPath("bootstrap.yaml")
+	if err != nil {
+		return 0
+	}
+	buff, err := ioutil.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+
+	err = yaml.Unmarshal(buff, &conf)
+	if err != nil {
+		return 0
+	}
+
+	return conf.PKShardCount
 }
 
 func loadMemberKeys(keysPath string, member *User) error {
@@ -473,13 +510,30 @@ func waitForLaunch() error {
 	}
 }
 
+func RunOnlyWithLaunchnet(t *testing.T) {
+	if disableLaunchnet {
+		t.Skip()
+	}
+}
+
 func setup() error {
-	err := startNet()
-	if err != nil {
-		return errors.Wrap(err, "[ setup ] could't startNet")
+	testRPCUrl := os.Getenv(testRPCUrlVar)
+	testRPCUrlPublic := os.Getenv(testRPCUrlPublicVar)
+
+	if testRPCUrl == "" || testRPCUrlPublic == "" {
+		err := startNet()
+		if err != nil {
+			return errors.Wrap(err, "[ setup ] could't startNet")
+		}
+	} else {
+		TestRPCUrl = testRPCUrl
+		TestRPCUrlPublic = testRPCUrlPublic
+		url := strings.Split(TestRPCUrlPublic, "/")
+		AdminHostPort = strings.Join(url[0:len(url)-1], "/")
+		disableLaunchnet = true
 	}
 
-	err = loadAllMembersKeys()
+	err := loadAllMembersKeys()
 	if err != nil {
 		return errors.Wrap(err, "[ setup ] could't load keys: ")
 	}


### PR DESCRIPTION
**- What I did**
Add env variable for functests, so we can run it without launch new insolar net:
INSOLAR_FUNC_RPC_URL - admin url (http://localhost:8001/admin-api/rpc)
INSOLAR_FUNC_RPC_URL_PUBLIC - public url  (http://localhost:8001/api/rpc)
INSOLAR_FUNC_KEYS_PATH - path to keys and configs (/tmp/jepsen-keys/)

**- How to verify it**
Run tests.