### PR TITLE
Noissue reduce iterator prefetch un pulse db

### DIFF
--- a/insolar/pulse/db.go
+++ b/insolar/pulse/db.go
@@ -246,6 +246,7 @@ func (s *DB) traverse(ctx context.Context, pn insolar.PulseNumber, steps int, re
 		err := s.db.View(func(txn *badger.Txn) error {
 			opts := badger.DefaultIteratorOptions
 			opts.Reverse = reverse
+			opts.PrefetchSize = steps + 1
 			it := txn.NewIterator(opts)
 			defer it.Close()
 
@@ -295,6 +296,8 @@ func (s *DB) traverse(ctx context.Context, pn insolar.PulseNumber, steps int, re
 func head(txn *badger.Txn) (insolar.PulseNumber, error) {
 	opts := badger.DefaultIteratorOptions
 	opts.Reverse = true
+	// we need only one last key
+	opts.PrefetchSize = 1
 	it := txn.NewIterator(opts)
 	defer it.Close()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Reduce prefetch of a lot of values in pulse db since we need only few of them

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
