### PR TITLE
INS-3925: use the same lightchainlimit as @ prod in launchnet.sh

### DIFF
--- a/scripts/insolard/defaults/insolard.yaml
+++ b/scripts/insolard/defaults/insolard.yaml
@@ -3,3 +3,5 @@ metrics:
 # Uncomment this section to disable consensus
 service:
   consensusenabled: false
+ledger:
+  lightchainlimit: 15

--- a/scripts/insolard/defaults/insolard.yaml
+++ b/scripts/insolard/defaults/insolard.yaml
@@ -1,7 +1,4 @@
 metrics:
   zpagesenabled: false
-# Uncomment this section to disable consensus
-service:
-  consensusenabled: false
 ledger:
   lightchainlimit: 15


### PR DESCRIPTION
This suppose to fix `last finalized pulse falls behind too much. Stop node` during nightly functests run.