### PR TITLE
NOISSUE: deposit tweaks

### DIFF
--- a/application/builtin/contract/deposit/deposit.go
+++ b/application/builtin/contract/deposit/deposit.go
@@ -21,6 +21,8 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/insolar/insolar/application/appfoundation"
 	"github.com/insolar/insolar/application/builtin/proxy/deposit"
 	"github.com/insolar/insolar/application/builtin/proxy/member"
@@ -51,6 +53,10 @@ type Deposit struct {
 
 // New creates new deposit.
 func New(txHash string, lockup int64, vesting int64, vestingStep int64) (*Deposit, error) {
+
+	if vesting%vestingStep != 0 {
+		return nil, errors.New("vesting is not multiple of vestingStep")
+	}
 
 	migrationDaemonConfirms := make(foundation.StableMap)
 

--- a/application/builtin/contract/deposit/deposit.go
+++ b/application/builtin/contract/deposit/deposit.go
@@ -142,7 +142,7 @@ func (d *Deposit) Confirm(
 
 	migrationDaemonRef := fromMember.String()
 	if txHash != d.TxHash {
-		return fmt.Errorf("transaction hash is incorrect")
+		return errors.New("transaction hash is incorrect")
 	}
 	if confirmedAmount, ok := d.MigrationDaemonConfirms[migrationDaemonRef]; ok {
 		if amountStr != confirmedAmount {
@@ -174,7 +174,7 @@ func (d *Deposit) Confirm(
 		if canConfirm {
 			currentPulse, err := foundation.GetPulseNumber()
 			if err != nil {
-				return fmt.Errorf("failed to get current pulse: %s", err.Error())
+				return errors.Wrap(err, "failed to get current pulse")
 			}
 			d.Amount = amountStr
 			d.PulseDepositUnHold = currentPulse + insolar.PulseNumber(d.Lockup)
@@ -182,7 +182,7 @@ func (d *Deposit) Confirm(
 			ma := member.GetObject(appfoundation.GetMigrationAdminMember())
 			walletRef, err := ma.GetWallet()
 			if err != nil {
-				return fmt.Errorf("failed to get wallet: %s", err.Error())
+				return errors.Wrap(err, "failed to get wallet")
 			}
 			ok, maDeposit, _ := wallet.GetObject(*walletRef).FindDeposit(genesisrefs.FundsDepositName)
 			if !ok {
@@ -193,7 +193,7 @@ func (d *Deposit) Confirm(
 				amountStr, d.GetReference(), appfoundation.GetMigrationAdminMember(), request, toMember,
 			)
 			if err != nil {
-				return fmt.Errorf("failed to transfer from migration deposit to deposit: %s", err.Error())
+				return errors.Wrap(err, "failed to transfer from migration deposit to deposit")
 			}
 			d.IsConfirmed = true
 		}
@@ -216,18 +216,18 @@ func (d *Deposit) TransferToDeposit(
 ) error {
 	amount, ok := new(big.Int).SetString(amountStr, 10)
 	if !ok {
-		return fmt.Errorf("can't parse input amount")
+		return errors.New("can't parse input amount")
 	}
 	balance, ok := new(big.Int).SetString(d.Balance, 10)
 	if !ok {
-		return fmt.Errorf("can't parse deposit balance")
+		return errors.New("can't parse deposit balance")
 	}
 	if balance.Sign() <= 0 {
-		return fmt.Errorf("not enough balance for transfer")
+		return errors.New("not enough balance for transfer")
 	}
 	newBalance, err := safemath.Sub(balance, amount)
 	if err != nil {
-		return fmt.Errorf("not enough balance for transfer: %s", err.Error())
+		return errors.Wrap(err, "not enough balance for transfer")
 	}
 	d.Balance = newBalance.String()
 	destination := deposit.GetObject(toDeposit)
@@ -240,7 +240,7 @@ func (d *Deposit) TransferToDeposit(
 		return nil
 	}
 	d.Balance = balance.String()
-	return fmt.Errorf("failed to transfer amount: %s", acceptDepositErr.Error())
+	return errors.Wrap(err, "failed to transfer amount")
 
 }
 
@@ -248,7 +248,7 @@ func (d *Deposit) TransferToDeposit(
 func (d *Deposit) checkAmount(activeDaemons map[string]string, migrationDaemonRef string, amountStr string) (bool, error) {
 	confirmed := false
 	if activeDaemons == nil || len(activeDaemons) == 0 {
-		return false, fmt.Errorf("list with migration daemons member is empty")
+		return false, errors.New("list with migration daemons member is empty")
 	}
 	amountConfirms := make(map[string]int) // amount: num of confirms
 	var errDaemon []string
@@ -278,12 +278,12 @@ func (d *Deposit) checkConfirm(migrationDaemonRef string, amountStr string) (boo
 	for ref, a := range d.MigrationDaemonConfirms {
 		migrationDaemonMemberRef, err := insolar.NewObjectReferenceFromString(ref)
 		if err != nil {
-			return false, fmt.Errorf(" failed to parse params.Reference")
+			return false, errors.New("failed to parse params.Reference")
 		}
 
 		migrationDaemonContractRef, err := appfoundation.GetMigrationDaemon(*migrationDaemonMemberRef)
 		if err != nil || migrationDaemonContractRef.IsEmpty() {
-			return false, fmt.Errorf(" get migration daemon contract from foundation failed, %s ", err)
+			return false, errors.Wrap(err, "get migration daemon contract from foundation failed")
 		}
 
 		migrationDaemonContract := migrationdaemon.GetObject(migrationDaemonContractRef)
@@ -300,7 +300,7 @@ func (d *Deposit) checkConfirm(migrationDaemonRef string, amountStr string) (boo
 	if len(activateDaemons) > 0 {
 		canConfirm, err := d.checkAmount(activateDaemons, migrationDaemonRef, amountStr)
 		if err != nil {
-			return canConfirm, fmt.Errorf("failed to check amount in confirmation from migration daemon: %s", err.Error())
+			return canConfirm, errors.Wrap(err, "failed to check amount in confirmation from migration daemon")
 		}
 		return canConfirm, nil
 	}
@@ -309,25 +309,25 @@ func (d *Deposit) checkConfirm(migrationDaemonRef string, amountStr string) (boo
 
 func (d *Deposit) canTransfer(transferAmount *big.Int) error {
 	if d.VestingType == appfoundation.DefaultVesting && !d.IsConfirmed {
-		return fmt.Errorf("number of confirms is less then 2")
+		return errors.New("number of confirms is less then 2")
 	}
 
 	currentPulse, err := foundation.GetPulseNumber()
 	if err != nil {
-		return fmt.Errorf("failed to get pulse number: %s", err.Error())
+		return errors.Wrap(err, "failed to get pulse number")
 	}
 	if d.PulseDepositUnHold > currentPulse {
-		return fmt.Errorf("hold period didn't end")
+		return errors.New("hold period didn't end")
 	}
 
 	spentPeriodInPulses := big.NewInt(int64(currentPulse-d.PulseDepositUnHold) / d.VestingStep)
 	amount, ok := new(big.Int).SetString(d.Amount, 10)
 	if !ok {
-		return fmt.Errorf("can't parse derposit amount")
+		return errors.New("can't parse derposit amount")
 	}
 	balance, ok := new(big.Int).SetString(d.Balance, 10)
 	if !ok {
-		return fmt.Errorf("can't parse derposit balance")
+		return errors.New("can't parse derposit balance")
 	}
 
 	// How much can we transfer for this time
@@ -339,7 +339,7 @@ func (d *Deposit) canTransfer(transferAmount *big.Int) error {
 	if new(big.Int).Sub(amount, availableForNow).Cmp(
 		new(big.Int).Sub(balance, transferAmount),
 	) == 1 {
-		return fmt.Errorf("not enough unholded balance for transfer")
+		return errors.New("not enough unholded balance for transfer")
 	}
 
 	return nil
@@ -352,15 +352,15 @@ func (d *Deposit) Transfer(
 
 	amount, ok := new(big.Int).SetString(amountStr, 10)
 	if !ok {
-		return nil, fmt.Errorf("can't parse input amount")
+		return nil, errors.New("can't parse input amount")
 	}
 
 	balance, ok := new(big.Int).SetString(d.Balance, 10)
 	if !ok {
-		return nil, fmt.Errorf("can't parse deposit balance")
+		return nil, errors.New("can't parse deposit balance")
 	}
 	if balance.Sign() <= 0 {
-		return nil, fmt.Errorf("not enough balance for transfer")
+		return nil, errors.New("not enough balance for transfer")
 	}
 	newBalance, err := safemath.Sub(balance, amount)
 	if err != nil {
@@ -382,7 +382,7 @@ func (d *Deposit) Transfer(
 		return nil, nil
 	}
 	d.Balance = balance.String()
-	return nil, fmt.Errorf("failed to transfer amount: %s", acceptMemberErr.Error())
+	return nil, errors.Wrap(acceptMemberErr, "failed to transfer amount")
 }
 
 // Accept accepts transfer to balance.
@@ -392,18 +392,18 @@ func (d *Deposit) Accept(arg appfoundation.SagaAcceptInfo) error {
 	amount := new(big.Int)
 	amount, ok := amount.SetString(arg.Amount, 10)
 	if !ok {
-		return fmt.Errorf("can't parse input amount")
+		return errors.New("can't parse input amount")
 	}
 
 	balance := new(big.Int)
 	balance, ok = balance.SetString(d.Balance, 10)
 	if !ok {
-		return fmt.Errorf("can't parse deposit balance")
+		return errors.New("can't parse deposit balance")
 	}
 
 	b, err := safemath.Add(balance, amount)
 	if err != nil {
-		return fmt.Errorf("failed to add amount to balance: %s", err.Error())
+		return errors.Wrap(err, "failed to add amount to balance")
 	}
 	d.Balance = b.String()
 

--- a/application/builtin/contract/deposit/deposit.go
+++ b/application/builtin/contract/deposit/deposit.go
@@ -348,6 +348,11 @@ func (d *Deposit) availableAmount() (*big.Int, error) {
 	// Amount that is now available for withdrawal
 	availableNow := new(big.Int).Sub(balance, onHold)
 
+	// availableNow can become negative when balance is 0 and vesting has already started
+	if availableNow.Cmp(big.NewInt(0)) == -1 {
+		return big.NewInt(0), nil
+	}
+
 	return availableNow, nil
 }
 

--- a/application/genesis/genesis.go
+++ b/application/genesis/genesis.go
@@ -424,6 +424,9 @@ func (g *Genesis) storeContracts(ctx context.Context) error {
 	if g.ContractsConfig.PKShardCount <= 0 {
 		panic(fmt.Sprintf("[genesis] store contracts failed: setup pk_shard_count parameter, current value %v", g.ContractsConfig.PKShardCount))
 	}
+	if g.ContractsConfig.VestingPeriodInPulses%g.ContractsConfig.VestingStepInPulses != 0 {
+		panic(fmt.Sprintf("[genesis] store contracts failed: vesting_pulse_period (%d) is not a multiple of vesting_pulse_step (%d)", g.ContractsConfig.VestingPeriodInPulses, g.ContractsConfig.VestingStepInPulses))
+	}
 
 	// Split genesis members by PK shards
 	var membersByPKShards []foundation.StableMap

--- a/ledger/heavy/integration/pulsefinalization_test.go
+++ b/ledger/heavy/integration/pulsefinalization_test.go
@@ -40,9 +40,11 @@ func Test_FinalizePulse(t *testing.T) {
 	defer os.RemoveAll(cfg.Ledger.Storage.DataDirectory)
 	heavyConfig := application.GenesisHeavyConfig{
 		ContractsConfig: application.GenesisContractsConfig{
-			PKShardCount:       10,
-			MAShardCount:       10,
-			MigrationAddresses: make([][]string, 10),
+			PKShardCount:          10,
+			MAShardCount:          10,
+			MigrationAddresses:    make([][]string, 10),
+			VestingStepInPulses:   10,
+			VestingPeriodInPulses: 10,
 		},
 	}
 	s, err := NewServer(ctx, cfg, heavyConfig, nil)

--- a/ledger/heavy/integration/startstop_test.go
+++ b/ledger/heavy/integration/startstop_test.go
@@ -32,9 +32,11 @@ func TestStartStop(t *testing.T) {
 	defer os.RemoveAll(cfg.Ledger.Storage.DataDirectory)
 	heavyConfig := application.GenesisHeavyConfig{
 		ContractsConfig: application.GenesisContractsConfig{
-			PKShardCount:       10,
-			MAShardCount:       10,
-			MigrationAddresses: make([][]string, 10),
+			PKShardCount:          10,
+			MAShardCount:          10,
+			MigrationAddresses:    make([][]string, 10),
+			VestingStepInPulses:   10,
+			VestingPeriodInPulses: 10,
 		},
 	}
 	s, err := NewServer(context.Background(), cfg, heavyConfig, nil)


### PR DESCRIPTION
 * Added restriction to deposit constructor that only allows creating a deposit if vesting period is a multiple of vesting step. To avoid creating deposits with "fractional" vesting steps.
 * Refactored all errors handling in the deposit (`errors.Wrap()` instead of `fmt.Errorf`).
 * Rewritten `canTransfer()` method in a clearer way.