### PR TITLE
INS-3929: when deposit is not yet confirmed then holdStartDate was negative

### DIFF
--- a/application/builtin/contract/deposit/deposit.go
+++ b/application/builtin/contract/deposit/deposit.go
@@ -121,9 +121,13 @@ func (d *Deposit) Itself() (interface{}, error) {
 	if err == nil {
 		pulseDepositUnHold = t.Unix()
 	}
+	holdStartDate := pulseDepositUnHold - d.Lockup
+	if holdStartDate < 0 {
+		holdStartDate = 0
+	}
 	return &DepositOut{
 		Balance:                 d.Balance,
-		HoldStartDate:           pulseDepositUnHold - d.Lockup,
+		HoldStartDate:           holdStartDate,
 		PulseDepositUnHold:      pulseDepositUnHold,
 		MigrationDaemonConfirms: daemonConfirms,
 		Amount:                  d.Amount,


### PR DESCRIPTION
this value shouldn't be negative, we have test for this in e2e/autotests