### PR TITLE
INS-4033: remove updateJet because virtual goes to latest executor

### DIFF
--- a/ledger/light/proc/get_request.go
+++ b/ledger/light/proc/get_request.go
@@ -20,15 +20,15 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/bus"
 	"github.com/insolar/insolar/insolar/jet"
 	"github.com/insolar/insolar/insolar/payload"
 	"github.com/insolar/insolar/insolar/record"
-	"github.com/insolar/insolar/instrumentation/inslogger"
 	"github.com/insolar/insolar/ledger/light/executor"
 	"github.com/insolar/insolar/ledger/object"
-	"github.com/pkg/errors"
 )
 
 type GetRequest struct {
@@ -119,19 +119,6 @@ func (p *GetRequest) Proceed(ctx context.Context) error {
 				return errors.Wrap(err, "failed to calculate role")
 			}
 			node = *l
-
-			inslogger.FromContext(ctx).Warn("virtual node missed jet")
-
-			// Send calculated jet to virtual node.
-			updateMsg, err := payload.NewMessage(&payload.UpdateJet{
-				Pulse: p.requestID.Pulse(),
-				JetID: insolar.JetID(*jetID),
-			})
-			if err != nil {
-				return errors.Wrap(err, "failed to create jet message")
-			}
-			_, done := p.dep.sender.SendTarget(ctx, updateMsg, p.message.Sender)
-			done()
 		}
 
 		_, done := p.dep.sender.SendTarget(ctx, msg, node)


### PR DESCRIPTION
**- What I did**
removed log and updateJet message for virtual, because virtual always goes to latest executor and it should redirect to proper one
