### PR TITLE
INS-4042: fix race logic in contract MigrationDaemon

### DIFF
--- a/application/builtin/contract/migrationdaemon/migrationdaemon.go
+++ b/application/builtin/contract/migrationdaemon/migrationdaemon.go
@@ -118,7 +118,7 @@ func (md *MigrationDaemon) depositMigration(
 	vestingParams, _ := migrationAdminContract.GetDepositParameters()
 	depositRef, err := w.FindOrCreateDeposit(txHash, vestingParams.Lockup, vestingParams.Vesting, vestingParams.VestingStep)
 	if err != nil {
-		return nil, fmt.Errorf("failed to save as child: %s", err.Error())
+		return nil, fmt.Errorf("failed to get or create deposit: %s", err.Error())
 	}
 
 	return addConfirmToDeposit(*tokenHolderRef, *depositRef, txHash, amount.String(), caller, request)

--- a/application/builtin/contract/migrationdaemon/migrationdaemon.go
+++ b/application/builtin/contract/migrationdaemon/migrationdaemon.go
@@ -113,28 +113,15 @@ func (md *MigrationDaemon) depositMigration(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get wallet: %s", err.Error())
 	}
+
 	w := wallet.GetObject(*tokenHolderWallet)
-	isFound, txDepositRef, err := w.FindDeposit(txHash)
+	vestingParams, _ := migrationAdminContract.GetDepositParameters()
+	depositRef, err := w.FindOrCreateDeposit(txHash, vestingParams.Lockup, vestingParams.Vesting, vestingParams.VestingStep)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get deposit: %s", err.Error())
+		return nil, fmt.Errorf("failed to save as child: %s", err.Error())
 	}
 
-	// If deposit doesn't exist - create new deposit
-	if !isFound {
-		var err error
-		vestingParams, _ := migrationAdminContract.GetDepositParameters()
-		dHolder := deposit.New(txHash, vestingParams.Lockup, vestingParams.Vesting, vestingParams.VestingStep)
-		txDeposit, err := dHolder.AsChild(*tokenHolderRef)
-		if err != nil {
-			return nil, fmt.Errorf("failed to save as child: %s", err.Error())
-		}
-		err = w.AddDeposit(txHash, txDeposit.GetReference())
-		if err != nil {
-			return nil, fmt.Errorf("failed to set deposit: %s", err.Error())
-		}
-		txDepositRef = &txDeposit.Reference
-	}
-	return addConfirmToDeposit(*tokenHolderRef, *txDepositRef, txHash, amount.String(), caller, request)
+	return addConfirmToDeposit(*tokenHolderRef, *depositRef, txHash, amount.String(), caller, request)
 }
 
 func getAmountFromParam(params map[string]interface{}) (*big.Int, error) {

--- a/application/builtin/contract/wallet/wallet.wrapper.go
+++ b/application/builtin/contract/wallet/wallet.wrapper.go
@@ -343,90 +343,6 @@ func INSMETHOD_GetBalance(object []byte, data []byte) (newState []byte, result [
 	return
 }
 
-func INSMETHOD_AddDeposit(object []byte, data []byte) (newState []byte, result []byte, err error) {
-	ph := common.CurrentProxyCtx
-	ph.SetSystemError(nil)
-
-	self := new(Wallet)
-
-	if len(object) == 0 {
-		err = &foundation.Error{S: "[ FakeAddDeposit ] ( INSMETHOD_* ) ( Generated Method ) Object is nil"}
-		return
-	}
-
-	err = ph.Deserialize(object, self)
-	if err != nil {
-		err = &foundation.Error{S: "[ FakeAddDeposit ] ( INSMETHOD_* ) ( Generated Method ) Can't deserialize args.Data: " + err.Error()}
-		return
-	}
-
-	args := make([]interface{}, 2)
-	var args0 string
-	args[0] = &args0
-	var args1 insolar.Reference
-	args[1] = &args1
-
-	err = ph.Deserialize(data, &args)
-	if err != nil {
-		err = &foundation.Error{S: "[ FakeAddDeposit ] ( INSMETHOD_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
-		return
-	}
-
-	var ret0 error
-
-	serializeResults := func() error {
-		return ph.Serialize(
-			foundation.Result{Returns: []interface{}{ret0}},
-			&result,
-		)
-	}
-
-	needRecover := true
-	defer func() {
-		if !needRecover {
-			return
-		}
-		if r := recover(); r != nil {
-			recoveredError := errors.Wrap(errors.Errorf("%v", r), "Failed to execute method (panic)")
-			recoveredError = ph.MakeErrorSerializable(recoveredError)
-
-			if PanicIsLogicalError {
-				ret0 = recoveredError
-
-				newState = object
-				err = serializeResults()
-				if err == nil {
-					newState = object
-				}
-			} else {
-				err = recoveredError
-			}
-		}
-	}()
-
-	ret0 = self.AddDeposit(args0, args1)
-
-	needRecover = false
-
-	if ph.GetSystemError() != nil {
-		return nil, nil, ph.GetSystemError()
-	}
-
-	err = ph.Serialize(self, &newState)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	ret0 = ph.MakeErrorSerializable(ret0)
-
-	err = serializeResults()
-	if err != nil {
-		return
-	}
-
-	return
-}
-
 func INSMETHOD_GetDeposits(object []byte, data []byte) (newState []byte, result []byte, err error) {
 	ph := common.CurrentProxyCtx
 	ph.SetSystemError(nil)
@@ -592,6 +508,95 @@ func INSMETHOD_FindDeposit(object []byte, data []byte) (newState []byte, result 
 	return
 }
 
+func INSMETHOD_FindOrCreateDeposit(object []byte, data []byte) (newState []byte, result []byte, err error) {
+	ph := common.CurrentProxyCtx
+	ph.SetSystemError(nil)
+
+	self := new(Wallet)
+
+	if len(object) == 0 {
+		err = &foundation.Error{S: "[ FakeFindOrCreateDeposit ] ( INSMETHOD_* ) ( Generated Method ) Object is nil"}
+		return
+	}
+
+	err = ph.Deserialize(object, self)
+	if err != nil {
+		err = &foundation.Error{S: "[ FakeFindOrCreateDeposit ] ( INSMETHOD_* ) ( Generated Method ) Can't deserialize args.Data: " + err.Error()}
+		return
+	}
+
+	args := make([]interface{}, 4)
+	var args0 string
+	args[0] = &args0
+	var args1 int64
+	args[1] = &args1
+	var args2 int64
+	args[2] = &args2
+	var args3 int64
+	args[3] = &args3
+
+	err = ph.Deserialize(data, &args)
+	if err != nil {
+		err = &foundation.Error{S: "[ FakeFindOrCreateDeposit ] ( INSMETHOD_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
+		return
+	}
+
+	var ret0 *insolar.Reference
+	var ret1 error
+
+	serializeResults := func() error {
+		return ph.Serialize(
+			foundation.Result{Returns: []interface{}{ret0, ret1}},
+			&result,
+		)
+	}
+
+	needRecover := true
+	defer func() {
+		if !needRecover {
+			return
+		}
+		if r := recover(); r != nil {
+			recoveredError := errors.Wrap(errors.Errorf("%v", r), "Failed to execute method (panic)")
+			recoveredError = ph.MakeErrorSerializable(recoveredError)
+
+			if PanicIsLogicalError {
+				ret1 = recoveredError
+
+				newState = object
+				err = serializeResults()
+				if err == nil {
+					newState = object
+				}
+			} else {
+				err = recoveredError
+			}
+		}
+	}()
+
+	ret0, ret1 = self.FindOrCreateDeposit(args0, args1, args2, args3)
+
+	needRecover = false
+
+	if ph.GetSystemError() != nil {
+		return nil, nil, ph.GetSystemError()
+	}
+
+	err = ph.Serialize(self, &newState)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ret1 = ph.MakeErrorSerializable(ret1)
+
+	err = serializeResults()
+	if err != nil {
+		return
+	}
+
+	return
+}
+
 func INSCONSTRUCTOR_New(ref insolar.Reference, data []byte) (state []byte, result []byte, err error) {
 	ph := common.CurrentProxyCtx
 	ph.SetSystemError(nil)
@@ -676,12 +681,12 @@ func Initialize() insolar.ContractWrapper {
 		GetCode:      INSMETHOD_GetCode,
 		GetPrototype: INSMETHOD_GetPrototype,
 		Methods: insolar.ContractMethods{
-			"GetAccount":  INSMETHOD_GetAccount,
-			"Transfer":    INSMETHOD_Transfer,
-			"GetBalance":  INSMETHOD_GetBalance,
-			"AddDeposit":  INSMETHOD_AddDeposit,
-			"GetDeposits": INSMETHOD_GetDeposits,
-			"FindDeposit": INSMETHOD_FindDeposit,
+			"GetAccount":          INSMETHOD_GetAccount,
+			"Transfer":            INSMETHOD_Transfer,
+			"GetBalance":          INSMETHOD_GetBalance,
+			"GetDeposits":         INSMETHOD_GetDeposits,
+			"FindDeposit":         INSMETHOD_FindDeposit,
+			"FindOrCreateDeposit": INSMETHOD_FindOrCreateDeposit,
 		},
 		Constructors: insolar.ContractConstructors{
 			"New": INSCONSTRUCTOR_New,

--- a/application/builtin/proxy/wallet/wallet.go
+++ b/application/builtin/proxy/wallet/wallet.go
@@ -409,84 +409,6 @@ func (r *Wallet) GetBalance(assetName string) (string, error) {
 	return ret0, nil
 }
 
-// AddDeposit is proxy generated method
-func (r *Wallet) AddDeposit(txId string, deposit insolar.Reference) error {
-	var args [2]interface{}
-	args[0] = txId
-	args[1] = deposit
-
-	var argsSerialized []byte
-
-	ret := make([]interface{}, 1)
-	var ret0 *foundation.Error
-	ret[0] = &ret0
-
-	err := common.CurrentProxyCtx.Serialize(args, &argsSerialized)
-	if err != nil {
-		return err
-	}
-
-	res, err := common.CurrentProxyCtx.RouteCall(r.Reference, false, false, "AddDeposit", argsSerialized, *PrototypeReference)
-	if err != nil {
-		return err
-	}
-
-	resultContainer := foundation.Result{
-		Returns: ret,
-	}
-	err = common.CurrentProxyCtx.Deserialize(res, &resultContainer)
-	if err != nil {
-		return err
-	}
-	if resultContainer.Error != nil {
-		err = resultContainer.Error
-		return err
-	}
-	if ret0 != nil {
-		return ret0
-	}
-	return nil
-}
-
-// AddDepositAsImmutable is proxy generated method
-func (r *Wallet) AddDepositAsImmutable(txId string, deposit insolar.Reference) error {
-	var args [2]interface{}
-	args[0] = txId
-	args[1] = deposit
-
-	var argsSerialized []byte
-
-	ret := make([]interface{}, 1)
-	var ret0 *foundation.Error
-	ret[0] = &ret0
-
-	err := common.CurrentProxyCtx.Serialize(args, &argsSerialized)
-	if err != nil {
-		return err
-	}
-
-	res, err := common.CurrentProxyCtx.RouteCall(r.Reference, true, false, "AddDeposit", argsSerialized, *PrototypeReference)
-	if err != nil {
-		return err
-	}
-
-	resultContainer := foundation.Result{
-		Returns: ret,
-	}
-	err = common.CurrentProxyCtx.Deserialize(res, &resultContainer)
-	if err != nil {
-		return err
-	}
-	if resultContainer.Error != nil {
-		err = resultContainer.Error
-		return err
-	}
-	if ret0 != nil {
-		return ret0
-	}
-	return nil
-}
-
 // GetDeposits is proxy generated method
 func (r *Wallet) GetDepositsAsMutable() ([]interface{}, error) {
 	var args [0]interface{}
@@ -647,4 +569,90 @@ func (r *Wallet) FindDeposit(transactionHash string) (bool, *insolar.Reference, 
 		return ret0, ret1, ret2
 	}
 	return ret0, ret1, nil
+}
+
+// FindOrCreateDeposit is proxy generated method
+func (r *Wallet) FindOrCreateDeposit(transactionHash string, lockup int64, vesting int64, vestingStep int64) (*insolar.Reference, error) {
+	var args [4]interface{}
+	args[0] = transactionHash
+	args[1] = lockup
+	args[2] = vesting
+	args[3] = vestingStep
+
+	var argsSerialized []byte
+
+	ret := make([]interface{}, 2)
+	var ret0 *insolar.Reference
+	ret[0] = &ret0
+	var ret1 *foundation.Error
+	ret[1] = &ret1
+
+	err := common.CurrentProxyCtx.Serialize(args, &argsSerialized)
+	if err != nil {
+		return ret0, err
+	}
+
+	res, err := common.CurrentProxyCtx.RouteCall(r.Reference, false, false, "FindOrCreateDeposit", argsSerialized, *PrototypeReference)
+	if err != nil {
+		return ret0, err
+	}
+
+	resultContainer := foundation.Result{
+		Returns: ret,
+	}
+	err = common.CurrentProxyCtx.Deserialize(res, &resultContainer)
+	if err != nil {
+		return ret0, err
+	}
+	if resultContainer.Error != nil {
+		err = resultContainer.Error
+		return ret0, err
+	}
+	if ret1 != nil {
+		return ret0, ret1
+	}
+	return ret0, nil
+}
+
+// FindOrCreateDepositAsImmutable is proxy generated method
+func (r *Wallet) FindOrCreateDepositAsImmutable(transactionHash string, lockup int64, vesting int64, vestingStep int64) (*insolar.Reference, error) {
+	var args [4]interface{}
+	args[0] = transactionHash
+	args[1] = lockup
+	args[2] = vesting
+	args[3] = vestingStep
+
+	var argsSerialized []byte
+
+	ret := make([]interface{}, 2)
+	var ret0 *insolar.Reference
+	ret[0] = &ret0
+	var ret1 *foundation.Error
+	ret[1] = &ret1
+
+	err := common.CurrentProxyCtx.Serialize(args, &argsSerialized)
+	if err != nil {
+		return ret0, err
+	}
+
+	res, err := common.CurrentProxyCtx.RouteCall(r.Reference, true, false, "FindOrCreateDeposit", argsSerialized, *PrototypeReference)
+	if err != nil {
+		return ret0, err
+	}
+
+	resultContainer := foundation.Result{
+		Returns: ret,
+	}
+	err = common.CurrentProxyCtx.Deserialize(res, &resultContainer)
+	if err != nil {
+		return ret0, err
+	}
+	if resultContainer.Error != nil {
+		err = resultContainer.Error
+		return ret0, err
+	}
+	if ret1 != nil {
+		return ret0, ret1
+	}
+	return ret0, nil
 }


### PR DESCRIPTION
Fixed race in case when two different migration daemons want to confirm deposit.
Both calls can didn't found deposit. And it will result a race in the AddDeposit to wallet step

New logic with method FindOrCreateDeposit will prevent it