### PR TITLE
INS-4032: remove t.Parallel() from light's interation tests

### DIFF
--- a/ledger/light/integration/abandoned_notification_test.go
+++ b/ledger/light/integration/abandoned_notification_test.go
@@ -172,7 +172,6 @@ func Test_AbandonedNotification_WhenLightEmpty(t *testing.T) {
 }
 
 func Test_AbandonedNotification_WhenLightInit(t *testing.T) {
-	t.Parallel()
 	// Configs.
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()

--- a/ledger/light/integration/getobject_test.go
+++ b/ledger/light/integration/getobject_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func Test_GetObject_PassingRequestID(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)

--- a/ledger/light/integration/jet_split_test.go
+++ b/ledger/light/integration/jet_split_test.go
@@ -62,8 +62,6 @@ func Test_JetSplitEveryPulse(t *testing.T) {
 		},
 	}
 
-	t.Parallel()
-
 	testCase := func(t *testing.T, sc splitCase) {
 
 		var hotObjects = make(chan insolar.JetID)
@@ -167,8 +165,6 @@ func Test_JetSplitEveryPulse(t *testing.T) {
 }
 
 func Test_JetSplitsWhenOverflows(t *testing.T) {
-	t.Parallel()
-
 	var hotObjects = make(chan insolar.JetID)
 	var replication = make(chan insolar.JetID)
 	var hotObjectConfirm = make(chan insolar.JetID)
@@ -284,8 +280,6 @@ func Test_JetSplitsWhenOverflows(t *testing.T) {
 }
 
 func Test_LightStartsFromInitialState(t *testing.T) {
-	t.Parallel()
-
 	var hotObjects = make(chan insolar.JetID)
 	var replication = make(chan insolar.JetID)
 	var hotObjectConfirm = make(chan insolar.JetID)

--- a/ledger/light/integration/light_replication_test.go
+++ b/ledger/light/integration/light_replication_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 func Test_LightReplication(t *testing.T) {
-	t.Parallel()
-
 	var secondPulseNumber = pulse.MinTimePulse + (PulseStep * 2)
 	var expectedLifeline record.Lifeline
 	var expectedObjectID insolar.ID

--- a/ledger/light/integration/light_test.go
+++ b/ledger/light/integration/light_test.go
@@ -35,8 +35,6 @@ import (
 )
 
 func Test_BootstrapCalls(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -59,8 +57,6 @@ func Test_BootstrapCalls(t *testing.T) {
 }
 
 func Test_BasicOperations(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)

--- a/ledger/light/integration/requests_test.go
+++ b/ledger/light/integration/requests_test.go
@@ -39,8 +39,6 @@ import (
 // Note, that we can't cover all combinations here anyway. This should be done in unit tests.
 
 func Test_IncomingRequest_Check(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -116,8 +114,6 @@ func Test_IncomingRequest_Check(t *testing.T) {
 }
 
 func Test_IncomingRequest_Duplicate(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -263,8 +259,6 @@ func Test_IncomingRequest_Duplicate(t *testing.T) {
 }
 
 func Test_OutgoingRequest_Duplicate(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -320,8 +314,6 @@ func Test_OutgoingRequest_Duplicate(t *testing.T) {
 }
 
 func Test_DetachedRequest_notification(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 
@@ -376,8 +368,6 @@ func Test_DetachedRequest_notification(t *testing.T) {
 }
 
 func Test_Result_Duplicate(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -411,8 +401,6 @@ func Test_Result_Duplicate(t *testing.T) {
 }
 
 func Test_IncomingRequest_ClosedReason(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -458,8 +446,6 @@ func Test_IncomingRequest_ClosedReason(t *testing.T) {
 }
 
 func Test_IncomingRequest_ClosingWithOpenOutgoings(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -508,8 +494,6 @@ func Test_IncomingRequest_ClosingWithOpenOutgoings(t *testing.T) {
 }
 
 func Test_IncomingRequest_ClosedReason_FromOtherObject(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -609,8 +593,6 @@ func Test_IncomingRequest_ClosedReason_FromOtherObject(t *testing.T) {
 }
 
 func Test_OutgoingRequest_ClosedReason(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -657,8 +639,6 @@ func Test_OutgoingRequest_ClosedReason(t *testing.T) {
 }
 
 func Test_Requests_OutgoingReason(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -716,8 +696,6 @@ func Test_Requests_OutgoingReason(t *testing.T) {
 }
 
 func Test_OutgoingRequests_DifferentObjects(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -752,8 +730,6 @@ func Test_OutgoingRequests_DifferentObjects(t *testing.T) {
 }
 
 func Test_OutgoingDetached_InPendings(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -818,8 +794,6 @@ func Test_OutgoingDetached_InPendings(t *testing.T) {
 }
 
 func Test_IncomingRequest_DifferentResults(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, nil)
@@ -867,8 +841,6 @@ func Test_IncomingRequest_DifferentResults(t *testing.T) {
 }
 
 func Test_SetRequest_NoObjectReturnsError(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	cfg := DefaultLightConfig()
 	s, err := NewServer(ctx, cfg, func(meta payload.Meta, pl payload.Payload) []payload.Payload {
@@ -903,8 +875,6 @@ func Test_SetRequest_NoObjectReturnsError(t *testing.T) {
 }
 
 func Test_SetRequest_LoopDetected(t *testing.T) {
-	t.Parallel()
-
 	ctx := inslogger.TestContext(t)
 	s, err := NewServer(ctx, DefaultLightConfig(), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
**- What I did**
remove t.Parallel() from light's integration tests

