### PR TITLE
GH actions release logic

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,81 @@
+name: insolar
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  build-pack-release:
+    name: build-pack-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@master
+      - name: gather info
+        id: info
+        run: |
+          echo "::set-output name=tag_name::$(echo $GITHUB_REF | cut -d '/' -f3)"
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "::set-output name=go_version::1.12.15"
+          echo "::set-output name=build_date::$(shell ./scripts/dev/git-date-time.sh -d)"
+          echo "::set-output name=build_time::$(shell ./scripts/dev/git-date-time.sh -t)"
+          echo "::set-output name=build_version::$(git describe --tags)"
+      - name: pack project
+        run: |
+          docker build -t ${{ github.workflow }}:${{ steps.info.outputs.tag_name }} --pull --build-arg "GOLANG_VERSION=${{ steps.info.outputs.go_version }}" --build-arg "BUILD_NUMBER=$GITHUB_RUN_NUMBER" --build-arg "BUILD_DATE=${{ steps.info.outputs.build_date }}" --build-arg "BUILD_TIME=${{ steps.info.outputs.build_time }}" --build-arg "BUILD_HASH=${{ steps.info.outputs.sha_short }}" --build-arg "BUILD_VERSION=${{ steps.info.outputs.build_version }}" .
+          docker tag ${{ github.workflow }}:${{ steps.info.outputs.tag_name }} ${{ secrets.REGISTRY_URL }}/${{ github.workflow }}:${{ steps.info.outputs.tag_name }}
+          docker login -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }} https://${{ secrets.REGISTRY_URL }}
+          docker push ${{ secrets.REGISTRY_URL }}/${{ github.workflow }}:${{ steps.info.outputs.tag_name }}
+      - name: copy artifacts
+        run: |
+          id=$(docker create ${{ secrets.REGISTRY_URL }}/${{ github.workflow }}:${{ steps.info.outputs.tag_name }})
+          mkdir bin
+          docker cp $id:/usr/local/bin/insolar bin/
+          docker cp $id:/usr/local/bin/insolard bin/
+          docker cp $id:/usr/local/bin/keeperd bin/
+          docker cp $id:/usr/local/bin/pulsard bin/
+      - name: create GH release
+        id: create_release
+        uses: actions/create-release@becafb2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: attach insolar binary to GH release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./bin/insolar
+          asset_name: insolar
+          asset_content_type: application/octet-stream
+      - name: attach insolard binary to GH release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./bin/insolard
+          asset_name: insolard
+          asset_content_type: application/octet-stream
+      - name: attach keeperd binary to GH release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./bin/keeperd
+          asset_name: keeperd
+          asset_content_type: application/octet-stream
+      - name: attach pulsard binary to GH release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./bin/pulsard
+          asset_name: pulsard
+          asset_content_type: application/octet-stream

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -15,7 +15,7 @@ jobs:
         run: |
           echo "::set-output name=tag_name::$(echo $GITHUB_REF | cut -d '/' -f3)"
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-          echo "::set-output name=go_version::1.12.15"
+          echo "::set-output name=go_version::1.12"
           echo "::set-output name=build_date::$(shell ./scripts/dev/git-date-time.sh -d)"
           echo "::set-output name=build_time::$(shell ./scripts/dev/git-date-time.sh -t)"
           echo "::set-output name=build_version::$(git describe --tags)"

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -15,7 +15,7 @@ jobs:
         run: |
           echo "::set-output name=tag_name::$(echo $GITHUB_REF | cut -d '/' -f3)"
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-          echo "::set-output name=go_version::1.12.5"
+          echo "::set-output name=go_version::1.12.15"
           echo "::set-output name=build_date::$(shell ./scripts/dev/git-date-time.sh -d)"
           echo "::set-output name=build_time::$(shell ./scripts/dev/git-date-time.sh -t)"
           echo "::set-output name=build_version::$(git describe --tags)"

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -15,7 +15,7 @@ jobs:
         run: |
           echo "::set-output name=tag_name::$(echo $GITHUB_REF | cut -d '/' -f3)"
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-          echo "::set-output name=go_version::1.12"
+          echo "::set-output name=go_version::1.12.5"
           echo "::set-output name=build_date::$(shell ./scripts/dev/git-date-time.sh -d)"
           echo "::set-output name=build_time::$(shell ./scripts/dev/git-date-time.sh -t)"
           echo "::set-output name=build_version::$(git describe --tags)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# 1) build step (approx local build time ~4m w/o cache)
+ARG GOLANG_VERSION=1.12.16
+FROM golang:${GOLANG_VERSION} AS build
+
+ADD . /go/src/github.com/insolar/insolar
+WORKDIR /go/src/github.com/insolar/insolar
+
+# pass build variables as arguments to avoid adding .git directory
+ARG BUILD_NUMBER
+ARG BUILD_DATE
+ARG BUILD_TIME
+ARG BUILD_HASH
+ARG BUILD_VERSION
+# build step
+RUN BUILD_NUMBER=${BUILD_NUMBER} \
+    BUILD_DATE=${BUILD_DATE} \
+    BUILD_TIME=${BUILD_TIME} \
+    BUILD_HASH=${BUILD_HASH} \
+    BUILD_VERSION=${BUILD_VERSION} \
+    make build
+
+FROM debian:buster-slim
+WORKDIR /go/src/github.com/insolar/insolar
+RUN  set -eux; \
+     groupadd -r insolar --gid=999; \
+     useradd -r -g insolar --uid=999 --shell=/bin/bash insolar
+COPY --from=build /go/src/github.com/insolar/insolar/bin/insolar /go/src/github.com/insolar/insolar/bin/insolard /go/src/github.com/insolar/insolar/bin/keeperd /go/src/github.com/insolar/insolar/bin/pulsard /usr/local/bin/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 1) build step (approx local build time ~4m w/o cache)
-ARG GOLANG_VERSION=1.12.16
+ARG GOLANG_VERSION=1.12
 FROM golang:${GOLANG_VERSION} AS build
 
 ADD . /go/src/github.com/insolar/insolar


### PR DESCRIPTION
- What I did
Added release workflow to the repo
- How I did it
I've added Dockerfile and GH actions workflow pipeline which is being triggered by tag event.
Every tag event will trigger build, after that docker image will be created and pushed to docker registry and new GH release will be added to releases page, w/ binaries produced by build stage.
- Requirements
Those secrets should be added to the repo for workflow to work properly:
```
REGISTRY_URL
REGISTRY_USERNAME
REGISTRY_PASSWORD
```
- How to verify it
You can tag any commit with any tag name like that:
```
$ git tag -a 'v1.0.0' -m 'v1.0.0' 
$ git push origin v1.0.0
```
After steps above you should be able to download artifacts from release page and pull image from registry:
```
docker pull insolar/insolar:v1.0.0
```
- Description for the changelog
GH Actions release pipeline