### PR TITLE
MN-308: remove the pulse number from the conflict check

### DIFF
--- a/ledger/object/postgres_index_db.go
+++ b/ledger/object/postgres_index_db.go
@@ -158,7 +158,7 @@ func (i *PostgresIndexDB) UpdateLastKnownPulse(ctx context.Context, pn insolar.P
 		for _, id := range rawIDs {
 			_, err := tx.Exec(ctx, `INSERT INTO last_known_pulse_for_indexes
 										 VALUES($1, $2)
-										 ON CONFLICT (object_id, pulse_number)
+										 ON CONFLICT (object_id)
 										 DO UPDATE
 											SET pulse_number = EXCLUDED.pulse_number`, id, pn)
 			if err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed method UpdateLastKnownPulse of PostgresIndexDB
**- How I did it**
Changed `ON CONFLICT` clause of SQL script. Related changes are found in https://github.com/insolar/insolar-scripts/pull/10
**- How to verify it**
Run unit test
**- Description for the changelog**
Fixes MN-308
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
