### PR TITLE
Penv 251

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,11 +162,11 @@ functest: ## run functests
 	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
 		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest" ./application/functest -count=$(TEST_COUNT) -failfast
 	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
-    		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "bloattest" ./application/functest -count=$(TEST_COUNT) -failfast
+    		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "bloattest" ./application/functest -count=1 -failfast
 	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
 		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest" ./applicationbase/functest -count=$(TEST_COUNT) -failfast
 	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
-        		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest_error" ./application/functest -count=$(TEST_COUNT) -failfast
+        		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest_error" ./application/functest -count=1 -failfast
 
 .PHONY: test_func
 test_func: functest ## alias for functest

--- a/Makefile
+++ b/Makefile
@@ -160,9 +160,11 @@ test: test_unit ## alias for test_unit
 .PHONY: functest
 functest: ## run functests
 	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
-		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest bloattest" ./application/functest -count=$(TEST_COUNT) -failfast
+		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest" ./application/functest -count=$(TEST_COUNT) -failfast
 	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
-		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest bloattest" ./applicationbase/functest -count=$(TEST_COUNT) -failfast
+    		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "bloattest" ./application/functest -count=$(TEST_COUNT) -failfast
+	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
+		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest" ./applicationbase/functest -count=$(TEST_COUNT) -failfast
 
 .PHONY: test_func
 test_func: functest ## alias for functest

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ functest: ## run functests
 	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
 		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest" ./applicationbase/functest -count=$(TEST_COUNT) -failfast
 	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
-        		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest_error" ./application/functest -count=1 -failfast
+        		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest_endless_abandon" ./application/functest -count=1 -failfast
 
 .PHONY: test_func
 test_func: functest ## alias for functest

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,8 @@ functest: ## run functests
     		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "bloattest" ./application/functest -count=$(TEST_COUNT) -failfast
 	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
 		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest" ./applicationbase/functest -count=$(TEST_COUNT) -failfast
+	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
+        		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest_error" ./application/functest -count=$(TEST_COUNT) -failfast
 
 .PHONY: test_func
 test_func: functest ## alias for functest

--- a/application/functest/logicrunner_errors_test.go
+++ b/application/functest/logicrunner_errors_test.go
@@ -1,0 +1,157 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
+
+// +build functest_error
+
+package functest
+
+import (
+	"github.com/insolar/insolar/applicationbase/testutils/launchnet"
+	"github.com/insolar/insolar/applicationbase/testutils/testrequest"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPanicIsSystemError(t *testing.T) {
+	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
+		map[string]interface{}{})
+	require.NoError(t, err)
+	ref, ok := result.(string)
+	require.True(t, ok)
+
+	_, err = testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, &Root, "first.Panic",
+		map[string]interface{}{"reference": ref})
+	data := checkConvertRequesterError(t, err).Data
+	require.Contains(t, data.Trace, "CallMethod returns error")
+	require.Contains(t, data.Trace, "AAAAAAAA!")
+
+	_, err = testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, &Root, "first.NewPanic",
+		map[string]interface{}{})
+	data = checkConvertRequesterError(t, err).Data
+	require.Contains(t, data.Trace, "CallMethod returns error")
+	require.Contains(t, data.Trace, "BBBBBBBB!")
+}
+
+func TestPanicIsLogicalError(t *testing.T) {
+	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "panicAsLogicalError.New",
+		map[string]interface{}{})
+	require.NoError(t, err)
+	ref, ok := result.(string)
+	require.True(t, ok)
+
+	_, err = testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, &Root, "panicAsLogicalError.Panic",
+		map[string]interface{}{"reference": ref})
+	data := checkConvertRequesterError(t, err).Data
+	require.NotContains(t, data.Trace, "CallMethod returns error")
+	require.Contains(t, data.Trace, "AAAAAAAA!")
+
+	_, err = testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, &Root, "panicAsLogicalError.NewPanic",
+		map[string]interface{}{})
+	data = checkConvertRequesterError(t, err).Data
+	require.NotContains(t, data.Trace, "CallMethod returns error")
+	require.Contains(t, data.Trace, "BBBBBBBB!")
+}
+
+func TestRecursiveCallError(t *testing.T) {
+	obj := callConstructor(t, "first", "New")
+	_, _, err := testrequest.MakeSignedRequest(
+		launchnet.TestRPCUrlPublic,
+		&Root,
+		"first.Recursive",
+		map[string]interface{}{"reference": obj})
+	data := checkConvertRequesterError(t, err).Data
+
+	require.Contains(t, data.Trace[len(data.Trace)-1], "loop detected")
+}
+
+func TestPrototypeMismatch(t *testing.T) {
+	objSecond := callConstructor(t, "third", "New")
+	objTest := callConstructor(t, "first", "New")
+
+	_, _, err := testrequest.MakeSignedRequest(
+		launchnet.TestRPCUrlPublic,
+		&Root,
+		"first.Test",
+		map[string]interface{}{
+			"reference": objTest,
+			"firstRef":  objSecond,
+		})
+	data := checkConvertRequesterError(t, err).Data
+
+	require.Contains(t, data.Trace, "try to call method of prototype as method of another prototype")
+}
+
+func TestContractWithEmbeddedConstructor(t *testing.T) {
+	_ = callConstructor(t, "first", "NewZero")
+	_, _, err := testrequest.MakeSignedRequest(
+		launchnet.TestRPCUrlPublic,
+		&Root,
+		"second.NewWithOne",
+		map[string]interface{}{
+			"oneNumber": "10",
+		})
+	data := checkConvertRequesterError(t, err).Data
+
+	require.Contains(t, data.Trace, "object is not activated")
+}
+
+// TestDeactivation
+
+func TestErrorInterface(t *testing.T) {
+	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
+		map[string]interface{}{})
+	require.NoError(t, err)
+	ref, ok := result.(string)
+	require.True(t, ok)
+
+	_, _, err = testrequest.MakeSignedRequest(
+		launchnet.TestRPCUrlPublic,
+		&Root,
+		"first.AnError",
+		map[string]interface{}{"reference": ref})
+	data := checkConvertRequesterError(t, err).Data
+	require.Contains(t, data.Trace, "an error")
+
+	_, err = testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.NoError",
+		map[string]interface{}{"reference": ref})
+	require.NoError(t, err)
+}
+
+// If a contract constructor returns `nil, nil` it's considered a logical error,
+// which is returned to the calling contract and/or API.
+func TestConstructorReturnNil(t *testing.T) {
+	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
+		map[string]interface{}{})
+	require.NoError(t, err)
+	ref, ok := result.(string)
+	require.True(t, ok)
+
+	_, _, err = testrequest.MakeSignedRequest(
+		launchnet.TestRPCUrlPublic,
+		&Root,
+		"first.ConstructorReturnNil",
+		map[string]interface{}{"reference": ref})
+	data := checkConvertRequesterError(t, err).Data
+	require.Contains(t, data.Trace, "constructor returned nil")
+
+}
+
+// If a contract constructor fails it's considered a logical error,
+// which is returned to the calling contract and/or API.
+func TestConstructorReturnError(t *testing.T) {
+	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
+		map[string]interface{}{})
+	require.NoError(t, err)
+	ref, ok := result.(string)
+	require.True(t, ok)
+
+	_, _, err = testrequest.MakeSignedRequest(
+		launchnet.TestRPCUrlPublic,
+		&Root,
+		"first.ConstructorReturnError",
+		map[string]interface{}{"reference": ref})
+	data := checkConvertRequesterError(t, err).Data
+	require.Contains(t, data.Trace, "Epic fail in NewWithErr()")
+}

--- a/application/functest/logicrunner_errors_test.go
+++ b/application/functest/logicrunner_errors_test.go
@@ -3,15 +3,16 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
 
-// +build functest_error
+// +build functest_endless_abandon
 
 package functest
 
 import (
+	"testing"
+
 	"github.com/insolar/insolar/applicationbase/testutils/launchnet"
 	"github.com/insolar/insolar/applicationbase/testutils/testrequest"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestPanicIsSystemError(t *testing.T) {
@@ -34,55 +35,6 @@ func TestPanicIsSystemError(t *testing.T) {
 	require.Contains(t, data.Trace, "BBBBBBBB!")
 }
 
-func TestPanicIsLogicalError(t *testing.T) {
-	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "panicAsLogicalError.New",
-		map[string]interface{}{})
-	require.NoError(t, err)
-	ref, ok := result.(string)
-	require.True(t, ok)
-
-	_, err = testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, &Root, "panicAsLogicalError.Panic",
-		map[string]interface{}{"reference": ref})
-	data := checkConvertRequesterError(t, err).Data
-	require.NotContains(t, data.Trace, "CallMethod returns error")
-	require.Contains(t, data.Trace, "AAAAAAAA!")
-
-	_, err = testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, &Root, "panicAsLogicalError.NewPanic",
-		map[string]interface{}{})
-	data = checkConvertRequesterError(t, err).Data
-	require.NotContains(t, data.Trace, "CallMethod returns error")
-	require.Contains(t, data.Trace, "BBBBBBBB!")
-}
-
-func TestRecursiveCallError(t *testing.T) {
-	obj := callConstructor(t, "first", "New")
-	_, _, err := testrequest.MakeSignedRequest(
-		launchnet.TestRPCUrlPublic,
-		&Root,
-		"first.Recursive",
-		map[string]interface{}{"reference": obj})
-	data := checkConvertRequesterError(t, err).Data
-
-	require.Contains(t, data.Trace[len(data.Trace)-1], "loop detected")
-}
-
-func TestPrototypeMismatch(t *testing.T) {
-	objSecond := callConstructor(t, "third", "New")
-	objTest := callConstructor(t, "first", "New")
-
-	_, _, err := testrequest.MakeSignedRequest(
-		launchnet.TestRPCUrlPublic,
-		&Root,
-		"first.Test",
-		map[string]interface{}{
-			"reference": objTest,
-			"firstRef":  objSecond,
-		})
-	data := checkConvertRequesterError(t, err).Data
-
-	require.Contains(t, data.Trace, "try to call method of prototype as method of another prototype")
-}
-
 func TestContractWithEmbeddedConstructor(t *testing.T) {
 	_ = callConstructor(t, "first", "NewZero")
 	_, _, err := testrequest.MakeSignedRequest(
@@ -95,63 +47,4 @@ func TestContractWithEmbeddedConstructor(t *testing.T) {
 	data := checkConvertRequesterError(t, err).Data
 
 	require.Contains(t, data.Trace, "object is not activated")
-}
-
-// TestDeactivation
-
-func TestErrorInterface(t *testing.T) {
-	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
-		map[string]interface{}{})
-	require.NoError(t, err)
-	ref, ok := result.(string)
-	require.True(t, ok)
-
-	_, _, err = testrequest.MakeSignedRequest(
-		launchnet.TestRPCUrlPublic,
-		&Root,
-		"first.AnError",
-		map[string]interface{}{"reference": ref})
-	data := checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "an error")
-
-	_, err = testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.NoError",
-		map[string]interface{}{"reference": ref})
-	require.NoError(t, err)
-}
-
-// If a contract constructor returns `nil, nil` it's considered a logical error,
-// which is returned to the calling contract and/or API.
-func TestConstructorReturnNil(t *testing.T) {
-	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
-		map[string]interface{}{})
-	require.NoError(t, err)
-	ref, ok := result.(string)
-	require.True(t, ok)
-
-	_, _, err = testrequest.MakeSignedRequest(
-		launchnet.TestRPCUrlPublic,
-		&Root,
-		"first.ConstructorReturnNil",
-		map[string]interface{}{"reference": ref})
-	data := checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "constructor returned nil")
-
-}
-
-// If a contract constructor fails it's considered a logical error,
-// which is returned to the calling contract and/or API.
-func TestConstructorReturnError(t *testing.T) {
-	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
-		map[string]interface{}{})
-	require.NoError(t, err)
-	ref, ok := result.(string)
-	require.True(t, ok)
-
-	_, _, err = testrequest.MakeSignedRequest(
-		launchnet.TestRPCUrlPublic,
-		&Root,
-		"first.ConstructorReturnError",
-		map[string]interface{}{"reference": ref})
-	data := checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "Epic fail in NewWithErr()")
 }

--- a/application/functest/logicrunner_test.go
+++ b/application/functest/logicrunner_test.go
@@ -19,89 +19,6 @@ import (
 	"github.com/insolar/insolar/applicationbase/testutils/testrequest"
 )
 
-func TestPanicIsSystemError(t *testing.T) {
-	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
-		map[string]interface{}{})
-	require.NoError(t, err)
-	ref, ok := result.(string)
-	require.True(t, ok)
-
-	_, err = testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, &Root, "first.Panic",
-		map[string]interface{}{"reference": ref})
-	data := checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "CallMethod returns error")
-	require.Contains(t, data.Trace, "AAAAAAAA!")
-
-	_, err = testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, &Root, "first.NewPanic",
-		map[string]interface{}{})
-	data = checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "CallMethod returns error")
-	require.Contains(t, data.Trace, "BBBBBBBB!")
-}
-
-func TestPanicIsLogicalError(t *testing.T) {
-	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "panicAsLogicalError.New",
-		map[string]interface{}{})
-	require.NoError(t, err)
-	ref, ok := result.(string)
-	require.True(t, ok)
-
-	_, err = testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, &Root, "panicAsLogicalError.Panic",
-		map[string]interface{}{"reference": ref})
-	data := checkConvertRequesterError(t, err).Data
-	require.NotContains(t, data.Trace, "CallMethod returns error")
-	require.Contains(t, data.Trace, "AAAAAAAA!")
-
-	_, err = testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, &Root, "panicAsLogicalError.NewPanic",
-		map[string]interface{}{})
-	data = checkConvertRequesterError(t, err).Data
-	require.NotContains(t, data.Trace, "CallMethod returns error")
-	require.Contains(t, data.Trace, "BBBBBBBB!")
-}
-
-func TestRecursiveCallError(t *testing.T) {
-	obj := callConstructor(t, "first", "New")
-	_, _, err := testrequest.MakeSignedRequest(
-		launchnet.TestRPCUrlPublic,
-		&Root,
-		"first.Recursive",
-		map[string]interface{}{"reference": obj})
-	data := checkConvertRequesterError(t, err).Data
-
-	require.Contains(t, data.Trace[len(data.Trace)-1], "loop detected")
-}
-
-func TestPrototypeMismatch(t *testing.T) {
-	objSecond := callConstructor(t, "third", "New")
-	objTest := callConstructor(t, "first", "New")
-
-	_, _, err := testrequest.MakeSignedRequest(
-		launchnet.TestRPCUrlPublic,
-		&Root,
-		"first.Test",
-		map[string]interface{}{
-			"reference": objTest,
-			"firstRef":  objSecond,
-		})
-	data := checkConvertRequesterError(t, err).Data
-
-	require.Contains(t, data.Trace, "try to call method of prototype as method of another prototype")
-}
-
-func TestContractWithEmbeddedConstructor(t *testing.T) {
-	_ = callConstructor(t, "first", "NewZero")
-	_, _, err := testrequest.MakeSignedRequest(
-		launchnet.TestRPCUrlPublic,
-		&Root,
-		"second.NewWithOne",
-		map[string]interface{}{
-			"oneNumber": "10",
-		})
-	data := checkConvertRequesterError(t, err).Data
-
-	require.Contains(t, data.Trace, "object is not activated")
-}
-
 func TestSingleContract(t *testing.T) {
 	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
 		map[string]interface{}{})
@@ -404,28 +321,6 @@ func TestContextPassing(t *testing.T) {
 	require.Equal(t, ref, prototype.(string))
 }
 
-// TestDeactivation
-
-func TestErrorInterface(t *testing.T) {
-	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
-		map[string]interface{}{})
-	require.NoError(t, err)
-	ref, ok := result.(string)
-	require.True(t, ok)
-
-	_, _, err = testrequest.MakeSignedRequest(
-		launchnet.TestRPCUrlPublic,
-		&Root,
-		"first.AnError",
-		map[string]interface{}{"reference": ref})
-	data := checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "an error")
-
-	_, err = testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.NoError",
-		map[string]interface{}{"reference": ref})
-	require.NoError(t, err)
-}
-
 func TestNilResult(t *testing.T) {
 	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
 		map[string]interface{}{})
@@ -437,43 +332,6 @@ func TestNilResult(t *testing.T) {
 		map[string]interface{}{"reference": ref})
 	require.NoError(t, err)
 	require.Nil(t, res)
-}
-
-// If a contract constructor returns `nil, nil` it's considered a logical error,
-// which is returned to the calling contract and/or API.
-func TestConstructorReturnNil(t *testing.T) {
-	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
-		map[string]interface{}{})
-	require.NoError(t, err)
-	ref, ok := result.(string)
-	require.True(t, ok)
-
-	_, _, err = testrequest.MakeSignedRequest(
-		launchnet.TestRPCUrlPublic,
-		&Root,
-		"first.ConstructorReturnNil",
-		map[string]interface{}{"reference": ref})
-	data := checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "constructor returned nil")
-
-}
-
-// If a contract constructor fails it's considered a logical error,
-// which is returned to the calling contract and/or API.
-func TestConstructorReturnError(t *testing.T) {
-	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
-		map[string]interface{}{})
-	require.NoError(t, err)
-	ref, ok := result.(string)
-	require.True(t, ok)
-
-	_, _, err = testrequest.MakeSignedRequest(
-		launchnet.TestRPCUrlPublic,
-		&Root,
-		"first.ConstructorReturnError",
-		map[string]interface{}{"reference": ref})
-	data := checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "Epic fail in NewWithErr()")
 }
 
 func TestGetRemoteData(t *testing.T) {

--- a/application/functest/logicrunner_test.go
+++ b/application/functest/logicrunner_test.go
@@ -19,6 +19,112 @@ import (
 	"github.com/insolar/insolar/applicationbase/testutils/testrequest"
 )
 
+func TestPanicIsLogicalError(t *testing.T) {
+	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "panicAsLogicalError.New",
+		map[string]interface{}{})
+	require.NoError(t, err)
+	ref, ok := result.(string)
+	require.True(t, ok)
+
+	_, err = testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, &Root, "panicAsLogicalError.Panic",
+		map[string]interface{}{"reference": ref})
+	data := checkConvertRequesterError(t, err).Data
+	require.NotContains(t, data.Trace, "CallMethod returns error")
+	require.Contains(t, data.Trace, "AAAAAAAA!")
+
+	_, err = testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrlPublic, &Root, "panicAsLogicalError.NewPanic",
+		map[string]interface{}{})
+	data = checkConvertRequesterError(t, err).Data
+	require.NotContains(t, data.Trace, "CallMethod returns error")
+	require.Contains(t, data.Trace, "BBBBBBBB!")
+}
+
+func TestRecursiveCallError(t *testing.T) {
+	obj := callConstructor(t, "first", "New")
+	_, _, err := testrequest.MakeSignedRequest(
+		launchnet.TestRPCUrlPublic,
+		&Root,
+		"first.Recursive",
+		map[string]interface{}{"reference": obj})
+	data := checkConvertRequesterError(t, err).Data
+
+	require.Contains(t, data.Trace[len(data.Trace)-1], "loop detected")
+}
+
+func TestPrototypeMismatch(t *testing.T) {
+	objSecond := callConstructor(t, "third", "New")
+	objTest := callConstructor(t, "first", "New")
+
+	_, _, err := testrequest.MakeSignedRequest(
+		launchnet.TestRPCUrlPublic,
+		&Root,
+		"first.Test",
+		map[string]interface{}{
+			"reference": objTest,
+			"firstRef":  objSecond,
+		})
+	data := checkConvertRequesterError(t, err).Data
+
+	require.Contains(t, data.Trace, "try to call method of prototype as method of another prototype")
+}
+
+func TestErrorInterface(t *testing.T) {
+	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
+		map[string]interface{}{})
+	require.NoError(t, err)
+	ref, ok := result.(string)
+	require.True(t, ok)
+
+	_, _, err = testrequest.MakeSignedRequest(
+		launchnet.TestRPCUrlPublic,
+		&Root,
+		"first.AnError",
+		map[string]interface{}{"reference": ref})
+	data := checkConvertRequesterError(t, err).Data
+	require.Contains(t, data.Trace, "an error")
+
+	_, err = testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.NoError",
+		map[string]interface{}{"reference": ref})
+	require.NoError(t, err)
+}
+
+// If a contract constructor returns `nil, nil` it's considered a logical error,
+// which is returned to the calling contract and/or API.
+func TestConstructorReturnNil(t *testing.T) {
+	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
+		map[string]interface{}{})
+	require.NoError(t, err)
+	ref, ok := result.(string)
+	require.True(t, ok)
+
+	_, _, err = testrequest.MakeSignedRequest(
+		launchnet.TestRPCUrlPublic,
+		&Root,
+		"first.ConstructorReturnNil",
+		map[string]interface{}{"reference": ref})
+	data := checkConvertRequesterError(t, err).Data
+	require.Contains(t, data.Trace, "constructor returned nil")
+
+}
+
+// If a contract constructor fails it's considered a logical error,
+// which is returned to the calling contract and/or API.
+func TestConstructorReturnError(t *testing.T) {
+	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
+		map[string]interface{}{})
+	require.NoError(t, err)
+	ref, ok := result.(string)
+	require.True(t, ok)
+
+	_, _, err = testrequest.MakeSignedRequest(
+		launchnet.TestRPCUrlPublic,
+		&Root,
+		"first.ConstructorReturnError",
+		map[string]interface{}{"reference": ref})
+	data := checkConvertRequesterError(t, err).Data
+	require.Contains(t, data.Trace, "Epic fail in NewWithErr()")
+}
+
 func TestSingleContract(t *testing.T) {
 	result, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "first.New",
 		map[string]interface{}{})

--- a/application/functest/main_func_test.go
+++ b/application/functest/main_func_test.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
 
-// +build functest bloattest
+// +build functest bloattest functest_error
 
 package functest
 

--- a/application/functest/main_func_test.go
+++ b/application/functest/main_func_test.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
 
-// +build functest
+// +build functest bloattest
 
 package functest
 

--- a/application/functest/main_func_test.go
+++ b/application/functest/main_func_test.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
 
-// +build functest bloattest functest_error
+// +build functest bloattest functest_endless_abandon
 
 package functest
 

--- a/application/functest/pressure_test.go
+++ b/application/functest/pressure_test.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
 
-// +build functest
+// +build bloattest
 
 package functest
 
@@ -90,13 +90,6 @@ func TestPressureOnSystem(t *testing.T) {
 		}
 		wg.Wait()
 	})
-}
-
-func callMethod(t testing.TB, objectRef string, method string) interface{} {
-	res, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, method,
-		map[string]interface{}{"reference": objectRef})
-	require.Empty(t, err)
-	return res
 }
 
 func TestCoinPassing(t *testing.T) {

--- a/application/functest/test_utils.go
+++ b/application/functest/test_utils.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
 
-// +build functest bloattest
+// +build functest bloattest functest_error
 
 package functest
 

--- a/application/functest/test_utils.go
+++ b/application/functest/test_utils.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
 
-// +build functest
+// +build functest bloattest
 
 package functest
 
@@ -40,6 +40,13 @@ func checkConvertRequesterError(t *testing.T, err error) *requester.Error {
 	rv, ok := err.(*requester.Error)
 	require.Truef(t, ok, "got wrong error %T (expected *requester.Error) with text '%s'", err, err.Error())
 	return rv
+}
+
+func callMethod(t testing.TB, objectRef string, method string) interface{} {
+	res, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, method,
+		map[string]interface{}{"reference": objectRef})
+	require.Empty(t, err)
+	return res
 }
 
 func createMember(t *testing.T) *AppUser {

--- a/application/functest/test_utils.go
+++ b/application/functest/test_utils.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
 
-// +build functest bloattest functest_error
+// +build functest bloattest functest_endless_abandon
 
 package functest
 

--- a/instrumentation/introspector/_swagger-helper/main.go
+++ b/instrumentation/introspector/_swagger-helper/main.go
@@ -60,13 +60,41 @@ func main() {
 	}
 	sw.writeString(")\n")
 
-	err = os.Rename(tmpF.Name(), outFileName)
+	err = MoveFile(tmpF.Name(), outFileName)
 	if err != nil {
 		log.Fatalf("failed move file from %v to %v: %s", tmpF.Name(), outFileName, err)
 	}
 
 	cwd, _ := os.Getwd()
 	_, _ = fmt.Fprintf(os.Stderr, "Generated file: %v (%v)", outFileName, cwd)
+}
+
+/*
+   GoLang: os.Rename() give error "invalid cross-device link" for Docker container with Volumes.
+   MoveFile(source, destination) will work moving file between folders
+*/
+func MoveFile(sourcePath, destPath string) error {
+	inputFile, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("Couldn't open source file: %s", err)
+	}
+	outputFile, err := os.Create(destPath)
+	if err != nil {
+		inputFile.Close()
+		return fmt.Errorf("Couldn't open dest file: %s", err)
+	}
+	defer outputFile.Close()
+	_, err = io.Copy(outputFile, inputFile)
+	inputFile.Close()
+	if err != nil {
+		return fmt.Errorf("Writing to output file failed: %s", err)
+	}
+	// The copy was successful, so now delete the original file
+	err = os.Remove(sourcePath)
+	if err != nil {
+		return fmt.Errorf("Failed removing original file: %s", err)
+	}
+	return nil
 }
 
 type strictWriter struct {


### PR DESCRIPTION
**- What I did**
Split func tests into groups because of https://insolar.atlassian.net/browse/PENV-251
Indefinitely executing error requests fail other tests, func tests must not be a scenario tests and be dependent on all other requests to the network, as we changed runner from 16 to 2 vCPU this is visible now
Set bloat, func_endless_abandon groups to count = 1, because we won't fix endless errors right now

**- How I did it**
Makefile, buildtags

**- How to verify it**
Run separate groups, only functest_error is failing now

GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest" ./application/functest -count=$(TEST_COUNT) -failfast
	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
    		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "bloattest" ./application/functest -count=$(TEST_COUNT) -failfast
	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest" ./applicationbase/functest -count=$(TEST_COUNT) -failfast
	GOMAXPROCS=$(GOMAXPROCS) CGO_ENABLED=1 \
        		$(GOTEST) -test.v -p=$(TEST_PARALLEL) $(TEST_ARGS) -tags "functest_error" ./application/functest -count=$(TEST_COUNT) -failfast

**- Description for the changelog**

