### PR TITLE
Penv-344: move metrics initialisation from init function to the constructor 

### DIFF
--- a/log/logmetrics/metrics.go
+++ b/log/logmetrics/metrics.go
@@ -1,12 +1,13 @@
-// Copyright 2020 Insolar Network Ltd.
-// All rights reserved.
-// This material is licensed under the Insolar License version 1.0,
-// available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
+//  Copyright 2020 Insolar Network Ltd.
+//  All rights reserved.
+//  This material is licensed under the Insolar License version 1.0,
+//  available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
 
 package logmetrics
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/insolar/insolar/insolar"
@@ -72,40 +73,43 @@ var (
 		"ns",
 	)
 )
+var once sync.Once
 
-func init() {
-	tags := []tag.Key{tagLevel}
-	err := view.Register(
-		&view.View{
-			Name:        statLogCalls.Name(),
-			Description: statLogCalls.Description(),
-			Measure:     statLogCalls,
-			Aggregation: view.Count(),
-			TagKeys:     tags,
-		},
-		&view.View{
-			Name:        statLogWrites.Name(),
-			Description: statLogWrites.Description(),
-			Measure:     statLogWrites,
-			Aggregation: view.Count(),
-			TagKeys:     tags,
-		},
-		&view.View{
-			Name:        statLogSkips.Name(),
-			Description: statLogSkips.Description(),
-			Measure:     statLogSkips,
-			Aggregation: view.Count(),
-			TagKeys:     tags,
-		},
-		&view.View{
-			Name:        statLogWriteDelays.Name(),
-			Description: statLogWriteDelays.Description(),
-			Measure:     statLogWriteDelays,
-			Aggregation: view.Distribution(0.0, float64(time.Second)),
-			TagKeys:     tags,
-		},
-	)
-	if err != nil {
-		panic(err)
-	}
+func initMetrics() {
+	once.Do(func() {
+		tags := []tag.Key{tagLevel}
+		err := view.Register(
+			&view.View{
+				Name:        statLogCalls.Name(),
+				Description: statLogCalls.Description(),
+				Measure:     statLogCalls,
+				Aggregation: view.Count(),
+				TagKeys:     tags,
+			},
+			&view.View{
+				Name:        statLogWrites.Name(),
+				Description: statLogWrites.Description(),
+				Measure:     statLogWrites,
+				Aggregation: view.Count(),
+				TagKeys:     tags,
+			},
+			&view.View{
+				Name:        statLogSkips.Name(),
+				Description: statLogSkips.Description(),
+				Measure:     statLogSkips,
+				Aggregation: view.Count(),
+				TagKeys:     tags,
+			},
+			&view.View{
+				Name:        statLogWriteDelays.Name(),
+				Description: statLogWriteDelays.Description(),
+				Measure:     statLogWriteDelays,
+				Aggregation: view.Distribution(0.0, float64(time.Second)),
+				TagKeys:     tags,
+			},
+		)
+		if err != nil {
+			panic(err)
+		}
+	})
 }

--- a/log/logmetrics/metrics.go
+++ b/log/logmetrics/metrics.go
@@ -1,7 +1,7 @@
-//  Copyright 2020 Insolar Network Ltd.
-//  All rights reserved.
-//  This material is licensed under the Insolar License version 1.0,
-//  available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
 
 package logmetrics
 

--- a/log/logmetrics/metrics_helper.go
+++ b/log/logmetrics/metrics_helper.go
@@ -1,7 +1,7 @@
-//  Copyright 2020 Insolar Network Ltd.
-//  All rights reserved.
-//  This material is licensed under the Insolar License version 1.0,
-//  available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
 
 package logmetrics
 

--- a/log/logmetrics/metrics_helper.go
+++ b/log/logmetrics/metrics_helper.go
@@ -1,7 +1,7 @@
-// Copyright 2020 Insolar Network Ltd.
-// All rights reserved.
-// This material is licensed under the Insolar License version 1.0,
-// available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
+//  Copyright 2020 Insolar Network Ltd.
+//  All rights reserved.
+//  This material is licensed under the Insolar License version 1.0,
+//  available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
 
 package logmetrics
 
@@ -14,6 +14,7 @@ import (
 )
 
 func NewMetricsHelper(recorder insolar.LogMetricsRecorder) *MetricsHelper {
+	initMetrics()
 	return &MetricsHelper{recorder}
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
move metrics initialisation from init function to the constructor 

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
