### PR TITLE
MN-567: copy a gRPC MD before setting a new value

### DIFF
--- a/server/internal/heavy/components.go
+++ b/server/internal/heavy/components.go
@@ -975,8 +975,9 @@ func authorize(ctx context.Context) (context.Context, error) {
 		return nil, err
 	}
 
-	md.Set(exporter.ObsID, sub)
-	return metadata.NewIncomingContext(ctx, md), nil
+	newMD := md.Copy()
+	newMD.Set(exporter.ObsID, sub)
+	return metadata.NewIncomingContext(ctx, newMD), nil
 }
 
 func validateJWT(token string) (string, error) {


### PR DESCRIPTION
**- What I did**
- I have fixed the modification of the MD. Copy first, then set a new value.
