### PR TITLE
PENV-347: set correct prev pn

### DIFF
--- a/ledger/heavy/exporter/pulse_exporter_server.go
+++ b/ledger/heavy/exporter/pulse_exporter_server.go
@@ -152,6 +152,7 @@ func (p *PulseServer) NextFinalizedPulse(ctx context.Context, gnfp *GetNextFinal
 		logger.Error(err)
 		return nil, err
 	}
+	pu.PrevPulseNumber = insolar.PulseNumber(pn)
 
 	return makeFullPulse(ctx, pu, p.jetKeeper.Storage()), nil
 }


### PR DESCRIPTION
**- What I did**
Set correct prev pulse number for NextFinalizedPulse response (we need it for correct process of pulses on BE, if pulsar was down for some time)