### PR TITLE
MN-632: fix gRPC server metrics

### DIFF
--- a/server/internal/heavy/components.go
+++ b/server/internal/heavy/components.go
@@ -857,7 +857,11 @@ func newGRPCServer(cfg configuration.Exporter) (*grpc.Server, error) {
 		)
 		return server, nil
 	}
-	return grpc.NewServer(), nil
+
+	return grpc.NewServer(
+		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
+		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
+	), nil
 }
 
 func newComponents(


### PR DESCRIPTION
**- What I did**
I have added interceptors for gRPC metrics in a case without auth.
