### PR TITLE
MN-714: add configuration and interceptors for rate limiting

### DIFF
--- a/ledger/heavy/exporter/errors.go
+++ b/ledger/heavy/exporter/errors.go
@@ -12,5 +12,7 @@ import (
 var (
 	ErrNilCount                = errors.New("count can't be 0")
 	ErrNotFinalPulseData       = errors.New("trying to get a non-finalized pulse data")
-	ErrDeprecatedClientVersion = errors.New("version of the observer is outdated. Please upgrade this client")
+	ErrDeprecatedClientVersion = errors.New("version of the observer is outdated, please upgrade this client")
 )
+
+var RateLimitExceededMsg = "rate limit exceeded, please retry later"

--- a/server/internal/heavy/components.go
+++ b/server/internal/heavy/components.go
@@ -846,9 +846,9 @@ var (
 var allowedVersionContract int64
 
 func newGRPCServer(cfg configuration.Exporter, grpcMetrics *grpc_prometheus.ServerMetrics) (*grpc.Server, error) {
-	serverLimiter := NewServerLimiter(cfg.RateLimit)
-	streamInterceptors := []grpc.StreamServerInterceptor{grpcMetrics.StreamServerInterceptor(), serverLimiter.StreamServerInterceptor()}
-	unaryInterceptors := []grpc.UnaryServerInterceptor{grpcMetrics.UnaryServerInterceptor(), serverLimiter.UnaryServerInterceptor()}
+	serverLimiters := NewServerLimiters(cfg.RateLimit)
+	streamInterceptors := []grpc.StreamServerInterceptor{grpcMetrics.StreamServerInterceptor(), serverLimiters.StreamServerInterceptor()}
+	unaryInterceptors := []grpc.UnaryServerInterceptor{grpcMetrics.UnaryServerInterceptor(), serverLimiters.UnaryServerInterceptor()}
 
 	// add authorization interceptor
 	if cfg.Auth.Required {

--- a/server/internal/heavy/components.go
+++ b/server/internal/heavy/components.go
@@ -846,8 +846,9 @@ var (
 var allowedVersionContract int64
 
 func newGRPCServer(cfg configuration.Exporter, grpcMetrics *grpc_prometheus.ServerMetrics) (*grpc.Server, error) {
-	streamInterceptors := []grpc.StreamServerInterceptor{grpcMetrics.StreamServerInterceptor()}
-	unaryInterceptors := []grpc.UnaryServerInterceptor{grpcMetrics.UnaryServerInterceptor()}
+	serverLimiter := NewServerLimiter(cfg.RateLimit)
+	streamInterceptors := []grpc.StreamServerInterceptor{grpcMetrics.StreamServerInterceptor(), serverLimiter.StreamServerInterceptor()}
+	unaryInterceptors := []grpc.UnaryServerInterceptor{grpcMetrics.UnaryServerInterceptor(), serverLimiter.UnaryServerInterceptor()}
 
 	// add authorization interceptor
 	if cfg.Auth.Required {

--- a/server/internal/heavy/components.go
+++ b/server/internal/heavy/components.go
@@ -846,9 +846,9 @@ var (
 var allowedVersionContract int64
 
 func newGRPCServer(cfg configuration.Exporter, grpcMetrics *grpc_prometheus.ServerMetrics) (*grpc.Server, error) {
-	serverLimiters := NewServerLimiters(cfg.RateLimit)
-	streamInterceptors := []grpc.StreamServerInterceptor{grpcMetrics.StreamServerInterceptor(), serverLimiters.StreamServerInterceptor()}
-	unaryInterceptors := []grpc.UnaryServerInterceptor{grpcMetrics.UnaryServerInterceptor(), serverLimiters.UnaryServerInterceptor()}
+	serverLimiters := newServerLimiters(cfg.RateLimit)
+	streamInterceptors := []grpc.StreamServerInterceptor{grpcMetrics.StreamServerInterceptor(), serverLimiters.streamServerInterceptor()}
+	unaryInterceptors := []grpc.UnaryServerInterceptor{grpcMetrics.UnaryServerInterceptor(), serverLimiters.unaryServerInterceptor()}
 
 	// add authorization interceptor
 	if cfg.Auth.Required {

--- a/server/internal/heavy/components_validate_version_test.go
+++ b/server/internal/heavy/components_validate_version_test.go
@@ -143,7 +143,7 @@ func TestValidateVersionHeavyVersion(t *testing.T) {
 		// test
 		err = validateClientVersion(ctx)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "version of the observer is outdated, please upgrade this client")
+		require.Contains(t, err.Error(), exporter.ErrDeprecatedClientVersion.Error())
 	})
 
 	t.Run("success new version observer", func(t *testing.T) {
@@ -289,7 +289,7 @@ func TestValidateVersionContractVersion(t *testing.T) {
 		// test
 		err = validateClientVersion(ctx)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "version of the observer is outdated, please upgrade this client")
+		require.Contains(t, err.Error(), exporter.ErrDeprecatedClientVersion.Error())
 	})
 
 	t.Run("success new version observer", func(t *testing.T) {

--- a/server/internal/heavy/components_validate_version_test.go
+++ b/server/internal/heavy/components_validate_version_test.go
@@ -143,7 +143,7 @@ func TestValidateVersionHeavyVersion(t *testing.T) {
 		// test
 		err = validateClientVersion(ctx)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "version of the observer is outdated. Please upgrade this client")
+		require.Contains(t, err.Error(), "version of the observer is outdated, please upgrade this client")
 	})
 
 	t.Run("success new version observer", func(t *testing.T) {
@@ -289,7 +289,7 @@ func TestValidateVersionContractVersion(t *testing.T) {
 		// test
 		err = validateClientVersion(ctx)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "version of the observer is outdated. Please upgrade this client")
+		require.Contains(t, err.Error(), "version of the observer is outdated, please upgrade this client")
 	})
 
 	t.Run("success new version observer", func(t *testing.T) {

--- a/server/internal/heavy/limits.go
+++ b/server/internal/heavy/limits.go
@@ -1,0 +1,130 @@
+package heavy
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/insolar/insolar/configuration"
+	"github.com/insolar/insolar/ledger/heavy/exporter"
+)
+
+type Limiter interface {
+	Allow() bool
+}
+
+type noLimit struct {
+}
+
+func (l *noLimit) Allow() bool {
+	return true
+}
+
+func NewNoLimit(_ int) *noLimit {
+	return &noLimit{}
+}
+
+type ServerLimiter struct {
+	inbound  *Limiters
+	outbound *Limiters
+}
+
+func NewServerLimiter(config configuration.RateLimit) *ServerLimiter {
+	return &ServerLimiter{
+		inbound:  NewLimiters(config.In),
+		outbound: NewLimiters(config.Out),
+	}
+}
+
+type Limiters struct {
+	config            configuration.Limits
+	globalLimiter     Limiter
+	perClientLimiters map[string]map[string]Limiter
+	mutex             *sync.RWMutex
+}
+
+func NewLimiters(config configuration.Limits) *Limiters {
+	// here we will use a suitable implementation of limiter with the RPS value from the config.Global
+	limiter := NewNoLimit(config.Global)
+	return &Limiters{
+		config:            config,
+		globalLimiter:     limiter,
+		perClientLimiters: make(map[string]map[string]Limiter),
+		mutex:             &sync.RWMutex{},
+	}
+}
+
+func (l *ServerLimiter) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		method := info.FullMethod
+		limiters := l.inbound
+		if limiters.GlobalLimit() || limiters.PerClientLimit(ctx, method) {
+			return nil, status.Errorf(codes.ResourceExhausted, "method: %s, %s", method, exporter.RateLimitExceededMsg)
+		}
+		return handler(ctx, req)
+	}
+}
+
+func (l *ServerLimiter) StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		method := info.FullMethod
+		limiters := l.inbound
+		if limiters.GlobalLimit() || limiters.PerClientLimit(stream.Context(), method) {
+			return status.Errorf(codes.ResourceExhausted, "method: %s, %s", method, exporter.RateLimitExceededMsg)
+		}
+		return handler(srv, l.LimitStream(stream, method))
+	}
+}
+
+func (l *ServerLimiter) LimitStream(stream grpc.ServerStream, method string) grpc.ServerStream {
+	return &limitedServerStream{
+		ServerStream: stream,
+		outbound:     l.outbound,
+		method:       method,
+	}
+}
+
+func (l *Limiters) GlobalLimit() bool {
+	if l.globalLimiter == nil {
+		return false
+	}
+	return !l.globalLimiter.Allow()
+}
+
+func (l *Limiters) PerClientLimit(ctx context.Context, method string) bool {
+	md, _ := metadata.FromIncomingContext(ctx)
+	client := "unknown"
+	if _, isContain := md[exporter.ObsID]; isContain {
+		client = md.Get(exporter.ObsID)[0]
+	}
+	l.mutex.RLock()
+	limiter := l.perClientLimiters[method][client]
+	l.mutex.RUnlock()
+	if limiter == nil {
+		// here we will use a suitable implementation of limiter with value l.config.PerClient.Limit(method)
+		rps := l.config.PerClient.Limit(method)
+		limiter = NewNoLimit(rps)
+		l.mutex.Lock()
+		l.perClientLimiters[method] = map[string]Limiter{client: limiter}
+		l.mutex.Unlock()
+	}
+	return !limiter.Allow()
+}
+
+type limitedServerStream struct {
+	grpc.ServerStream
+	outbound *Limiters
+	method   string
+}
+
+func (s *limitedServerStream) SendMsg(m interface{}) error {
+	limiters := s.outbound
+	if limiters.GlobalLimit() || limiters.PerClientLimit(s.Context(), s.method) {
+		return status.Errorf(codes.ResourceExhausted, "method: %s, %s", s.method, exporter.RateLimitExceededMsg)
+	}
+	return s.ServerStream.SendMsg(m)
+}

--- a/server/internal/heavy/limits.go
+++ b/server/internal/heavy/limits.go
@@ -29,25 +29,21 @@ func newNoLimit(_ int) *noLimit {
 }
 
 type syncLimiter struct {
+	sync.Mutex
 	l limiter
-	m *sync.Mutex
 }
 
 func newSyncLimiter(l limiter) *syncLimiter {
 	return &syncLimiter{
 		l: l,
-		m: &sync.Mutex{},
 	}
 }
 
 func (s *syncLimiter) allow() bool {
-	var allow bool
-	func() {
-		s.m.Lock()
-		defer s.m.Unlock()
-		allow = s.l.allow()
-	}()
-	return allow
+	s.Lock()
+	defer s.Unlock()
+
+	return s.l.allow()
 }
 
 type serverLimiters struct {

--- a/server/internal/heavy/limits_test.go
+++ b/server/internal/heavy/limits_test.go
@@ -25,7 +25,7 @@ func TestNewLimiters(t *testing.T) {
 	require.NotNil(t, limiters.mutex)
 }
 
-func TestLimiters_GlobalLimit(t *testing.T) {
+func TestLimiters_isGlobalLimitExceeded(t *testing.T) {
 	t.Run("nil limiter", func(t *testing.T) {
 		limiters := &limiters{}
 		require.False(t, limiters.isGlobalLimitExceeded())
@@ -37,7 +37,7 @@ func TestLimiters_GlobalLimit(t *testing.T) {
 	})
 }
 
-func TestLimiters_PerClientLimit(t *testing.T) {
+func TestLimiters_isClientLimitExceeded(t *testing.T) {
 	t.Run("zero limits, empty limiters", func(t *testing.T) {
 		limiters := newLimiters(configuration.Limits{})
 		methods := []string{
@@ -56,7 +56,7 @@ func TestLimiters_PerClientLimit(t *testing.T) {
 	t.Run("zero limits, not empty limiter", func(t *testing.T) {
 		method := "method"
 		limiters := newLimiters(configuration.Limits{})
-		limiters.perClientLimiters[method] = map[string]limiter{"unknown": newNoLimit(0)}
+		limiters.perClientLimiters[method] = map[string]limiter{"unknown": newSyncLimiter(newNoLimit(0))}
 
 		require.False(t, limiters.isClientLimitExceeded(context.Background(), method))
 	})

--- a/server/internal/heavy/limits_test.go
+++ b/server/internal/heavy/limits_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewServerLimiter(t *testing.T) {
-	sl := NewServerLimiter(configuration.RateLimit{})
+	sl := NewServerLimiters(configuration.RateLimit{})
 	require.NotNil(t, sl)
 	require.NotNil(t, sl.inbound)
 	require.NotNil(t, sl.outbound)
@@ -28,12 +28,12 @@ func TestNewLimiters(t *testing.T) {
 func TestLimiters_GlobalLimit(t *testing.T) {
 	t.Run("nil limiter", func(t *testing.T) {
 		limiters := &Limiters{}
-		require.False(t, limiters.GlobalLimit())
+		require.False(t, limiters.isGlobalLimitExceeded())
 	})
 
 	t.Run("not limited implementation", func(t *testing.T) {
 		limiters := NewLimiters(configuration.Limits{})
-		require.False(t, limiters.GlobalLimit())
+		require.False(t, limiters.isGlobalLimitExceeded())
 	})
 }
 
@@ -49,7 +49,7 @@ func TestLimiters_PerClientLimit(t *testing.T) {
 		}
 
 		for _, m := range methods {
-			require.False(t, limiters.PerClientLimit(context.Background(), m))
+			require.False(t, limiters.isClientLimitExceeded(context.Background(), m))
 		}
 	})
 
@@ -58,6 +58,6 @@ func TestLimiters_PerClientLimit(t *testing.T) {
 		limiters := NewLimiters(configuration.Limits{})
 		limiters.perClientLimiters[method] = map[string]Limiter{"unknown": NewNoLimit(0)}
 
-		require.False(t, limiters.PerClientLimit(context.Background(), method))
+		require.False(t, limiters.isClientLimitExceeded(context.Background(), method))
 	})
 }

--- a/server/internal/heavy/limits_test.go
+++ b/server/internal/heavy/limits_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestNewServerLimiter(t *testing.T) {
-	sl := NewServerLimiters(configuration.RateLimit{})
+	sl := newServerLimiters(configuration.RateLimit{})
 	require.NotNil(t, sl)
 	require.NotNil(t, sl.inbound)
 	require.NotNil(t, sl.outbound)
 }
 
 func TestNewLimiters(t *testing.T) {
-	limiters := NewLimiters(configuration.Limits{})
+	limiters := newLimiters(configuration.Limits{})
 	require.NotNil(t, limiters)
 	require.NotNil(t, limiters.config)
 	require.NotNil(t, limiters.globalLimiter)
@@ -27,19 +27,19 @@ func TestNewLimiters(t *testing.T) {
 
 func TestLimiters_GlobalLimit(t *testing.T) {
 	t.Run("nil limiter", func(t *testing.T) {
-		limiters := &Limiters{}
+		limiters := &limiters{}
 		require.False(t, limiters.isGlobalLimitExceeded())
 	})
 
 	t.Run("not limited implementation", func(t *testing.T) {
-		limiters := NewLimiters(configuration.Limits{})
+		limiters := newLimiters(configuration.Limits{})
 		require.False(t, limiters.isGlobalLimitExceeded())
 	})
 }
 
 func TestLimiters_PerClientLimit(t *testing.T) {
 	t.Run("zero limits, empty limiters", func(t *testing.T) {
-		limiters := NewLimiters(configuration.Limits{})
+		limiters := newLimiters(configuration.Limits{})
 		methods := []string{
 			"",
 			"/exporter.RecordExporter/Export",
@@ -55,8 +55,8 @@ func TestLimiters_PerClientLimit(t *testing.T) {
 
 	t.Run("zero limits, not empty limiter", func(t *testing.T) {
 		method := "method"
-		limiters := NewLimiters(configuration.Limits{})
-		limiters.perClientLimiters[method] = map[string]Limiter{"unknown": NewNoLimit(0)}
+		limiters := newLimiters(configuration.Limits{})
+		limiters.perClientLimiters[method] = map[string]limiter{"unknown": newNoLimit(0)}
 
 		require.False(t, limiters.isClientLimitExceeded(context.Background(), method))
 	})

--- a/server/internal/heavy/limits_test.go
+++ b/server/internal/heavy/limits_test.go
@@ -1,0 +1,63 @@
+package heavy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/insolar/insolar/configuration"
+)
+
+func TestNewServerLimiter(t *testing.T) {
+	sl := NewServerLimiter(configuration.RateLimit{})
+	require.NotNil(t, sl)
+	require.NotNil(t, sl.inbound)
+	require.NotNil(t, sl.outbound)
+}
+
+func TestNewLimiters(t *testing.T) {
+	limiters := NewLimiters(configuration.Limits{})
+	require.NotNil(t, limiters)
+	require.NotNil(t, limiters.config)
+	require.NotNil(t, limiters.globalLimiter)
+	require.NotNil(t, limiters.perClientLimiters)
+	require.NotNil(t, limiters.mutex)
+}
+
+func TestLimiters_GlobalLimit(t *testing.T) {
+	t.Run("nil limiter", func(t *testing.T) {
+		limiters := &Limiters{}
+		require.False(t, limiters.GlobalLimit())
+	})
+
+	t.Run("not limited implementation", func(t *testing.T) {
+		limiters := NewLimiters(configuration.Limits{})
+		require.False(t, limiters.GlobalLimit())
+	})
+}
+
+func TestLimiters_PerClientLimit(t *testing.T) {
+	t.Run("zero limits, empty limiters", func(t *testing.T) {
+		limiters := NewLimiters(configuration.Limits{})
+		methods := []string{
+			"",
+			"/exporter.RecordExporter/Export",
+			"/exporter.PulseExporter/Export",
+			"/exporter.PulseExporter/TopSyncPulse",
+			"/exporter.PulseExporter/NextFinalizedPulse",
+		}
+
+		for _, m := range methods {
+			require.False(t, limiters.PerClientLimit(context.Background(), m))
+		}
+	})
+
+	t.Run("zero limits, not empty limiter", func(t *testing.T) {
+		method := "method"
+		limiters := NewLimiters(configuration.Limits{})
+		limiters.perClientLimiters[method] = map[string]Limiter{"unknown": NewNoLimit(0)}
+
+		require.False(t, limiters.PerClientLimit(context.Background(), method))
+	})
+}


### PR DESCRIPTION
**- What I did**
- I have added a configuration for rate-limiting into exporter configuration.
- I have added the 'ServerLimiter' structure, it stores limiters per method per client.
- I have added a temporary implementation of the Limiter interface that always allow execution.

In the next task, we can choose and start to use a suitable limiter implementation instead of the current mock limiter.

Linked PR: https://github.com/insolar/insolar-scripts/pull/14