### PR TITLE
MN-715: put rate-limiting interceptors after auth ones

### DIFF
--- a/server/internal/heavy/components_auth_test.go
+++ b/server/internal/heavy/components_auth_test.go
@@ -1,3 +1,8 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
+
 package heavy
 
 import (

--- a/server/internal/heavy/components_validate_version_test.go
+++ b/server/internal/heavy/components_validate_version_test.go
@@ -1,3 +1,8 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
+
 package heavy
 
 import (

--- a/server/internal/heavy/limits.go
+++ b/server/internal/heavy/limits.go
@@ -110,7 +110,12 @@ func (l *limiters) isClientLimitExceeded(ctx context.Context, method string) boo
 		func() {
 			l.mutex.Lock()
 			defer l.mutex.Unlock()
-			l.perClientLimiters[method] = map[string]limiter{client: cl}
+			lm, isContain := l.perClientLimiters[method]
+			if !isContain {
+				lm = make(map[string]limiter)
+				l.perClientLimiters[method] = lm
+			}
+			lm[client] = cl
 		}()
 	}
 

--- a/server/internal/heavy/limits_test.go
+++ b/server/internal/heavy/limits_test.go
@@ -1,3 +1,8 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/insolar/blob/master/LICENSE.md.
+
 package heavy
 
 import (


### PR DESCRIPTION
**- What I did**
I have placed rate-limiting interceptor after auth interceptors.
A nested map in limiters now correctly check and fill.